### PR TITLE
Added dart:io to make templates work by default and delete error while using Platform.environment

### DIFF
--- a/src/routes/docs/products/functions/examples/+page.markdoc
+++ b/src/routes/docs/products/functions/examples/+page.markdoc
@@ -397,6 +397,7 @@ return function ($context) {
 ```dart
 import 'dart:async';
 import 'package:dart_appwrite/dart_appwrite.dart';
+import: 'dart:io';
 
 Future main(final context) async {
     final vote = {
@@ -723,6 +724,7 @@ end
 ```dart
 import 'dart:async';
 import 'package:dart_appwrite/dart_appwrite.dart';
+import: 'dart:io';
 
 Future main(final context) async {
     final html = '''<!doctype html>


### PR DESCRIPTION
## What does this PR do?

Added dart:io to make the template work by default so users don't need to import it manually