### PR TITLE
Remove quotes from nuxt tutorial .env file

### DIFF
--- a/src/routes/docs/tutorials/nuxt/step-3/+page.markdoc
+++ b/src/routes/docs/tutorials/nuxt/step-3/+page.markdoc
@@ -46,8 +46,8 @@ Your project id is located in the **Settings** page in the Appwrite console.
 Add a `.env` file to the root directory and add the following code to it, replacing `YOUR_PROJECT_ID` with your project id.
 
 ```
-VITE_APPWRITE_ENDPOINT="https://cloud.appwrite.io/v1"
-VITE_APPWRITE_PROJECT="YOUR_PROJECT_ID"
+VITE_APPWRITE_ENDPOINT=https://cloud.appwrite.io/v1
+VITE_APPWRITE_PROJECT=YOUR_PROJECT_ID
 ```
 
 # Initialize Appwrite SDK {% #init-sdk %}


### PR DESCRIPTION

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

.env files should not have double quotes. Doing so may add the double quotes into the actual string at runtime.

See https://nuxt.com/docs/guide/directory-structure/env

## Test Plan

Manual:

<img width="771" alt="image" src="https://github.com/appwrite/website/assets/1477010/35f1d85a-1d1d-4850-a0c0-580aff78b6ae">

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes