### PR TITLE
add rule to prevent dragging on bg img

### DIFF
--- a/src/routes/docs/+page.svelte
+++ b/src/routes/docs/+page.svelte
@@ -449,6 +449,7 @@
     .bg-blur {
         inset-inline-end: -300px;
         inset-block-start: -100px;
+        pointer-events: none;
     }
 
     .tech-hero {


### PR DESCRIPTION
## What does this PR do?

Adds `pointer-events: none` to the background image, ensuring that it isn't draggable.

## Test Plan

Works as expected in browser:

https://github.com/appwrite/website/assets/109598904/e6e1b114-256a-40ca-9f28-e45bcf1c7e06


## Related PRs and Issues

Closes #988.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅