### PR TITLE
Fixed uneven spacing in footer (2)

### DIFF
--- a/src/scss/7-components/_footer-nav.scss
+++ b/src/scss/7-components/_footer-nav.scss
@@ -1,7 +1,7 @@
 @use '../abstract' as *;
 
 .#{$p}-footer-nav {
-  display:flex; justify-content:space-between; padding-block:pxToRem(64); font-size:var(--web-font-size-tiny);
+  display:flex; justify-content:space-between; padding-top:pxToRem(64); font-size:var(--web-font-size-tiny);
   .web-logo { align-self:start; }
   &-main {
     &-title { margin-block-end:pxToRem(24); }


### PR DESCRIPTION
## What does this PR do?
Fixes uneven spacing in the footer section, this time I kept the top `4rem` and bottom `3rem`, just as I was told to do.

Related PR: https://github.com/appwrite/website/pull/893

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
yes