### PR TITLE
doc: update instructions for creating a SvelteKit project

### DIFF
--- a/src/routes/docs/quick-starts/sveltekit/+page.markdoc
+++ b/src/routes/docs/quick-starts/sveltekit/+page.markdoc
@@ -35,7 +35,7 @@ You can skip optional steps.
 Create a SvelteKit project.
 
 ```sh
-npm create svelte@next my-app && cd my-app && npm install
+npm create svelte@latest my-app && cd my-app && npm install
 ```
 {% /section %}
 {% section #step-3 step=3 title="Install Appwrite" %}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Updates the instructions for creating a SvelteKit project in the quick-start docs.

Since SvelteKit is available in the `@latest` version of the Svelte, we don't have to use `@next` which is more likely to contain unstable code.

The change reflects the instructions provided on the official SvelteKit site.
https://kit.svelte.dev/docs/creating-a-project

Fixes: https://github.com/appwrite/website/issues/551

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes