### PR TITLE
Remove the manual installation section from the self-hosting page

### DIFF
--- a/src/routes/docs/advanced/self-hosting/+page.markdoc
+++ b/src/routes/docs/advanced/self-hosting/+page.markdoc
@@ -102,16 +102,6 @@ Make these configurations to unlock the full power of Appwrite.
 
 [Configure TLS Certificates](/docs/advanced/self-hosting/tls-certificates)
 
-# Manual (Docker Compose) {% #manual %}
-
-For advanced Docker users, the manual installation might seem more familiar. To set up Appwrite manually, download the Appwrite base `docker-compose.yml` and `.env` files from the [Appwrite repo](https://github.com/appwrite/appwrite), then move them inside a directory named `appwrite`. After the download completes, update the different environment variables as you wish in the `.env` file and start the Appwrite stack using the following Docker command:
-
-```bash
-docker compose up -d --remove-orphans
-```
-
-Once the Docker installation completes, go to your machine's hostname or IP address on your browser to access the Appwrite Console. Please note that on hosts that are not Linux-native, the server might take a few minutes to start after installation completes.
-
 # Stop {% #stop %}
 
 You can stop your Appwrite containers by using the following command executed from the same directory as your `docker-compose.yml` file.


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

The manual section suggests using the docker-compose.yml and .env from our repo, but those are development files, requires the source code, and should not be used by someone trying to setup Appwrite.

We need to figure out how to automate the creation of the docker-compose.yml and .env files and then bring back this section.

## Test Plan

Manually checked the docs:

<img width="1036" alt="image" src="https://github.com/appwrite/website/assets/1477010/95cc62b1-de1d-43bd-813b-5d9583121913">

## Related PRs and Issues

Previous PR: 

* https://github.com/appwrite/website/pull/304

Related issue for adding manual installation files:

* https://github.com/appwrite/appwrite/issues/6367 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes