### PR TITLE
fix: mobile sections

### DIFF
--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -31,7 +31,7 @@
 </svelte:head>
 
 <Main>
-    <div class="aw-big-padding-section">
+    <div class="aw-big-padding-section" style:overflow-x="hidden">
         <div class="aw-big-padding-section-level-1 u-position-relative">
             <div
                     class="u-position-absolute"

--- a/src/routes/docs/+page.svelte
+++ b/src/routes/docs/+page.svelte
@@ -416,7 +416,9 @@
     .aw-main-section {
         max-inline-size: unset;
         margin-inline: unset;
-        padding-inline-start: 3rem; // 48px
+        @media (min-width:1280px) {
+            padding-inline-start: 3rem; // 48px
+        }
     }
 
     .bg-blur {


### PR DESCRIPTION
## What does this PR do?

- fixes mobile overflow on blog
- fixes paddings on mobile docs

<img width="484" alt="Bildschirmfoto 2024-01-10 um 15 41 44" src="https://github.com/appwrite/website/assets/1759475/60de3d2e-d605-4939-96af-c748bfddc1a2">
<img width="466" alt="Bildschirmfoto 2024-01-10 um 15 41 57" src="https://github.com/appwrite/website/assets/1759475/4d467a38-dd8a-44d7-a1c0-36eec76322b7">


## Test Plan

- manual