### PR TITLE
Use web-grid-two-side-navs for model references

### DIFF
--- a/src/routes/docs/references/+layout.svelte
+++ b/src/routes/docs/references/+layout.svelte
@@ -4,7 +4,7 @@
     import Sidebar, { type NavParent, type NavTree } from '$lib/layouts/Sidebar.svelte';
     import { preferredPlatform, preferredVersion } from '$lib/utils/references';
 
-    $: expandable = !!$page.url.pathname.match(/\/docs\/references\/.*?\/.*?\/.*?\/?/);
+    $: expandable = !!$page.url.pathname.match(/\/docs\/references\/.*?\/(client|server).*?\/.*?\/?/);
 
     $: prefix = `/docs/references/${$preferredVersion ?? $page.params?.version ?? 'cloud'}/${
         $preferredPlatform ?? $page.params?.platform ?? 'client-web'


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

web-grid-huge-navs is too wide for the model references pages.

## Test Plan

Before

![appwrite io_docs_references_1 2 x_models_account](https://github.com/appwrite/website/assets/1477010/6553fcc0-4fad-4854-9ed8-ab61efad9b68)

After

![after](https://github.com/appwrite/website/assets/1477010/4f6c2c86-95f3-4742-ba7d-a1bc73540b33)

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes