### PR TITLE
fix: sidebar footer --> go to console button (mobile view)

### DIFF
--- a/src/lib/layouts/Sidebar.svelte
+++ b/src/lib/layouts/Sidebar.svelte
@@ -84,6 +84,7 @@
 				</section>
 			{/each}
 		</div>
+		
 		{#if expandable}
 			<button
 				on:click={toggleSidenav}
@@ -94,10 +95,11 @@
 				<span class="icon-cheveron-right" aria-hidden="true" />
 			</button>
 		{/if}
+
 		<div class="aw-side-nav-mobile-footer-buttons">
-			<button class="aw-button u-width-full-line">
-				<span class="text">Go to console</span>
-			</button>
+			<a href="https://cloud.appwrite.io/console" class="aw-button">
+				<span class="aw-sub-body-500">Go to console</span>
+			</a>
 
 			<a
 				href="https://github.com/appwrite/appwrite/stargazers"

--- a/src/lib/layouts/Sidebar.svelte
+++ b/src/lib/layouts/Sidebar.svelte
@@ -97,7 +97,7 @@
 		{/if}
 
 		<div class="aw-side-nav-mobile-footer-buttons">
-			<a href="https://cloud.appwrite.io/console" class="aw-button">
+			<a href="https://cloud.appwrite.io/console" class="aw-button u-width-full-line">
 				<span class="aw-sub-body-500">Go to console</span>
 			</a>
 


### PR DESCRIPTION
## What does this PR do?

Fixed the go-to console link at the footer in the sidebar when we are in mobile view.

## Test Plan

I replaced the button with a link tag which redirects to the console.

![image](https://github.com/appwrite/website/assets/68741416/615c72ac-b7fb-49f2-80b5-305bbf6db276)

## Related PRs and Issues
> checkout pr: #176

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes.