### PR TITLE
docs: fix broken link to the demos-for-react repository onnextjs-ssr-…

### DIFF
--- a/src/routes/docs/tutorials/nextjs-ssr-auth/step-8/+page.markdoc
+++ b/src/routes/docs/tutorials/nextjs-ssr-auth/step-8/+page.markdoc
@@ -4,7 +4,7 @@ title: All set
 description: Add authentication to a Next.js project using Appwrite.
 step: 8
 ---
-If you want to see the complete source code with styling, see the [demos-for-react](https://github.com/appwrite/demos-for-react) repository.
+If you want to see the complete source code with styling, see the [demos-for-react](https://github.com/appwrite/demos-for-react/tree/master/nextjs/server-side-rendering) repository.
 
 # Other authentication methods {% #other-authentication-methods %}
 Appwrite also supports OAuth, passwordless login, anonymous login, and phone login. 

--- a/src/routes/docs/tutorials/nextjs-ssr-auth/step-8/+page.markdoc
+++ b/src/routes/docs/tutorials/nextjs-ssr-auth/step-8/+page.markdoc
@@ -4,7 +4,7 @@ title: All set
 description: Add authentication to a Next.js project using Appwrite.
 step: 8
 ---
-If you want to see the complete source code with styling, see the [demos-for-react](https://github.com/appwrite/demos-for-react/tree/main/nextjs/server-side-rendering) repository.
+If you want to see the complete source code with styling, see the [demos-for-react](https://github.com/appwrite/demos-for-react) repository.
 
 # Other authentication methods {% #other-authentication-methods %}
 Appwrite also supports OAuth, passwordless login, anonymous login, and phone login. 


### PR DESCRIPTION
## What does this PR do?

Fix the link to the demos-for-react repository on the last page of the nextjs-ssr-auth tutorial 

Fixes https://github.com/appwrite/website/issues/802

## Test Plan

x

## Related PRs and Issues

* https://github.com/appwrite/website/issues/802

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes