### PR TITLE
separated `anonymous` and `magic URL` by comma

### DIFF
--- a/src/routes/docs/products/auth/accounts/+page.markdoc
+++ b/src/routes/docs/products/auth/accounts/+page.markdoc
@@ -13,10 +13,10 @@ Each user's account can also have their own preference object, which you can use
 # Signup and login {% #signup-login %}
 
 You can signup and login a user with an account create through 
-[Email-Password](/docs/products/auth/email-password),
-[Phone (SMS)](/docs/products/auth/phone-sms),
+[email password](/docs/products/auth/email-password),
+[phone (SMS)](/docs/products/auth/phone-sms),
 [Anonymous](/docs/products/auth/anonymous),
-[Magic URL](/docs/products/auth/magic-url), and
+[magic URL](/docs/products/auth/magic-url), and
 [OAuth 2](/docs/products/auth/oauth2)
 authentication.
 

--- a/src/routes/docs/products/auth/accounts/+page.markdoc
+++ b/src/routes/docs/products/auth/accounts/+page.markdoc
@@ -13,12 +13,12 @@ Each user's account can also have their own preference object, which you can use
 # Signup and login {% #signup-login %}
 
 You can signup and login a user with an account create through 
-[email password](/docs/products/auth/email-password),
-[phone (SMS)](/docs/products/auth/phone-sms),
-[Anonymous](/docs/products/auth/anonymous)
-[magic URL](/docs/products/auth/magic-url), and
+[Email-Password](/docs/products/auth/email-password),
+[Phone (SMS)](/docs/products/auth/phone-sms),
+[Anonymous](/docs/products/auth/anonymous),
+[Magic URL](/docs/products/auth/magic-url), and
 [OAuth 2](/docs/products/auth/oauth2)
-authentication. 
+authentication.
 
 # Preferences {% #preferences %}
 


### PR DESCRIPTION
separated `anonymous` and `magic URL` by comma, removed unnecessary space, and made all method names Camal Case

## What does this PR do?

Fixes punctuation issues in the doc so that any readers get a better understanding of the documentation

## Test Plan

No tests necessary

## Related PRs and Issues

Not related to any other PR

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes