### PR TITLE
Docs: Add fortune cookie authentication

### DIFF
--- a/src/routes/docs/products/auth/+layout.svelte
+++ b/src/routes/docs/products/auth/+layout.svelte
@@ -47,12 +47,20 @@
                 {
                     label: 'Tokens',
                     href: '/docs/products/auth/tokens'
+                },
+                {
+                    label: 'Fortune cookies',
+                    href: '/docs/products/auth/fortune-cookies'
                 }
             ]
         },
         {
             label: 'Journeys',
             items: [
+                {
+                    label: 'Fortune cookie login',
+                    href: '/docs/products/auth/fortune-cookie'
+                },
                 {
                     label: 'Email and password login',
                     href: '/docs/products/auth/email-password'

--- a/src/routes/docs/products/auth/+page.markdoc
+++ b/src/routes/docs/products/auth/+page.markdoc
@@ -16,6 +16,9 @@ Add authentication to your app in 5 minutes
 Appwrite supports a variety of authentication methods to fit every app and every niche. Explore Appwrite's authentication flows.
 
 {% cards %}
+{% cards_item href="/docs/products/auth/fortune-cookie" title="Fortune cookie" %}
+Login with a fortune cookie message to access your account.
+{% /cards_item %}
 {% cards_item href="/docs/products/auth/email-password" title="Email and password" %}
 Email and password login with just a few lines of code secured with state of the art Argon2 hasing.
 {% /cards_item %}

--- a/src/routes/docs/products/auth/fortune-cookie/+page.markdoc
+++ b/src/routes/docs/products/auth/fortune-cookie/+page.markdoc
@@ -1,0 +1,76 @@
+---
+layout: article
+title: Fortune cookie login
+description: Implement fortune cookie authentication with Appwrite. Securely authenticate users in your applications using Appwrite's robust fortune cookie authentication system.
+---
+
+Fortune cookie is the most secretive authentication method. Appwrite Authentication recommends this login only for your special users.
+
+This is an effortless login procedure beneficial to both developers and end users. Users merely input their fortune message and submit. Instantaneously, they gain access. This facilitates a swift onboarding process for your end users to your product.
+
+# Login {% #login %}
+
+Log in users using the Create Fortune Cookie Session method.
+
+```client-web
+import { Client, Account } from "appwrite";
+
+const client = new Client()
+    .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
+    .setProject('<PROJECT_ID>');                 // Your project ID
+
+const account = new Account(client);
+
+const promise = account.createFortuneCookieSession("There is no secret ingredient, it's just you!");
+
+promise.then(function (response) {
+    console.log(response); // Success
+}, function (error) {
+    console.log(error); // Failure
+});
+```
+
+{% info title="Note" %}
+1. A fortune message permits single-use access only. Once utilized, it loses its validity, requiring a new message for subsequent logins.
+2. Retrieving a lost or damaged fortune cookie message is not feasible. However, acquiring a new one is always an accessible option.
+{% /info %}
+
+
+# Next steps {% #next-steps %}
+
+Once a user has logged in using their fortune message, it's important to maintain the session's activity by preserving the session state within your app. Verify the user's login status for every fresh session by accessing the user account.
+
+If this action is unsuccessful, direct them towards the login screen. This is the cue to obtain a new cookie.
+
+```client-web
+try {
+    const user = await account.get();
+    // Logged in
+} catch (err) {
+    // Not logged in
+}
+```
+
+Refer to [the Accounts API](/docs/references/cloud/client-web/account) to find the response payload with attributes definition and example payload.
+
+# Access recovery {% #access-recovery %}
+
+Regaining system access is not possible if the fortune message is lost. The solution lies in acquiring another cookie containing a new fortune message. Utilize this new message to regain access swiftly.
+
+The fortune message is yours, akin to other passwords, so refrain from sharing it with friends or others.
+
+A crucial piece of advice: resist the temptation to consume your message, as it's necessary for login processes.
+
+# Security {% #security %}
+
+Appwrite's security-first mindset goes beyond a securely implemented authentication API. Your fortune cookie message is assigned to only you, and no one else knows your message unless you share the cookie with them yourself. By hiding your cookie away, you can protect your account safely.
+
+# Errors {% #errors %}
+
+| Error code| Error message              | Description                                                 |
+|-----------|----------------------------|-------------------------------------------------------------|
+| 400       | Bad request                | Check the fortune message format.                           |
+| 401       | Unauthorised access        | Get a new cookie. It’s expired or already used.             |
+| 403       | Forbidden                  | This message is intentionally ignored. Get a new cookie.    |
+| 404       | Fortune message not found  | Possibly the cookie is not from us. Try ours.               |
+| 413       | Payload Too Large          | The input is too long. Is this really your fortune message? |

--- a/src/routes/docs/products/auth/fortune-cookies/+page.markdoc
+++ b/src/routes/docs/products/auth/fortune-cookies/+page.markdoc
@@ -1,0 +1,19 @@
+---
+layout: article
+title: Fortune cookies
+description: Implement fortune cookie authentication with Appwrite. Securely authenticate users in your applications using Appwrite's robust fortune cookie authentication system.
+---
+
+Fortune cookie is one of the most unique authentication method. This mechanism is reserved for special users of your product while offering a touch of mystique and security.
+
+Unlike traditional authentication methods, fortune cookie authentication does not rely on email or password. It uses a unique message that is delivered in secret ways. Users can use the fortune cookie message to log in to your account.
+
+Users cannot obtain a fortune cookie themselves ensuring a layer of security.
+
+# Fortune cookie login {% #fortune-cookie-login %}
+Find how to integrate with fortune cookie authentication method in Appwrite.
+
+{% cards %}
+{% cards_item href="/docs/products/auth/fortune-cookie" title="Fortune cookie login" %}
+{% /cards_item %}
+{% /cards %}

--- a/src/routes/docs/products/auth/quick-start/+page.markdoc
+++ b/src/routes/docs/products/auth/quick-start/+page.markdoc
@@ -6,12 +6,13 @@ description: Effortlessly add authentication to your apps - simple signup & logi
 You can get up and running with Appwrite Authentication in minutes.
 You can add basic email and password authentication to your app with just a few lines of code.
 
-{% section #sign-up step=1 title="Signup" %}
-You can use the Appwrite [Client SDKs](/docs/sdks#client) to create an account using email and password.
+{% section #login step=1 title="Login" %}
+
+Log in users using the Create Fortune Cookie Session method.
 
 {% multicode %}
 ```client-web
-import { Client, Account, ID } from "appwrite";
+import { Client, Account } from "appwrite";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -19,11 +20,13 @@ const client = new Client()
 
 const account = new Account(client);
 
-const user = await account.create(
-    ID.unique(), 
-    'email@example.com', 
-    'password'
-);
+const promise = account.createFortuneCookieSession('There is no secret ingredient, it is just you!');
+
+promise.then(function (response) {
+    console.log(response); // Success
+}, function (error) {
+    console.log(error); // Failure
+});
 ```
 ```client-flutter
 import 'package:appwrite/appwrite.dart';
@@ -34,11 +37,7 @@ final client = Client()
 
 final account = Account(client);
 
-final user = await account.create(
-    userId: ID.unique(),
-    email: 'email@example.com',
-    password: 'password',
-);
+final session = await account.createFortuneCookieSession('There is no secret ingredient, it is just you!');
 ```
 ```client-apple
 import Appwrite
@@ -49,11 +48,7 @@ let client = Client()
 
 let account = Account(client)
 
-let user = try await account.create(
-    userId: ID.unique(),
-    email: "email@example.com",
-    password: "password"
-)
+let session = try await account.createFortuneCookieSession('There is no secret ingredient, it is just you!')
 ```
 ```client-android-kotlin
 import io.appwrite.Client
@@ -66,22 +61,18 @@ val client = Client()
 
 val account = Account(client)
 
-val user = account.create(
-    userId = ID.unique(),
-    email = "email@example.com",
-    password = "password"
-)
+val session = account.createFortuneCookieSession('There is no secret ingredient, it is just you!')
 ```
 ```graphql
 mutation {
-    accountCreate(userId: "unique()", email: "email@example.com", password: "password") {
+    createFortuneCookieSession('There is no secret ingredient, it is just you!') {
         _id
-        email
-        name
+        userId
+        provider
+        expire
     }
 }
 ```
-
 ```client-react-native
 import { Client, Account, ID } from "appwrite";
 const client = new Client()
@@ -90,69 +81,13 @@ const client = new Client()
 
 const account = new Account(client);
 
-const user = await account.create(
-    ID.unique(), 
-    'email@example.com', 
-    'password'
-);
+const session = await account.createFortuneCookieSession('There is no secret ingredient, it is just you!');
 ```
 {% /multicode %}
 {% /section %}
 
-{% section #login step=2 title="Login" %}
 
-After you've created your account, users can be logged in using the [Create Email Session](/docs/references/cloud/client-web/account#createEmailPasswordSession) method.
-
-{% multicode %}
-```client-web
-const session = await account.createEmailPasswordSession(
-    email, 
-    password
-);
-```
-
-```client-flutter
-final session = await account.createEmailPasswordSession(
-    email: 'email@example.com',
-    password: 'password'
-);
-```
-
-```client-apple
-let session = try await account.createEmailPasswordSession(
-    email: "email@example.com",
-    password: "password"
-)
-```
-
-```client-android-kotlin
-val session = account.createEmailPasswordSession(
-    email = "email@example.com",
-    password = "password"
-)
-```
-
-```graphql
-mutation {
-    accountcreateEmailPasswordSession(email: "email@example.com", password: "password") {
-        _id
-        userId
-        provider
-        expire
-    }
-}
-```
-
-```client-react-native
-const session = await account.createEmailPasswordSession(
-    email, 
-    password
-);
-```
-{% /multicode %}
-{% /section %}
-
-{% section #check-authentication-state step=3 title="Check authentication state" %}
+{% section #check-authentication-state step=2 title="Check authentication state" %}
 After logging in, you can check the authentication state of the user.
 
 Appwrite's SDKs are stateless, so you need to manage the session state in your app. 


### PR DESCRIPTION
## What does this PR do?

I have added a feature in Auth for Fortune Cookie message-based authentication. With this feature, users can further simplify the login process by using the fortune message to log in to their account.
I have added all the relevant sections in the documentation to provide a quick start, concept explanation, and usage tutorial. This PR ignores any relevant REST API for creating a session.

## Test Plan

I have tested the changes locally by executing the project locally. The relevant added pages appear in the desired location, and the changes do not disturb any other pages from being rendered.

## Related PRs and Issues

Not applicable

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes, I have read the Contributing Guidelines.