### PR TITLE
fix: deployment cache

### DIFF
--- a/server/cache.js
+++ b/server/cache.js
@@ -1,9 +1,0 @@
-/**
- * @returns {import('express').RequestHandler}
- */
-export function cache() {
-    return function (_req, res, next) {
-        res.setHeader('Cache-Control', 'max-age=3600, no-cache');
-        next();
-    }
-}

--- a/server/main.js
+++ b/server/main.js
@@ -1,12 +1,10 @@
 import express from 'express';
 import compression from 'compression'
-import { cache } from './cache.js';
 import { sitemap } from './sitemap.js'
 import { handler } from '../build/handler.js';
 
 async function main() {
     const app = express();
-    app.use(cache());
     app.use(compression());
     app.use(await sitemap());
     app.use(handler);

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -81,11 +81,11 @@
         });
     });
 
-   	beforeNavigate(({ willUnload, to }) => {
-		if ($updated && !willUnload && to?.url) {
-			location.href = to.url.href;
-		}
-	});
+    beforeNavigate(({ willUnload, to }) => {
+        if ($updated && !willUnload && to?.url) {
+            location.href = to.url.href;
+        }
+    });
 
     $: if (browser) currentTheme.subscribe((theme) => applyTheme(theme));
     $: if (browser && $loggedIn) {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -46,10 +46,11 @@
     import '$scss/index.scss';
 
     import { browser, dev } from '$app/environment';
-    import { navigating, page } from '$app/stores';
+    import { navigating, page, updated } from '$app/stores';
     import { onMount } from 'svelte';
     import { derived, writable } from 'svelte/store';
     import { loggedIn } from '$lib/utils/console';
+    import { beforeNavigate } from '$app/navigation';
 
     function applyTheme(theme: Theme) {
         const resolvedTheme = theme === 'system' ? getSystemTheme() : theme;
@@ -79,6 +80,12 @@
             }
         });
     });
+
+   	beforeNavigate(({ willUnload, to }) => {
+		if ($updated && !willUnload && to?.url) {
+			location.href = to.url.href;
+		}
+	});
 
     $: if (browser) currentTheme.subscribe((theme) => applyTheme(theme));
     $: if (browser && $loggedIn) {

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -38,6 +38,9 @@ const config = {
     extensions: ['.markdoc', '.svelte', '.md'],
     kit: {
         adapter: nodeAdapter(),
+        version: {
+            pollInterval: 60 * 1000,
+        },
         files: {
             hooks: {
                 server: isVercel ? undefined : './src/hooks/server.ts'


### PR DESCRIPTION
## What does this PR do?

- let svelte decide what cache headers to use, we where too strict
- poll new version every minute in the background - so if a deployment happened, the next navigation will not be a client side navigation

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅ 