### PR TITLE
Fix: broken link to env variables in advanced/self-hosting/sms page

### DIFF
--- a/src/routes/docs/advanced/self-hosting/sms/+page.markdoc
+++ b/src/routes/docs/advanced/self-hosting/sms/+page.markdoc
@@ -50,7 +50,7 @@ Appwrite supports a growing list of SMS providers that you can choose from. Choo
 
 # Environment variables {% #environment-variables %}
 
-You will need to configure these [environment variables](https://example.com/docs/environment-variables#phone) and restart your Appwrite containers before you can use phone authentication.
+You will need to configure these [environment variables](https://appwrite.io/docs/environment-variables#phone) and restart your Appwrite containers before you can use phone authentication.
 
 {% info title="URL encode" %}
 Ensure the values you insert in the `_APP_SMS_PROVIDER` placeholders are [URL encoded](https://developer.mozilla.org/en-US/docs/Glossary/Percent-encoding) if they contain any non-alphanumeric characters.


### PR DESCRIPTION
The link being shown in the page was

https://example.com/docs/environment-variables#phone

instead of 

https://appwrite.io/docs/environment-variables#phone


Fixed it.