### PR TITLE
fix: blog image loading to lazy

### DIFF
--- a/src/markdoc/layouts/Post.svelte
+++ b/src/markdoc/layouts/Post.svelte
@@ -96,9 +96,10 @@
                                                 <img
                                                     class="web-author-image"
                                                     src={authorData.avatar}
+                                                    alt={authorData.name}
+                                                    loading="lazy"
                                                     width="44"
                                                     height="44"
-                                                    alt=""
                                                 />
                                             {/if}
                                             <div class="u-flex-vertical">
@@ -116,7 +117,7 @@
 														class="web-icon-button"
 														aria-label="Author twitter"
 														target="_blank" rel="noopener noreferrer"
-														
+
 													>
 														<span class="web-icon-x" aria-hidden="true" />
 													</a>
@@ -129,7 +130,7 @@
 														class="web-icon-button"
 														aria-label="Author LinkedIn"
 														target="_blank" rel="noopener noreferrer"
-														
+
 													>
 														<span class="web-icon-linkedin" aria-hidden="true" />
 													</a>
@@ -142,7 +143,7 @@
 														class="web-icon-button"
 														aria-label="Author GitHub"
 														target="_blank" rel="noopener noreferrer"
-														
+
 													>
 														<span class="web-icon-github" aria-hidden="true" />
 													</a>

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -97,7 +97,7 @@
                         {@const author = data.authors.find((author) => author.slug === featured.author)}
                         <article class="web-feature-article u-margin-block-start-48">
                             <a href={featured.href} class="web-feature-article-image">
-                                <img src={featured.cover} class="web-image-ratio-4/3" alt="cover" />
+                                <img src={featured.cover} class="web-image-ratio-4/3" loading="lazy" alt="cover" />
                             </a>
                             <div class="web-feature-article-content">
                                 <header class="web-feature-article-header">
@@ -118,9 +118,10 @@
                                         <img
                                                 class="web-author-image"
                                                 src={author?.avatar}
+                                                alt={author?.name}
+                                                loading="lazy"
                                                 width="24"
                                                 height="24"
-                                                alt=""
                                         />
                                         <div class="web-author-info">
                                             <a href={author?.href} class="web-sub-body-400 web-link"


### PR DESCRIPTION
## What does this PR do?

- adds missing `loading="lazy"` to the blog pages
 
### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅ 