### PR TITLE
Minor spelling mistake

### DIFF
--- a/src/routes/docs/products/databases/quick-start/+page.markdoc
+++ b/src/routes/docs/products/databases/quick-start/+page.markdoc
@@ -152,7 +152,7 @@ const client = new Client()
 const databases = new Databases(client);
 
 let promise = databases.listDocuments(
-    "<DATABASE_ID>"
+    "<DATABASE_ID>",
     "<COLLECTION_ID>",
     [
         Query.equal('title', 'Hamlet')


### PR DESCRIPTION
This is just the smallest little bug I found, but it's kinda annoying, especially for beginners, who'll just copy the code from the docs and then wonder, why they are getting an error in their code editor.

Anyways, there was a missing `,` in your docs xD.

Hope this is gonna get merged!