### PR TITLE
fix: layout by url in docs

### DIFF
--- a/src/routes/docs/quick-starts/+layout.svelte
+++ b/src/routes/docs/quick-starts/+layout.svelte
@@ -4,7 +4,7 @@
 	import Sidebar from '../Sidebar.svelte';
 </script>
 
-<Docs variant={$page.url.pathname.endsWith('/quick-starts') ? 'default' : 'two-side-navs'}>
+<Docs variant={$page.route.id === '/docs/quick-starts' ? 'default' : 'two-side-navs'}>
 	<Sidebar />
 	<slot />
 </Docs>

--- a/src/routes/docs/tutorials/+layout.svelte
+++ b/src/routes/docs/tutorials/+layout.svelte
@@ -3,7 +3,7 @@
     import Docs, { type DocsLayoutVariant } from '$lib/layouts/Docs.svelte';
     import Sidebar from '../Sidebar.svelte';
 
-    $: variant = $page.url.pathname.endsWith('/tutorials')
+    $: variant = $page.route.id === '/docs/tutorials'
         ? 'default'
         : ('two-side-navs' as DocsLayoutVariant);
 </script>


### PR DESCRIPTION
## What does this PR do?

- depend the layout on the route id, not the pathname which can contain a trailing slash

## Test Plan

- manual

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅ 