### PR TITLE
fix: nesting ul and ol

### DIFF
--- a/src/scss/6-elements/_lists.scss
+++ b/src/scss/6-elements/_lists.scss
@@ -26,7 +26,7 @@
     color:hsl(var(--web-color-accent-click)); padding-inline-end:pxToRem(12);
     line-height:var(--web-line-height-md);
   }
-  li {
+  >li {
     display:flex;
     &::before {
       counter-increment: numeric-list;
@@ -36,7 +36,7 @@
   .#{$p}-numeric-list {
     counter-reset: numeric-list-level-2;
     padding-inline-start: pxToRem(24);
-    li {
+    >li {
       &::before {
         color:revert;
         counter-increment: numeric-list-level-2;
@@ -45,7 +45,7 @@
     }
     .#{$p}-numeric-list {
       counter-reset: numeric-list-level-3;
-      li {
+      >li {
         &::before {
           counter-increment: numeric-list-level-3;
           content:counter(numeric-list-level-3, lower-latin);


### PR DESCRIPTION
## What does this PR do?

- there was a tug of war between classes targeting ol and ul
- with this fix, only immediate children will have the style applied of the parent list

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅ 