### PR TITLE
fix missing link in self-hosting

### DIFF
--- a/src/routes/docs/advanced/self-hosting/+page.markdoc
+++ b/src/routes/docs/advanced/self-hosting/+page.markdoc
@@ -104,7 +104,7 @@ Make these configurations to unlock the full power of Appwrite.
 
 # Manual (Docker Compose) {% #manual %}
 
-For advanced Docker users, the manual installation might seem more familiar. To set up Appwrite manually, download the Appwrite base `docker-compose.yml` and `.env` files, then move them inside a directory named `appwrite`. After the download completes, update the different environment variables as you wish in the `.env` file and start the Appwrite stack using the following Docker command:
+For advanced Docker users, the manual installation might seem more familiar. To set up Appwrite manually, download the Appwrite base `docker-compose.yml` and `.env` files from the [Appwrite repo](https://github.com/appwrite/appwrite), then move them inside a directory named `appwrite`. After the download completes, update the different environment variables as you wish in the `.env` file and start the Appwrite stack using the following Docker command:
 
 ```bash
 docker compose up -d --remove-orphans


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

There's no link to where developers can get docker-compose.yml for manual install. This adds a link
## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)