### PR TITLE
Fix Dead Links in Custom Domains Documentation

### DIFF
--- a/src/routes/docs/advanced/platform/custom-domains/+page.markdoc
+++ b/src/routes/docs/advanced/platform/custom-domains/+page.markdoc
@@ -54,41 +54,41 @@ Below, you'll find a list of registrars and links to their DNS setting documenta
 | 123 Reg         | [A Record](https://www.123-reg.co.uk/support/domains/how-do-i-point-my-domain-name-to-an-ip-address/) / [CNAME Record](https://www.123-reg.co.uk/support/domains/how-do-i-set-up-a-cname-record-on-my-domain-name/) |
 | AWS Route 53    | [Settings](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-creating.html) |
 | Alfahosting     | [Settings](https://alfahosting.de/antworten-auf-ihre-fragen/?cid=78#faqContent) |
-| Binero          | [A Record](https://www.binero.se/guider/guider-dom-nnamn/dns/skapa-a-record) / [CNAME Record](https://www.binero.se/guider/guider-dom-nnamn/dns/skapa-ett-cname) / [Settings](https://www.binero.se/guider/guider-dom-nnamn/dns/ndra-eller-radera-dns-information) |
+| Binero          | [Settings](https://docs.binero.com/dns.html) |
 | Bluehost        | [A Record](https://my.bluehost.com/hosting/help/whats-an-a-record) / [CNAME Record](https://my.bluehost.com/hosting/help/cname) / [Settings](https://my.bluehost.com/hosting/help/559) |
 | ClouDNS         | [A Record](https://www.cloudns.net/wiki/article/10/) / [CNAME Record](https://www.cloudns.net/wiki/article/13/) |
 | Cloudflare      | [Settings](https://support.cloudflare.com/hc/en-us/articles/360019093151) |
-| Crazydomains    | [A Record](https://www.crazydomains.com/help/how-do-i-create-update-an-a-record/) / [CNAME Record](https://www.crazydomains.com/help/how-do-i-change-update-my-cname-records/) |
-| DNS Made Easy   | [A Record](https://help.dnsmadeeasy.com/managed-dns/records/record/) / [CNAME Record](https://help.dnsmadeeasy.com/managed-dns/records/cname-record/) |
+| Crazydomains    | [Settings](https://www.crazydomains.com.au/help/manage-dns-records-in-cpanel/) |
+| DNS Made Easy   | [A Record](https://support.dnsmadeeasy.com/support/solutions/articles/47001024724-a-record) / [CNAME Record](https://support.dnsmadeeasy.com/support/solutions/articles/47001001393-cname-record) |
 | DNSimple        | [A Record](https://support.dnsimple.com/articles/manage-a-record/) / [CNAME Record](https://support.dnsimple.com/articles/manage-cname-record/) |
 | DigitalOcean    | [A Record](https://www.digitalocean.com/community/tutorials/an-introduction-to-digitalocean-dns#a-records) / [CNAME Record](https://www.digitalocean.com/community/tutorials/an-introduction-to-digitalocean-dns#cname-records) / [Settings](https://www.digitalocean.com/community/tutorials/an-introduction-to-digitalocean-dns) |
 | DreamHost       | [A Record](https://help.dreamhost.com/hc/en-us/articles/215414867-How-do-I-add-custom-DNS-records-#A_record) / [CNAME Record](https://help.dreamhost.com/hc/en-us/articles/215414867-How-do-I-add-custom-DNS-records-#CNAME_record) |
-| Freeparking     | [Settings](https://helpdesk.freeparking.co.nz/index.php?/Knowledgebase/Article/View/314/0/managing-basic-dns-records) |
+| Freeparking     | [Settings](https://www.freeparking.co.nz/help/manage-dns-records-in-freeparking-dashboard) |
 | Gandi           | [A Record](https://wiki.gandi.net/en/dns/zone/a-record) / [CNAME Record](https://wiki.gandi.net/en/dns/zone/cname-record) |
 | Godaddy         | [A Record](https://www.godaddy.com/help/add-an-a-record-19238) / [CNAME Record](https://www.godaddy.com/help/add-a-cname-record-19236) |
 | Google Domains  | [A Record](https://support.google.com/a/answer/2579934?hl=en&ref_topic=2721296) / [CNAME Record](https://support.google.com/a/answer/47283?hl=en) |
-| Host Europe     | [Settings](https://www.hosteurope.de/faq/domains/verwaltung/nameserver-einrichten/) |
-| Hover           | [A Record](https://help.hover.com/hc/en-us/articles/217282457-How-to-Edit-your-DNS-Records) / [CNAME Record](https://help.hover.com/hc/en-us/articles/217282467-How-to-Edit-your-DNS-Records) |
-| Hostinger       | [Settings](https://www.hostinger.com/tutorials/dns/how-to-change-dns-records) |
-| Infomaniak      | [Settings](https://www.infomaniak.com/en/support/faq/2853/dns-name-server-change) |
-| InMotion Hosting| [A Record](https://www.inmotionhosting.com/support/website/dns-nameserver-changes/how-to-edit-dns-records) / [CNAME Record](https://www.inmotionhosting.com/support/website/dns-nameserver-changes/adding-cname-records-tutorial) |
-| Internet.bs     | [Settings](https://www.internet.bs/faq/EN/domains-general/dns-management-how-to-change-dns-servers-on-my-domain) |
-| LeaseWeb        | [A Record](https://www.leaseweb.com/platforms/api/knowledge-base/creating-dns-records) / [CNAME Record](https://www.leaseweb.com/platforms/api/knowledge-base/creating-dns-records) |
-| LCN.com         | [Settings](https://www.lcn.com/support/articles/how-to-change-dns-records/) |
-| Loopia          | [Settings](https://www.loopia.se/support/dns/andra-dns-poster/) |
-| Media Temple    | [A Record](https://mediatemple.net/community/products/grid/204643230/how-do-i-associate-a-domain-name-with-my-website) / [CNAME Record](https://mediatemple.net/community/products/grid/204643230/how-do-i-associate-a-domain-name-with-my-website) |
+| Host Europe     | [Settings](https://www.hosteurope.de/faq/domains/verwaltung/nameserver-eintraege/) |
+| Hover           | [Settings](https://help.hover.com/hc/en-us/articles/217282457-Managing-DNS-records) |
+| Hostinger       | [Settings](https://support.hostinger.com/en/articles/1583249-how-to-manage-dns-records-at-hostinger) |
+| Infomaniak      | [Settings](https://www.infomaniak.com/en/support/faq/2000/change-dns-zone-simple-mode) |
+| InMotion Hosting| [Settings](https://www.inmotionhosting.com/support/product-guides/wordpress-hosting/central/domains/dns-management/) / [CNAME Record](https://www.inmotionhosting.com/support/domain-names/create-cname-record/) |
+| Internet.bs     | [Settings](https://faq.internetbs.net/hc/en-gb/sections/360004926357-DNS-Nameservers) |
+| LeaseWeb        | [Settings](https://kb.leaseweb.com/products/hosting/domain-name) |
+| LCN.com         | [Settings](https://www.lcn.com/support/articles/how-to-manage-dns-settings-in-cpanel/) |
+| Loopia          | [Settings](https://support.loopia.com/wiki/dns-editor-a-and-cname-2/) |
+| Media Temple    | [Settings](https://mediatemple.zendesk.com/hc/en-us/articles/204403794-How-can-I-change-the-DNS-records-for-my-domain) |
 | Namecheap       | [A Record](https://www.namecheap.com/support/knowledgebase/article.aspx/319/78/how-can-i-set-up-an-a-address-record-for-my-domain) / [CNAME Record](https://www.namecheap.com/support/knowledgebase/article.aspx/9256/2208/how-can-i-set-up-a-cname-record-for-my-domain) |
 | Namesilo        | [A Record](https://www.namesilo.com/Support/DNS-Manager) / [CNAME Record](https://www.namesilo.com/Support/DNS-Manager) |
-| Network Solutions | [A Record](https://www.networksolutions.com/support/a-record-host-great-com/) / [CNAME Record](https://www.networksolutions.com/support/what-is-a-cname-and-how-to-add-one/) |
-| One.com         | [Settings](https://help.one.com/hc/en-us/articles/115005585905-How-do-I-add-custom-DNS-records-) |
-| OVH             | [Settings](https://docs.ovh.com/gb/en/domains/web_hosting_the_dns_zone_for_my_domain_name_is_managed_by_an_external_provider_on_their_side/) |
-| Porkbun         | [A Record](https://kb.porkbun.com/article/aa-00309) / [CNAME Record](https://kb.porkbun.com/article/aa-00250) |
-| Register.it     | [A Record](https://help.register.it/en/domains/add-dns-record) / [CNAME Record](https://help.register.it/en/domains/add-dns-record) |
-| SiteGround      | [A Record](https://www.siteground.com/kb/how_to_add_a_cname_record_in_my_account/) / [CNAME Record](https://www.siteground.com/kb/how_to_add_a_cname_record_in_my_account/) |
-| United Domains  | [Settings](https://help.uniteddomains.com/en/support/solutions/articles/35000150726) |
+| Network Solutions | [A Record](https://customerservice.networksolutions.com/prweb/PRAuth/webkm/help/article/manage-dns-adns-records) / [CNAME Record](https://customerservice.networksolutions.com/prweb/PRAuth/webkm/help/article/manage-dns-adns-records) |
+| One.com         | [Settings](https://help.one.com/hc/en-us/articles/115005595925-Manage-your-DNS-settings) |
+| OVH             | [Settings](https://help.ovhcloud.com/csm/en-dns-edit-dns-zone?id=kb_article_view&sysparm_article=KB0051682) |
+| Porkbun         | [A Record](https://kb.porkbun.com/article/54-pointing-your-domain-to-hosting-with-a-records) / [CNAME Record](https://kb.porkbun.com/article/68-how-to-edit-dns-records) |
+| Register.it     | [Settings](https://www.register.it/assistenza/cambiare-dns/) |
+| SiteGround      | [Settings](https://www.siteground.com/kb/manage-dns-records/) |
+| United Domains  | [A Record](https://www.uniteddomains.com/faq/question/11) / [CNAME Record](https://www.uniteddomains.com/faq/question/14)|
 | Vercel          | [Settings](https://vercel.com/docs/custom-domains) |
 | Wix             | [Settings](https://support.wix.com/en/article/connecting-a-wix-domain-to-an-external-site) |
-| Yahoo Small Business | [A Record](https://help.smallbusiness.yahoo.net/s/article/SLN22171) / [CNAME Record](https://help.smallbusiness.yahoo.net/s/article/SLN22175) |
+| Yahoo Small Business | [A Record](https://help.turbify.com/s/article/how-do-i-add-edit-and-delete-an-a-record) / [CNAME Record](https://help.turbify.com/s/article/how-do-i-add-edit-and-delete-a-cname-record) |
 
 DNS changes might take up to 48 hours to propagate worldwide. This means that it might take up to two days for your new domain to become accessible using Appwrite. For debugging, you can try using [this online tool](https://dnschecker.org/) to check your DNS propagation status.
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Updates Dead / Expired links in the [Custom Domains](https://appwrite.io/docs/advanced/platform/custom-domains) documentations

## Test Plan

`pnpm run dev` > navigate to localhost:port/docs/advanced/platform/custom-domains and reviewed formatting + validation of links

`pnpm build` ran build command successfully, however errors appeared that were likely unrelated to this change



## Related PRs and Issues

N/A - this was brought to my attention from a Hostsinger user not being able to access linked URL.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes