### PR TITLE
Fix typo: missing `$` symbol

### DIFF
--- a/src/routes/docs/products/functions/examples/+page.markdoc
+++ b/src/routes/docs/products/functions/examples/+page.markdoc
@@ -154,7 +154,7 @@ return function ($context) {
         $amountInRupees = floatval($context->req->query['amount']);
         $response = $client->get('https://api.exchangerate.host/latest?base=INR&symbols=USD');
         $data = $response->json();
-        $amountInDollars = amountInRupees * $data['rates']['USD'];
+        $amountInDollars = $amountInRupees * $data['rates']['USD'];
         return $context->res->send(strval($amountInDollars));
     }
 


### PR DESCRIPTION
## What does this PR do?

There is a missing `$` symbol in the code section on [this page](https://appwrite.io/docs/products/functions/examples), under the header **Currency conversion API**.

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes