### PR TITLE
Update sentence in events+page.markdoc

### DIFF
--- a/src/routes/docs/advanced/platform/events/+page.markdoc
+++ b/src/routes/docs/advanced/platform/events/+page.markdoc
@@ -6,7 +6,7 @@ description: Harness the power of events in Appwrite. Explore event-driven archi
 
 Appwrite provides a variety of events that allows your application to react to changes as they happen. 
 A event will fire when a change occurs in your Appwrite project, like when a new user registers or a new file is uploaded to Appwrite. 
-You can subscribe to these events to with Appwrite [Functions](/docs/products/functions), [Realtime](/docs/apis/realtime), or [Webhooks](/docs/advanced/platform/webhooks).
+You can subscribe to these events with Appwrite [Functions](/docs/products/functions), [Realtime](/docs/apis/realtime), or [Webhooks](/docs/advanced/platform/webhooks).
 
 You can subscribe to events for specific resources using their ID or subscribe to changes of all resources of the same type by using a wildcard character * instead of an ID. 
 You can also filter for events of specific actions like create, update, or delete. 


### PR DESCRIPTION
## What does this PR do?
Update sentence by removing (IMHO) a redundant "to"

In the events documentation, the last sentence of the first paragraph had an extra _to_ which made the sentence in my humble opinion a bit off (grammatically). This PR just removes that extra _to_ in the sentence. Also, I considered that the author may have meant to type **too** but considering the "flow" of the paragraph I concluded removing the extra _to_ the better option.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes