### PR TITLE
Fixed Bug #360 - No Focus Style on quick start button

### DIFF
--- a/src/lib/components/Technologies.svelte
+++ b/src/lib/components/Technologies.svelte
@@ -59,7 +59,7 @@
     {#each platforms as platform}
         <Tooltip>
             <li>
-                <a href={platform.href} class="aw-box-icon has-border-gradient">
+                <a href={platform.href} class="aw-icon-button aw-box-icon has-border-gradient">
                     <img src={platform.image} alt="{platform.name} Logo" width="32" height="32" />
                 </a>
             </li>


### PR DESCRIPTION
Fixes #360 

### Expected Behavior:

<img width="728" alt="Screenshot 2023-11-22 at 7 13 45 PM" src="https://github.com/appwrite/website/assets/66913564/929ff870-e6b6-4a95-a048-32ba1a4764e3">
