### PR TITLE
Remove envFixer plugin to remove zero-width spaces

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,27 +3,9 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vitest/config';
 import { ViteImageOptimizer } from 'vite-plugin-image-optimizer';
 import { enhancedImages } from '@sveltejs/enhanced-img';
-import type { Plugin } from 'vite';
-
-const envFixer: Plugin = {
-    name: 'env-fixer',
-    enforce: 'pre',
-    transform(code, id) {
-        if (!id.includes('.markdoc')) {
-            return { code };
-        }
-
-        // The replacement uses a zero-width space to avoid being detected by vite
-        const transformed = code.replaceAll(/process\.env/g, 'process​.env');
-        return {
-            code: transformed
-        };
-    }
-};
 
 export default defineConfig({
     plugins: [
-        envFixer,
         enhancedImages(),
         sveltekit(),
         dynamicImport({


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

The plugin was created because `process.env` in our code samples was being replaced so the code samples looked incorrect. However, Vite 5 has fixed this so we don't need this plugin anymore.

In addition, the zero-width space was causing issues when people would copy and paste the code into their editor to run.

## Test Plan

Manually checked the [tutorials](https://appwrite-io-docker-pr-944.onrender.com/docs/tutorials/nextjs-ssr-auth/step-3) to make sure they looked okay.

<img width="735" alt="image" src="https://github.com/appwrite/website/assets/1477010/464be0c9-7b97-4ad3-a385-cdcb7d02d9b9">

Checked the code to make sure non-printable chars weren't in the code.

![image](https://github.com/appwrite/website/assets/1477010/bd497f90-c42e-4f15-9025-f67afac19ccd)

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes