### PR TITLE
doc-#999-Typo-docs/products/auth/email-password-page-fixed

### DIFF
--- a/src/routes/docs/products/auth/email-password/+page.markdoc
+++ b/src/routes/docs/products/auth/email-password/+page.markdoc
@@ -149,4 +149,4 @@ promise.then(function (response) {
 
 # Security {% #security %}
 
-Appwrite's security first mindset goes beyond a securely implemented of authentication API. You can enable features like password dictionary, password history, and disallow personal data in passwords to encourage users to pick better passwords. By enabling these features, you protect user data and teach better password choices, which helps make the internet a safer place.
+Appwrite's security first mindset goes beyond a securely implemented authentication API. You can enable features like password dictionary, password history, and disallow personal data in passwords to encourage users to pick better passwords. By enabling these features, you protect user data and teach better password choices, which helps make the internet a safer place.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR resolves the issue of Typo in the Security section of the docs/products/auth/email-password Page.

![Screenshot 2024-06-03 181032](https://github.com/appwrite/website/assets/134297032/a9cdb60f-8a4e-486e-9a27-d02619e2393c)


## Test Plan

I run the development environment and everything looks great and fine after resolving the issue.

## Related PRs and Issues

fix/#999

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes