### PR TITLE
fix: replaced `ref()` with `useState`

### DIFF
--- a/src/routes/docs/tutorials/nuxt/step-4/+page.markdoc
+++ b/src/routes/docs/tutorials/nuxt/step-4/+page.markdoc
@@ -30,9 +30,11 @@ import { ref } from "vue";
 import { account } from "../appwrite";
 import { type Models } from 'appwrite';
 
-const current = ref<Models.Session | null>(null); // Reference to current user object
+export const useCurrentUser = () => useState<Models.Session | null>('current-user', () => null); // Reference to current user object.
 
 export const useUserSession = () =>  {
+    const current = useCurrentUser()
+
     const register = async (email: string, password: string): Promise<void> => {
         await account.create(ID.unique(), email, password); // Register new user in Appwrite
         await login(email, password); // Login registered user


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

1 - move the usage of reactive state inside a composable
2 - replace `ref` with `useState` so when  the `web sdk` has better support for SSR there will be no need to update the tutorial.

(Provide a description of what this PR does.)

## Test Plan

Currently as the `web sdk` can't be tested with `ssr` it can't be tested with `Appwrite` but you can check [Nuxt docs](https://nuxt.com/docs/getting-started/state-management#best-practices) 

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)

As the usage of `ref` or `useState` outside a `setup()` or `script setup` it could lead that all visitor share the same data. [from Nuxt docs](https://nuxt.com/docs/getting-started/state-management#best-practices). 

I have faced this issue with `ssr` in the past using firebase and caught it before going to production. I believe now as `appwrite web sdk` requires ssr to be turned off won't be a major issue.