### PR TITLE
[441] Documentation: Replace 'Svelte' with 'React' in React tutorial

### DIFF
--- a/src/routes/docs/tutorials/react/step-3/+page.markdoc
+++ b/src/routes/docs/tutorials/react/step-3/+page.markdoc
@@ -31,7 +31,7 @@ You can skip optional steps.
 
 # Initialize Appwrite SDK {% #init-sdk %}
 
-To use Appwrite in our Svelte app, we'll need to find our project ID. Find your project's ID in the **Settings** page. 
+To use Appwrite in our React app, we'll need to find our project ID. Find your project's ID in the **Settings** page. 
 
 {% only_dark %}
 ![Project settings screen](/images/docs/quick-starts/dark/project-id.png)


### PR DESCRIPTION
## What does this PR do?

Replaces the mention of Svelte in the React tutorial in docs. 

## Test Plan

No code change.

## Related PRs and Issues

This closes #441.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.