### PR TITLE
fix: api references paragraphs

### DIFF
--- a/src/lib/utils/markdown.ts
+++ b/src/lib/utils/markdown.ts
@@ -19,7 +19,7 @@ function transform_tokens(tokens: ReturnType<typeof md.parse>): ReturnType<typeo
         }
         switch (token.type) {
             case 'paragraph_open':
-                token.attrPush(['class', 'web-paragraph']);
+                token.attrPush(['class', 'web-sub-body-400']);
                 break;
             case 'link_open': {
                 const href = token.attrGet('href');

--- a/src/lib/utils/markdown.ts
+++ b/src/lib/utils/markdown.ts
@@ -19,7 +19,7 @@ function transform_tokens(tokens: ReturnType<typeof md.parse>): ReturnType<typeo
         }
         switch (token.type) {
             case 'paragraph_open':
-                token.attrPush(['class', 'web-sub-body-400']);
+                token.attrPush(['class', 'web-paragraph']);
                 break;
             case 'link_open': {
                 const href = token.attrGet('href');

--- a/src/routes/docs/references/[version]/[platform]/[service]/+page.svelte
+++ b/src/routes/docs/references/[version]/[platform]/[service]/+page.svelte
@@ -158,7 +158,7 @@
         </header>
         <div class="web-article-content" style:gap="6rem">
             <section class="web-article-content-grid-6-4">
-                <div class="web-article-content-grid-6-4-column-1 u-flex-vertical u-gap-32">
+                <div class="web-article-content-grid-6-4-column-1 u-flex-vertical u-gap-8">
                     <!-- eslint-disable-next-line svelte/no-at-html-tags -->
                     {@html parse(data.service?.description)}
                 </div>
@@ -192,10 +192,10 @@
                         <header class="web-article-content-header">
                             <Heading id={method.id} level={2} inReferences>{method.title}</Heading>
                         </header>
-                        <p class="web-sub-body-400">
+                        <div class="u-flex-vertical u-gap-8">
                             <!-- eslint-disable-next-line svelte/no-at-html-tags -->
                             {@html parse(method.description)}
-                        </p>
+                        </div>
                         <Accordion>
                             {#if method.parameters.length > 0}
                                 <AccordionItem open={true} title="Request">


### PR DESCRIPTION
## What does this PR do?

- fixes line breaks to be 8 on references page
- add line breaks to sdk method description

## Test Plan

**before**
<img width="1442" alt="Bildschirmfoto 2024-06-05 um 11 00 30" src="https://github.com/appwrite/website/assets/1759475/6bf131ac-2099-4f64-b845-8feada351a88">

**after**
<img width="1512" alt="Bildschirmfoto 2024-06-05 um 11 02 40" src="https://github.com/appwrite/website/assets/1759475/6e8d44d8-a3de-488c-9aa8-89fb7eafdace">

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅ 