### PR TITLE
Document python ml runtime

### DIFF
--- a/src/routes/docs/advanced/self-hosting/functions/+page.markdoc
+++ b/src/routes/docs/advanced/self-hosting/functions/+page.markdoc
@@ -122,10 +122,10 @@ To enable a runtime, add it to the `_APP_FUNCTIONS_RUNTIMES` environment variabl
 The example below would enable Dart 2.15, .NET 6.0, and Java 18 runtimes.
 
 ```bash
-_APP_FUNCTIONS_RUNTIMES=dart-2.15, dotnet-6.0, java-18.0
+_APP_FUNCTIONS_RUNTIMES=dart-2.15,dotnet-6.0,java-18.0
 ```
 
-You can find a full list of supported runtimes on the [environment variables page](/docs/advanced/self-hosting/environment-variables).
+You can find a full list of supported runtimes [here](/docs/advanced/self-hosting/environment-variables).
 
 You can also configure the maximum timeout that can be set on individual Appwrite Functions. The maximum configurable timeout can be increased by changing the `_APP_FUNCTIONS_TIMEOUT` environment variable. This environment variable changes the configurable maximum but does not alter existing configurations of individual functions.
 

--- a/src/routes/docs/advanced/self-hosting/functions/+page.markdoc
+++ b/src/routes/docs/advanced/self-hosting/functions/+page.markdoc
@@ -125,7 +125,7 @@ The example below would enable Dart 2.15, .NET 6.0, and Java 18 runtimes.
 _APP_FUNCTIONS_RUNTIMES=dart-2.15,dotnet-6.0,java-18.0
 ```
 
-You can find a full list of supported runtimes [here](/docs/advanced/self-hosting/environment-variables).
+You can find a full list of supported runtimes [here](/docs/products/functions/runtimes#available-runtimes).
 
 You can also configure the maximum timeout that can be set on individual Appwrite Functions. The maximum configurable timeout can be increased by changing the `_APP_FUNCTIONS_TIMEOUT` environment variable. This environment variable changes the configurable maximum but does not alter existing configurations of individual functions.
 

--- a/src/routes/docs/products/functions/runtimes/+page.markdoc
+++ b/src/routes/docs/products/functions/runtimes/+page.markdoc
@@ -18,11 +18,6 @@ While still in beta, Appwrite Cloud has limited support for Cloud runtimes. As w
 * Versions
 * Architectures
 ---
-* {% icon icon="python" size="l" /%}
-* [Python ML](https://hub.docker.com/r/openruntimes/python-ml)
-* `python-ML-3.11`
-* x86 / arm64
----
 * {% icon icon="node_js" size="l" /%}
 * [Node.js](https://hub.docker.com/r/openruntimes/node/tags)
 * `node-14.5`
@@ -54,6 +49,11 @@ While still in beta, Appwrite Cloud has limited support for Cloud runtimes. As w
 `python-3.11`
 `python-3.12`
 * x86 / arm64 / armv7 / armv8
+---
+* {% icon icon="python" size="l" /%}
+* [Python ML](https://hub.docker.com/r/openruntimes/python-ml)
+* `python-ML-3.11`
+* x86 / arm64
 ---
 * {% icon icon="dart" size="l" /%}
 * [Dart](https://hub.docker.com/r/openruntimes/dart/tags)

--- a/src/routes/docs/products/functions/runtimes/+page.markdoc
+++ b/src/routes/docs/products/functions/runtimes/+page.markdoc
@@ -18,6 +18,11 @@ While still in beta, Appwrite Cloud has limited support for Cloud runtimes. As w
 * Versions
 * Architectures
 ---
+* {% icon icon="python" size="l" /%}
+* [Python ML](https://hub.docker.com/r/openruntimes/python-ml)
+* `python-ML-3.11`
+* x86 / arm64
+---
 * {% icon icon="node_js" size="l" /%}
 * [Node.js](https://hub.docker.com/r/openruntimes/node/tags)
 * `node-14.5`


### PR DESCRIPTION
## What does this PR do?

Updates docs to mention how to enable the released [Python ML runtime](https://appwrite.io/blog/post/introducing-python-machine-learning-runtime).

 Updated the [example](https://appwrite.io/docs/advanced/self-hosting/functions#functions) to remove the extra spaces
 Updated the "You can find a full list of supported runtimes on the [environment variables page](https://appwrite.io/docs/advanced/self-hosting/environment-variables)." to "You can find a full list of supported runtimes [here](https://appwrite.io/docs/products/functions/runtimes#available-runtimes)."
 Updated the [Available runtimes](https://appwrite.io/docs/products/functions/runtimes#available-runtimes) table to include a new row for Python (ML) 3.11 and the architecture

## Related PRs and Issues

- Fixes https://github.com/appwrite/website/issues/1016

## Test Plan

X

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes