### PR TITLE
Add 1.6.x references

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "@appwrite.io/console": "^0.6.2",
         "@appwrite.io/pink": "~0.26.0",
         "@appwrite.io/pink-icons": "~0.26.0",
-        "@appwrite.io/repo": "github:appwrite/appwrite#main",
+        "@appwrite.io/repo": "github:appwrite/appwrite#1.6.x",
         "@internationalized/date": "3.5.0",
         "@melt-ui/pp": "^0.3.2",
         "@melt-ui/svelte": "^0.74.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ importers:
         specifier: ~0.26.0
         version: 0.26.0
       '@appwrite.io/repo':
-        specifier: github:appwrite/appwrite#main
-        version: https://codeload.github.com/appwrite/appwrite/tar.gz/e3bc1887a4abbc8de3b82d0ec7aadc5e9f46c8a1
+        specifier: github:appwrite/appwrite#1.6.x
+        version: https://codeload.github.com/appwrite/appwrite/tar.gz/f85ad00ee45b3784eb1844e7c4055d98586d4e1f
       '@internationalized/date':
         specifier: 3.5.0
         version: 3.5.0
@@ -163,8 +163,8 @@ packages:
   '@appwrite.io/pink@0.26.0':
     resolution: {integrity: sha512-iPeGE56pauzxuIXt15ZswjKCErwp3QdF3XOlJZfyYY7J2nirra85JNTL+3lWuFIf8yYWL7NbvCjhf8ig79TgwA==}
 
-  '@appwrite.io/repo@https://codeload.github.com/appwrite/appwrite/tar.gz/e3bc1887a4abbc8de3b82d0ec7aadc5e9f46c8a1':
-    resolution: {tarball: https://codeload.github.com/appwrite/appwrite/tar.gz/e3bc1887a4abbc8de3b82d0ec7aadc5e9f46c8a1}
+  '@appwrite.io/repo@https://codeload.github.com/appwrite/appwrite/tar.gz/f85ad00ee45b3784eb1844e7c4055d98586d4e1f':
+    resolution: {tarball: https://codeload.github.com/appwrite/appwrite/tar.gz/f85ad00ee45b3784eb1844e7c4055d98586d4e1f}
     version: 0.0.0
 
   '@babel/code-frame@7.24.7':
@@ -3860,7 +3860,7 @@ snapshots:
       normalize.css: 8.0.1
       the-new-css-reset: 1.11.2
 
-  '@appwrite.io/repo@https://codeload.github.com/appwrite/appwrite/tar.gz/e3bc1887a4abbc8de3b82d0ec7aadc5e9f46c8a1': {}
+  '@appwrite.io/repo@https://codeload.github.com/appwrite/appwrite/tar.gz/f85ad00ee45b3784eb1844e7c4055d98586d4e1f': {}
 
   '@babel/code-frame@7.24.7':
     dependencies:

--- a/src/lib/utils/references.ts
+++ b/src/lib/utils/references.ts
@@ -2,7 +2,17 @@ import { writable } from 'svelte/store';
 import type { Language } from './code';
 import { browser } from '$app/environment';
 
-const allVersions = ['1.5.x', '1.4.x', '1.3.x', '1.2.x', '1.1.x', '1.0.x', '0.15.x', 'cloud'] as const;
+const allVersions = [
+    '1.6.x',
+    '1.5.x',
+    '1.4.x',
+    '1.3.x',
+    '1.2.x',
+    '1.1.x',
+    '1.0.x',
+    '0.15.x',
+    'cloud'
+] as const;
 
 export type Version = (typeof allVersions)[number];
 

--- a/src/lib/utils/specs.ts
+++ b/src/lib/utils/specs.ts
@@ -101,6 +101,11 @@ function getExamples(version: string) {
                 query: '?raw',
                 import: 'default'
             });
+        case '1.6.x':
+            return import.meta.glob('$appwrite/docs/examples/1.6.x/**/*.md', {
+                query: '?raw',
+                import: 'default'
+            });
     }
 }
 

--- a/src/routes/docs/references/[version]/[platform]/[service]/+page.server.ts
+++ b/src/routes/docs/references/[version]/[platform]/[service]/+page.server.ts
@@ -18,7 +18,7 @@ export const entries: EntryGenerator = () => {
 
 export const load: PageServerLoad = async ({ params }) => {
 	const { platform, service } = params;
-	const version = params.version === 'cloud' ? '1.5.x' : params.version;
+	const version = params.version === 'cloud' ? '1.6.x' : params.version;
 	if (!versions.includes(version)) error(404, 'Invalid version');
 	if (!services.includes(service as Service)) error(404, 'Invalid service');
 	if (!platforms.includes(platform as Platform)) error(404, 'Invalid platform');

--- a/src/routes/docs/references/[version]/models/[model]/+page.server.ts
+++ b/src/routes/docs/references/[version]/models/[model]/+page.server.ts
@@ -19,7 +19,7 @@ type Example = {
 }
 
 export const load: PageServerLoad = async ({ params }) => {
-    const version = params.version === 'cloud' ? '1.5.x' : params.version;
+    const version = params.version === 'cloud' ? '1.6.x' : params.version;
     const api = await getApi(version, 'console-web');
     const schema = getSchema(params.model, api);
     const props = Object.entries(schema.properties ?? {});


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Update API references to include 1.6.x and set Cloud to point to 1.6.x references.

## Test Plan

Manual:

<img width="1574" alt="image" src="https://github.com/user-attachments/assets/a3c7ef85-1b35-4c17-8762-08740cc3e846">

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes