### PR TITLE
fix: trailing threads

### DIFF
--- a/src/routes/threads/+layout.ts
+++ b/src/routes/threads/+layout.ts
@@ -1,1 +1,1 @@
-export const prerender = 'auto';
+export const prerender = false;

--- a/src/routes/threads/+layout.ts
+++ b/src/routes/threads/+layout.ts
@@ -1,1 +1,1 @@
-export const prerender = false;
+export const prerender = 'auto';

--- a/src/routes/threads/[id]/+page.server.ts
+++ b/src/routes/threads/[id]/+page.server.ts
@@ -1,7 +1,7 @@
 import { error } from '@sveltejs/kit';
 import { getRelatedThreads, getThread, getThreadMessages, iterateAllThreads } from '../helpers.js';
 
-export const prerender = true;
+export const prerender = 'auto';
 
 export const entries = async () => {
     const ids = [];


### PR DESCRIPTION
## What does this PR do?

- setting prerender to `auto` to prerender all threads on build time and allow fetching trailing ones

## Test Plan

- manual

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅ 