### PR TITLE
Remove Typo in hugging face text-generation demo

### DIFF
--- a/src/routes/docs/products/ai/tutorials/text-generation/+page.markdoc
+++ b/src/routes/docs/products/ai/tutorials/text-generation/+page.markdoc
@@ -57,8 +57,6 @@ export default async ({ req, res }) => {
   }
 }
 ```
-
-The
 {% /section %}
 
 {% section #step-4 step=4 title="Make a request to Hugging Face" %}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR removes a typo that left the word `the` inside the hugging face text generation demo.

## Test Plan

N/A

## Related PRs and Issues

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes
