### PR TITLE
Docs: fix headings on Storage (Self-hosting) page

### DIFF
--- a/src/routes/docs/advanced/self-hosting/storage/+page.markdoc
+++ b/src/routes/docs/advanced/self-hosting/storage/+page.markdoc
@@ -8,7 +8,7 @@ Appwrite's Storage Service can be configured to store files locally, or with sel
 By default, Appwrite's Storage Service **stores files on your server's local storage**.
 If you expect large volumes of data or the need to have scalable data storage, you may choose to use a separate storage service.
 
-# Available adapters {% #adapters %}
+# Available adapters {% #available-adapters %}
 Appwrite supports AWS S3, Digital Ocean Spaces, Backblaze, Akamai Object Storage, and Wasabi as storage adapters. 
 Some of these services can be self-hosted, just like Appwrite.
 
@@ -18,7 +18,7 @@ You can select which storage adapter to use by setting the `_APP_STORAGE_DEVICE`
 Learn more about storage environment variables 
 {% /arrow_link %}
 
-# Maximum file size {% #adapters %}
+# Maximum file size {% #maximum-file-size %}
 
 The maximum size for a single file upload is controlled by the `_APP_STORAGE_LIMIT` environment variable, which defaults to 30 MB. 
 [Learn more about environment variables](/docs/advanced/self-hosting/environment-variables).

--- a/src/routes/docs/advanced/self-hosting/storage/+page.markdoc
+++ b/src/routes/docs/advanced/self-hosting/storage/+page.markdoc
@@ -8,7 +8,7 @@ Appwrite's Storage Service can be configured to store files locally, or with sel
 By default, Appwrite's Storage Service **stores files on your server's local storage**.
 If you expect large volumes of data or the need to have scalable data storage, you may choose to use a separate storage service.
 
-# Available adpters {% #adapters %}
+# Available adapters {% #adapters %}
 Appwrite supports AWS S3, Digital Ocean Spaces, Backblaze, Akamai Object Storage, and Wasabi as storage adapters. 
 Some of these services can be self-hosted, just like Appwrite.
 


### PR DESCRIPTION
## What does this PR do?

Corrects a typo and resolves heading ID duplication by assigning new, unique identifiers.

## Test Plan

Navigate to _Docs_ &rarr; _Self-hosting_ &rarr; _Storage_ and verify the correct spelling of "adapters" in the "Available adapters" heading and confirm distinct identifiers for both "Available adapters" and "Maximum file size" headings, ensuring their listing in the references menu.

## Related PRs and Issues

N/A

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.