### PR TITLE
fix - UI bug where TOC header was overlapping with contents in Terms page

### DIFF
--- a/src/markdoc/layouts/Policy.svelte
+++ b/src/markdoc/layouts/Policy.svelte
@@ -79,6 +79,7 @@
                     style:inline-size="100vw"
                     style:background-color="hsl(var(--p-body-bg-color) / 0.1)"
                     style:translate="0 {$isHeaderHidden ? '-4.5rem' : '0'}"
+                    style:z-index="1"
                     on:click={() => (showToc = !showToc)}
                 >
                     <span class="web-description">Table of contents</span>


### PR DESCRIPTION
## What does this PR do?

This is a minor Front-end change where we had to fix the table of contents header getting overlapped after a certain point by the contents below it.

## Test Plan

Have added a single style. No other parts of the code are touched. The website should be working fine. The main thing we have to check is whether the changes are working fine in the website itself.

Running pnpm i && pnpm run dev would do.

## Related PRs and Issues

Closes #1042.

## Screenshots
![image](https://github.com/appwrite/website/assets/74983916/cfff41a7-f22a-4e44-89d9-46cb06c77201)


### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.