### PR TITLE
Add datetime attribute to attributes list

### DIFF
--- a/src/routes/docs/products/databases/collections/+page.markdoc
+++ b/src/routes/docs/products/databases/collections/+page.markdoc
@@ -248,6 +248,7 @@ You can choose between the following types.
 | `integer`    | Integer attribute.                                               |
 | `float`      | Float attribute.                                                 |
 | `boolean`    | Boolean attribute.                                               |
+| `datetime`   | Datetime attribute formatted as an ISO 8601 string.              |
 | `enum`       | Enum attribute.                                                  |
 | `ip`         | IP address attribute for IPv4 and IPv6.                          |
 | `email`      | Email address attribute.                                         |


### PR DESCRIPTION
## What does this PR do?

Seems like we missed the datetime attribute.

## Test Plan

Manual:

<img width="741" alt="image" src="https://github.com/appwrite/website/assets/1477010/473172a7-7f2b-4d2f-9823-e66667a47ea0">


## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes