### PR TITLE
fix-overflow

### DIFF
--- a/src/lib/layouts/Docs.svelte
+++ b/src/lib/layouts/Docs.svelte
@@ -76,7 +76,7 @@
 
 <svelte:window on:keydown={handleKeydown} />
 
-<div class="u-position-relative">
+<div class="u-position-relative" style="overflow-x: clip;">
     <section class="aw-mobile-header is-transparent">
         <div class="aw-mobile-header-start">
             <a href="/" aria-label="homepage">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -108,20 +108,22 @@
     </div>
 </div>
 
-<div
-    class="u-position-absolute aw-is-only-desktop"
-    style="top: 22rem; left: 54%; translate: calc(-50% - 900px); width: 75.9375rem;"
-    class:aw-u-hide-mobile={$isMobileNavOpen}
->
-    <img src="/images/bgs/hero-lines-1.png" alt="" />
-</div>
+<div class="u-position-relative" style="overflow-x: clip;">
+    <div
+        class="u-position-absolute aw-is-only-desktop"
+        style="top: 22rem; left: 54%; translate: calc(-50% - 900px); width: 75.9375rem;"
+        class:aw-u-hide-mobile={$isMobileNavOpen}
+    >
+        <img src="/images/bgs/hero-lines-1.png" alt="" />
+    </div>
 
-<div
-    class="u-position-absolute aw-is-only-desktop"
-    style="top: 42rem; left: 49%; translate: calc(-50% + 800px); width: 60rem;"
-    class:aw-u-hide-mobile={$isMobileNavOpen}
->
-    <img src="/images/bgs/hero-lines-2.png" alt="" />
+    <div
+        class="u-position-absolute aw-is-only-desktop"
+        style="top: 42rem; left: 49%; translate: calc(-50% + 800px); width: 60rem;"
+        class:aw-u-hide-mobile={$isMobileNavOpen}
+    >
+        <img src="/images/bgs/hero-lines-2.png" alt="" />
+    </div>
 </div>
 
 <Main>


### PR DESCRIPTION
In Safari (or Chrome when dev tools is open for some reason) some images overflow and allow for unintended horizontal scrolling. This commit fixes one occurrence on the home page hero (with a viewport > 1280px) as well as once on the docs page. 