### PR TITLE
Update spacing of "blockquote" section in article

### DIFF
--- a/src/scss/7-components/_article.scss
+++ b/src/scss/7-components/_article.scss
@@ -28,7 +28,7 @@
       &-list,
       &-numeric-list,
       &-pink-dots    { margin-block-end:pxToRem(24); }
-      &-blockquote    { margin-block:pxToRem(16); }
+      &-blockquote    { margin-block:pxToRem(32); }
       &-table-wrapper { margin-block-end:pxToRem(32); }
       &-media         {
         margin-block-end:pxToRem(32);


### PR DESCRIPTION
update spacing of "blockquote" section in article to have 32px spacing from top & bottom (instead of 16px)