### PR TITLE
fix: activate the correct menu item based on content scrolling

### DIFF
--- a/src/lib/components/TocRoot.svelte
+++ b/src/lib/components/TocRoot.svelte
@@ -23,8 +23,8 @@
 <script lang="ts">
     export let selector = '#main';
     export let exclude: CreateTableOfContentsArgs['exclude'] = ['h1', 'h3', 'h4', 'h5', 'h6'];
-    export let activeType: CreateTableOfContentsArgs['activeType'] = 'lowest';
-    export let scrollOffset: CreateTableOfContentsArgs['scrollOffset'] = 120;
+    export let activeType: CreateTableOfContentsArgs['activeType'] = 'highest';
+    export let scrollOffset: CreateTableOfContentsArgs['scrollOffset'] = 0;
 
     const toc = createTableOfContents({
         selector,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR fixes an issue where the active menu item does not correspond to the content currently displayed on the screen. The active menu item now accurately reflects the content being viewed.

## Test Plan

1. Navigate to the `Terms and Conditions` page.
2. Click on various items in the side menu.
3. Verify that the active menu item correctly matches the title of the content displayed on the right side of the screen.

## Related PRs and Issues

- Related Issue: #982

---

This version provides more precise language, ensuring that the purpose and testing steps are clear.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)