### PR TITLE
Long links break into new line

### DIFF
--- a/src/scss/6-elements/_link.scss
+++ b/src/scss/6-elements/_link.scss
@@ -9,7 +9,8 @@
   --p-link-color-text-focus-visible: var(--web-color-accent-click);
 
   color: hsl(var(--p-link-color-text));
-  display:inline-flex; gap:pxToRem(4); border-radius:pxToRem(4); cursor:pointer;
+  /* display:inline-flex; gap:pxToRem(4); */ /* made issues on long links that break into new line */
+  border-radius:pxToRem(4); cursor:pointer;
 
   &:where(:is(:hover):not(#{$disabled})) { --p-link-color-text:var(--p-link-color-text-hover); }
   &:where(:is(:active):not(#{$disabled})) { --p-link-color-text:var(--p-link-color-text-active); }


### PR DESCRIPTION
Fix the issue. If we will have specific locations where links will need inline-flex behavior will support different solution to them.

(Issues happened on big chunl of text on Docs)