### PR TITLE
Fixed a typo. Changed from 100GB to 10GB

### DIFF
--- a/src/routes/pricing/+page.svelte
+++ b/src/routes/pricing/+page.svelte
@@ -75,7 +75,7 @@
 										</header>
 										<div class="aw-pricing-cards-content">
 											<ul class="aw-checked-list-circle">
-												<li><span>100GB bandwidth</span></li>
+												<li><span>10GB bandwidth</span></li>
 												<li><span>Unlimited projects</span></li>
 												<li><span>Never paused</span></li>
 												<li><span>750K executions</span></li>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixed a typo. Free plan has 10GB bandwidth, but it said 100GB

(Provide a description of what this PR does.)
In the file src/routes/pricing/+pages.svelte there was a typo that said 100GB instead of 10GB

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)
https://github.com/appwrite/appwrite/issues/6368

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
Yes