### PR TITLE
using databases instead of database for the variable name

### DIFF
--- a/src/routes/docs/tutorials/react/step-3/+page.markdoc
+++ b/src/routes/docs/tutorials/react/step-3/+page.markdoc
@@ -53,5 +53,5 @@ client
   .setProject("<YOUR_PROJECT_ID>"); // Replace with your project ID
 
 export const account = new Account(client);
-export const database = new Databases(client);
+export const databases = new Databases(client);
 ```

--- a/src/routes/docs/tutorials/sveltekit/step-3/+page.markdoc
+++ b/src/routes/docs/tutorials/sveltekit/step-3/+page.markdoc
@@ -52,5 +52,5 @@ client
   .setProject("<YOUR_PROJECT_ID>"); // Replace with your project ID
 
 export const account = new Account(client);
-export const database = new Databases(client);
+export const databases = new Databases(client);
 ```

--- a/src/routes/docs/tutorials/vue/step-3/+page.markdoc
+++ b/src/routes/docs/tutorials/vue/step-3/+page.markdoc
@@ -52,5 +52,5 @@ client
   .setProject("<YOUR_PROJECT_ID>"); // Replace with your project ID
 
 export const account = new Account(client);
-export const database = new Databases(client);
+export const databases = new Databases(client);
 ```


### PR DESCRIPTION
## What does this PR do?

This i a PR for the issue [#150](https://github.com/appwrite/website/issues/150).
In the tutorials section under [Step-3](https://appwrite.io/docs/tutorials/react/step-3#init-sdk) of **React**, **Vue** and **Svelte** the variable name was database and we are importing the same variable in [Step-6](https://appwrite.io/docs/tutorials/react/step-6) as databases. 

My changes include the updation of variable name from database to databases.

## Test Plan

Haven't done any changes in the code part.

## Related PRs and Issues

Related PR: [https://github.com/appwrite/website/issues/150](https://github.com/appwrite/website/issues/150)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes, i have read the contribution guide.