### PR TITLE
(fix):Update Heading Tags in Side Navbar for Improved Accessibility

### DIFF
--- a/src/lib/layouts/Sidebar.svelte
+++ b/src/lib/layouts/Sidebar.svelte
@@ -64,7 +64,7 @@
 						{/if}
 					{:else}
 						{#if navGroup.label}
-							<h4 class="aw-side-nav-header aw-eyebrow u-un-break-text">{navGroup.label}</h4>
+							<h2 class="aw-side-nav-header aw-eyebrow u-un-break-text">{navGroup.label}</h2>
 						{/if}
 						<ul>
 							{#each navGroup.items as groupItem}


### PR DESCRIPTION
## What does this PR do?

This PR addresses the issue #279  by changing the heading tags in the left navigation sidebar. Currently, all headings are marked as `<h4>`, and this PR updates them to use `<h2>` tags for improved accessibility.

## Related PRs and Issues

This PR is related to the issue "📚 Documentation: Heading levels in menu should be h2s [a11y][TheA11y100]" in the repository. No other related PRs or issues are currently associated with this change.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes, I have read the Contributing Guidelines on issues.
