### PR TITLE
Fix typo: 'Appwrite' misspelled in the community page (#328)

### DIFF
--- a/src/routes/community/+page.svelte
+++ b/src/routes/community/+page.svelte
@@ -79,7 +79,7 @@
     const projects: ProjectCardProps[] = [
         {
             title: 'Auth UI',
-            description: 'Appwirte-powered authentication screens generator for any application.',
+            description: 'Appwrite-powered authentication screens generator for any application.',
             image: {
                 src: 'https://cloud.appwrite.io/v1/storage/buckets/thumbnails/files/64803bb4f34eb4b05ee3/preview?width=800&output=webp&project=builtWithAppwrite',
                 alt: 'Auth UI: Fully customizable login flow for your applications'


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?
This PR addresses issue #328, where the word "Appwrite" was misspelled on the community page. It fixes the typo by updating the text to "Appwrite" in the specified location.

Changes made in this PR:
- Modified the affected file to correct the spelling mistake.
- Reviewed and confirmed that the page layout remains intact after the change.


### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes