### PR TITLE
docs: Fix import path typo in Nextjs Quickstart documentation

### DIFF
--- a/src/routes/docs/quick-starts/nextjs/+page.markdoc
+++ b/src/routes/docs/quick-starts/nextjs/+page.markdoc
@@ -6,35 +6,31 @@ difficulty: beginner
 readtime: 3
 back: /docs/quick-starts
 ---
-
 Learn how to setup your first Next.js project powered by Appwrite.
-
 {% section #step-1 step=1 title="Create project" %}
 Head to the [Appwrite Console](https://cloud.appwrite.io/console).
 
 {% only_dark %}
 ![Create project screen](/images/docs/quick-starts/dark/create-project.png)
 {% /only_dark %}
-
 {% only_light %}
 ![Create project screen](/images/docs/quick-starts/create-project.png)
 {% /only_light %}
 
 If this is your first time using Appwrite, create an account and create your first project.
 
-Then, under **Add a platform**, add a **Web app**. The **Hostname** should be `localhost`.
+Then, under **Add a platform**, add a **Web app**. The **Hostname** should be `localhost`. 
 
 {% only_dark %}
 ![Add a platform](/images/docs/quick-starts/dark/add-platform.png)
 {% /only_dark %}
-
 {% only_light %}
 ![Add a platform](/images/docs/quick-starts/add-platform.png)
 {% /only_light %}
 
 You can skip optional steps.
-{% /section %}
 
+{% /section %}
 {% section #step-2 step=2 title="Create Next.js project" %}
 Create a Next.js project and create a **JavaScript** Next.js project.
 
@@ -42,22 +38,20 @@ Create a Next.js project and create a **JavaScript** Next.js project.
 npx create-next-app@latest && cd my-app
 ```
 {% /section %}
-
 {% section #step-3 step=3 title="Install Appwrite SDK" %}
+
 Install the JavaScript Appwrite SDK.
 
 ```sh
 npm install appwrite
 ```
 {% /section %}
-
 {% section #step-4 step=4 title="Define Appwrite service" %}
-Find your project's ID in the **Settings** page.
+Find your project's ID in the **Settings** page. 
 
 {% only_dark %}
 ![Project settings screen](/images/docs/quick-starts/dark/project-id.png)
 {% /only_dark %}
-
 {% only_light %}
 ![Project settings screen](/images/docs/quick-starts/project-id.png)
 {% /only_light %}
@@ -77,7 +71,6 @@ export const account = new Account(client);
 export { ID } from 'appwrite';
 ```
 {% /section %}
-
 {% section #step-5 step=5 title="Create a login page" %}
 Create or update `app/page.jsx` file and add the following code to it.
 

--- a/src/routes/docs/quick-starts/nextjs/+page.markdoc
+++ b/src/routes/docs/quick-starts/nextjs/+page.markdoc
@@ -72,7 +72,7 @@ export { ID } from 'appwrite';
 ```
 {% /section %}
 {% section #step-5 step=5 title="Create a login page" %}
-Create or update `app/page.jsx` file and add the following code to it.
+Create or update `app/page.js` file and add the following code to it.
 
 ```js
 "use client";

--- a/src/routes/docs/quick-starts/nextjs/+page.markdoc
+++ b/src/routes/docs/quick-starts/nextjs/+page.markdoc
@@ -6,31 +6,35 @@ difficulty: beginner
 readtime: 3
 back: /docs/quick-starts
 ---
+
 Learn how to setup your first Next.js project powered by Appwrite.
+
 {% section #step-1 step=1 title="Create project" %}
 Head to the [Appwrite Console](https://cloud.appwrite.io/console).
 
 {% only_dark %}
 ![Create project screen](/images/docs/quick-starts/dark/create-project.png)
 {% /only_dark %}
+
 {% only_light %}
 ![Create project screen](/images/docs/quick-starts/create-project.png)
 {% /only_light %}
 
 If this is your first time using Appwrite, create an account and create your first project.
 
-Then, under **Add a platform**, add a **Web app**. The **Hostname** should be `localhost`. 
+Then, under **Add a platform**, add a **Web app**. The **Hostname** should be `localhost`.
 
 {% only_dark %}
 ![Add a platform](/images/docs/quick-starts/dark/add-platform.png)
 {% /only_dark %}
+
 {% only_light %}
 ![Add a platform](/images/docs/quick-starts/add-platform.png)
 {% /only_light %}
 
 You can skip optional steps.
-
 {% /section %}
+
 {% section #step-2 step=2 title="Create Next.js project" %}
 Create a Next.js project and create a **JavaScript** Next.js project.
 
@@ -38,20 +42,22 @@ Create a Next.js project and create a **JavaScript** Next.js project.
 npx create-next-app@latest && cd my-app
 ```
 {% /section %}
-{% section #step-3 step=3 title="Install Appwrite SDK" %}
 
+{% section #step-3 step=3 title="Install Appwrite SDK" %}
 Install the JavaScript Appwrite SDK.
 
 ```sh
 npm install appwrite
 ```
 {% /section %}
+
 {% section #step-4 step=4 title="Define Appwrite service" %}
-Find your project's ID in the **Settings** page. 
+Find your project's ID in the **Settings** page.
 
 {% only_dark %}
 ![Project settings screen](/images/docs/quick-starts/dark/project-id.png)
 {% /only_dark %}
+
 {% only_light %}
 ![Project settings screen](/images/docs/quick-starts/project-id.png)
 {% /only_light %}
@@ -71,13 +77,14 @@ export const account = new Account(client);
 export { ID } from 'appwrite';
 ```
 {% /section %}
+
 {% section #step-5 step=5 title="Create a login page" %}
 Create or update `app/page.jsx` file and add the following code to it.
 
 ```js
 "use client";
 import { useState } from "react";
-import { account, ID } from "appwrite";
+import { account, ID } from "./appwrite";
 
 const LoginPage = () => {
   const [loggedInUser, setLoggedInUser] = useState(null);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR addresses a minor documentation issue by correcting an import path typo in the documentation. The previous import statement incorrectly referred to "appwrite" without specifying the file path. This change ensures that the import statement points to the correct file location.


## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)