### PR TITLE
Document the CLI's --json flag

### DIFF
--- a/src/routes/docs/tooling/command-line/commands/+page.markdoc
+++ b/src/routes/docs/tooling/command-line/commands/+page.markdoc
@@ -72,6 +72,13 @@ In case of errors with any command, you can get more information about what went
 appwrite users list --verbose
 ```
 
+# JSON {% #json %}
+By default, output is rendered in a tabular format. To format the output as JSON, use the `--json` flag.
+
+```sh
+appwrite users list --json
+```
+
 # Examples {% #examples %}
 
 ## Create user {% #create-user %}

--- a/src/routes/docs/tooling/command-line/commands/+page.markdoc
+++ b/src/routes/docs/tooling/command-line/commands/+page.markdoc
@@ -9,7 +9,7 @@ Other than commands to create and deploy databases, collections, functions, team
 Commands follows the following general syntax:
 
 ```sh
-appwrite [COMMAND] --[OPTIONS]
+appwrite [COMMAND] [OPTIONS]
 ```
 
 # List {% #list %}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

The `--json` flag is useful when output is long and doesn't render right a terminal. This adds the option to the docs to amke it more well known.

## Test Plan

<img width="825" alt="image" src="https://github.com/appwrite/website/assets/1477010/2829491d-b875-4af8-9468-5ce751c242d7">


<img width="822" alt="image" src="https://github.com/appwrite/website/assets/1477010/879a2800-769e-4ed7-8d2a-7e79df536aa5">

<img width="384" alt="image" src="https://github.com/appwrite/website/assets/1477010/7e8901d3-fb7c-4ca4-918f-2ce830b76401">


## Related PRs and Issues

* https://github.com/appwrite/appwrite/issues/7577

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes