### PR TITLE
Fix: Broken `XML` due to Title and Urls in `RSS`

### DIFF
--- a/src/routes/blog/rss.xml/+server.ts
+++ b/src/routes/blog/rss.xml/+server.ts
@@ -3,7 +3,7 @@ import { posts } from '../content';
 
 export const prerender = true;
 
-function encodeTitle(str: string): string {
+function encodeText(str: string): string {
     return str.replace(/&/g, '&amp;')
         .replace(/</g, '&lt;')
         .replace(/>/g, '&gt;')
@@ -24,11 +24,11 @@ export const GET: RequestHandler = () => {
     <atom:link href="https://appwrite.io/blog/rss.xml" rel="self" type="application/rss+xml" />
     <description>Appwrite is an open-source platform for building applications at any scale, using your preferred programming languages and tools.</description>
     ${posts.map((post) => `<item>
-        <title>${encodeTitle(post.title)}</title>
+        <title>${encodeText(post.title)}</title>
         <pubDate>${post.date.toUTCString()}</pubDate>
         <link>${encodeUrl(post.href)}</link>
         <guid>${encodeUrl(post.href)}</guid>
-        <description>${post.description}</description>
+        <description>${encodeText(post.description)}</description>
     </item>
     `).join('')}
   </channel>

--- a/src/routes/blog/rss.xml/+server.ts
+++ b/src/routes/blog/rss.xml/+server.ts
@@ -3,23 +3,40 @@ import { posts } from '../content';
 
 export const prerender = true;
 
+function encodeTitle(str: string): string {
+    return str.replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+function encodeUrl(href: string): string {
+    return encodeURI(`https://appwrite.io${href}`)
+}
+
 export const GET: RequestHandler = () => {
     const feed = `<?xml version="1.0" encoding="UTF-8" ?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
 <channel>
     <title>Appwrite</title>
     <link>https://appwrite.io</link>
+    <atom:link href="https://appwrite.io/blog/rss.xml" rel="self" type="application/rss+xml" />
     <description>Appwrite is an open-source platform for building applications at any scale, using your preferred programming languages and tools.</description>
     ${posts.map((post) => `<item>
-        <title>${post.title}</title>
+        <title>${encodeTitle(post.title)}</title>
         <pubDate>${post.date.toUTCString()}</pubDate>
-        <link>https://appwrite.io${post.href}</link>
-        <guid>https://appwrite.io${post.href}</guid>
+        <link>${encodeUrl(post.href)}</link>
+        <guid>${encodeUrl(post.href)}</guid>
         <description>${post.description}</description>
     </item>
     `).join('')}
   </channel>
 </rss>`;
 
-    return new Response(feed);
+    return new Response(feed, {
+        headers: {
+            'Content-Type': 'application/rss+xml'
+        }
+    });
 };

--- a/src/routes/blog/rss.xml/+server.ts
+++ b/src/routes/blog/rss.xml/+server.ts
@@ -3,7 +3,9 @@ import { posts } from '../content';
 
 export const prerender = true;
 
-function encodeText(str: string): string {
+function encodeText(str: string | null): string {
+    if (str === null) return '';
+
     return str.replace(/&/g, '&amp;')
         .replace(/</g, '&lt;')
         .replace(/>/g, '&gt;')


### PR DESCRIPTION
## What does this PR do?

An `&` and a ` ` (space) broke the xml format. This should fix the issue.

## Test Plan

Manual check via `https://validator.w3.org/feed`.

## Related PRs and Issues

* #974.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.