### PR TITLE
Doc: Instanciate appwrite instead of using class

### DIFF
--- a/src/routes/docs/quick-starts/apple/+page.markdoc
+++ b/src/routes/docs/quick-starts/apple/+page.markdoc
@@ -160,7 +160,8 @@ class ViewModel: ObservableObject {
 
 struct ContentView: View {
     @ObservedObject var viewModel = ViewModel()
-    
+    let appwrite = Appwrite()
+
     var body: some View {
         VStack {
             TextField(
@@ -173,7 +174,7 @@ struct ContentView: View {
             )
             Button(
                 action: { Task {
-                    try await Appwrite.onRegister(
+                    try await appwrite.onRegister(
                         viewModel.email,
                         viewModel.password
                     )
@@ -184,7 +185,7 @@ struct ContentView: View {
             )
             Button(
                 action: { Task {
-                    try! await Appwrite.onLogin(
+                    try! await appwrite.onLogin(
                         viewModel.email,
                         viewModel.password
                     )


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

In order to use Appwrite, we need to instanciate a class of it instead of directly calling the class

Keep in mind that this method is not working with Swift 6

## Related PRs and Issues

https://discord.com/channels/564160730845151244/1263141402867535882

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅ 