### PR TITLE
Fix createEmailPasswordSession() typo

### DIFF
--- a/src/routes/docs/quick-starts/vue/+page.markdoc
+++ b/src/routes/docs/quick-starts/vue/+page.markdoc
@@ -107,7 +107,7 @@ const password = ref('');
 const name = ref('');
 
 const login = async (email, password) => {
-  await account.createEmailPasswordSession(email, password);
+  await account.createEmailSession(email, password);
   loggedInUser.value = await account.get();
 };
 


### PR DESCRIPTION
## What does this PR do?

Fixes small typo in [Vue Quickstart Docs](https://appwrite.io/docs/quick-starts/vue) "create a login page" section...

from
```javascript
await account.createEmailPasswordSession(email, password);
```
to
```javascript
await account.createEmailSession(email, password);
```

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

Followed the tutorial on the quickstart to verify issue #724 then tested with the provided fix in the issue.

## Related PRs and Issues

#724 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.