### PR TITLE
📚 Documentation: Fixed a typo. Changed from 100GB to 10GB 

### DIFF
--- a/src/routes/pricing/+page.svelte
+++ b/src/routes/pricing/+page.svelte
@@ -75,7 +75,7 @@
 										</header>
 										<div class="aw-pricing-cards-content">
 											<ul class="aw-checked-list-circle">
-												<li><span>100GB bandwidth</span></li>
+												<li><span>10GB bandwidth</span></li>
 												<li><span>Unlimited projects</span></li>
 												<li><span>Never paused</span></li>
 												<li><span>750K executions</span></li>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Solved the Typo mistake on pricing page . There's 100 GB written instead of 10GB in Starter Plan . So I corrected that from 100 GB to 10GB.

## Test Plan

I cloned the repo and set it up in development mode. I made a simple fix of typo and checked it by running it in localhost.

## Related PRs and Issues

https://github.com/appwrite/appwrite/issues/6368

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes