### PR TITLE
added navigation link on 'view all open issues' button on the community page

### DIFF
--- a/src/routes/community/+page.svelte
+++ b/src/routes/community/+page.svelte
@@ -201,10 +201,15 @@
 								<p class="aw-main-body-500 u-margin-block-start-4">
 									Anyone can join and help Appwrite become better.
 								</p>
-								<button class="aw-button is-secondary u-margin-block-start-32">
+								<a
+									href="https://github.com/appwrite/appwrite/issues"
+									target="_blank"
+									rel="noopener noreferrer"
+									class="aw-button is-secondary u-margin-block-start-32"
+								>
 									<span class="aw-icon-github" aria-hidden="true" />
 									<span class="">View all Open Issues</span>
-								</button>
+								</a>
 							</div>
 							<div class="u-stretch">
 								<table class="aw-table-line">


### PR DESCRIPTION
![ss-1](https://github.com/appwrite/website/assets/77732479/58892d4b-ca30-4855-94e9-3d14094554e7)

## What does this PR do?

This PR adds the navigation link in **view all open issues** button on the community page
- the link will now navigate to the "https://github.com/appwrite/appwrite/issues" page

## Test Plan
- [x] tested on the desktop and mobile view.

## 👀 Have you spent some time to check if this issue has been raised before?
- [x] I checked and didn't find similar issue

## Have you read the Contributing Guidelines on issues?
- [x] I have read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)

## 🏢 Have you read the Code of Conduct?
- [x] I have read the [Code of Conduct](https://github.com/appwrite/.github/blob/main/CODE_OF_CONDUCT.md)