### PR TITLE
Typo fixed

### DIFF
--- a/src/routes/docs/products/messaging/send-email-messages/+page.markdoc
+++ b/src/routes/docs/products/messaging/send-email-messages/+page.markdoc
@@ -12,7 +12,7 @@ You can send custom email messages to your app's users using Appwrite Messaging 
 This guide takes you through the implementation path of adding email messaging to your app.
 
 # Add a provider {% #add-a-provider %}
-Appwrite supports [Mailgun](/docs/products/messaging/mailgun/) and [Sendgird](/docs/products/messaging/sendgrid/) as
+Appwrite supports [Mailgun](/docs/products/messaging/mailgun/) and [Sendgrid](/docs/products/messaging/sendgrid/) as
 SMTP providers. You must configure one of them as a provider.
 {% only_dark %}
 ![Add a SMTP provider](/images/docs/messaging/providers/mailgun/dark/add-mailgun.png)


### PR DESCRIPTION
## What does this PR do?

Fixing typo for email provider name for documentation


## Related PRs and Issues

[Documentation: Typo at email provider documentation page](https://github.com/appwrite/website/issues/821)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes