### PR TITLE
doc-page.markdoc: Fix typo, change "Svelte" to "Vue"

### DIFF
--- a/src/routes/docs/tutorials/vue/step-3/+page.markdoc
+++ b/src/routes/docs/tutorials/vue/step-3/+page.markdoc
@@ -31,7 +31,7 @@ You can skip optional steps.
 
 # Initialize Appwrite SDK {% #init-sdk %}
 
-To use Appwrite in our Svelte app, we'll need to find our project ID. Find your project's ID in the **Settings** page. 
+To use Appwrite in our Vue app, we'll need to find our project ID. Find your project's ID in the **Settings** page. 
 
 {% only_dark %}
 ![Project settings screen](/images/docs/quick-starts/dark/project-id.png)


### PR DESCRIPTION
While I was doing Vue tutorial I realized a little typo and fixed it.