### PR TITLE
Fixed uneven spacing in footer

### DIFF
--- a/src/lib/components/MainFooter.svelte
+++ b/src/lib/components/MainFooter.svelte
@@ -8,7 +8,7 @@
 </script>
 
 {#if variant === 'homepage'}
-    <footer class="web-main-footer u-position-relative u-margin-block-start-48">
+    <footer class="web-main-footer u-position-relative">
         <ul class="u-flex u-gap-8">
             {#each socials as social}
                 <li>


### PR DESCRIPTION
## What does this PR do?

This PR fixes the uneven spacing that you get in the footer ( [MainFooter.svelte](https://github.com/appwrite/website/blob/main/src/lib/components/MainFooter.svelte) to be exact) on the homepage:

![uneven-spacing](https://github.com/appwrite/website/assets/151644171/b768af0b-e181-4263-a1ef-cb65f8573578)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
yes