### PR TITLE
DOC - Change react-native createEmailSession to createEmailPasswordSession

### DIFF
--- a/src/routes/docs/tutorials/react-native/step-4/+page.markdoc
+++ b/src/routes/docs/tutorials/react-native/step-4/+page.markdoc
@@ -29,7 +29,7 @@ export function UserProvider(props) {
   const [user, setUser] = useState(null);
 
   async function login(email, password) {
-    const loggedIn = await account.createEmailSession(email, password);
+    const loggedIn = await account.createEmailPasswordSession(email, password);
     setUser(loggedIn);
     toast('Welcome back. You are logged in');
   }


### PR DESCRIPTION
createEmailSession doesn't exist

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?
Corrects the login method to `createEmailPasswordSession`. Using `createEmailSession` throws `[TypeError: _appWrite.account.createEmailSession is not a function (it is undefined)]`

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes