### PR TITLE
Disable Save changes button while saving updates to init ticket

### DIFF
--- a/src/routes/init/(components)/TicketActions.svelte
+++ b/src/routes/init/(components)/TicketActions.svelte
@@ -13,6 +13,7 @@
     export let showGitHub = true;
     export let customizing = false;
     export let modified = false;
+    export let saving = false;
     export let saveTicket: () => void;
     let { ticket } = $page.data as PageData;
 
@@ -75,7 +76,7 @@
             <button class="web-button is-secondary" on:click={() => (customizing = false)}>
                 <span class="text">Cancel</span>
             </button>
-            <button class="web-button save-button" on:click={saveTicket} disabled={!modified}>
+            <button class="web-button save-button" on:click={saveTicket} disabled={!modified || saving}>
                 <span class="text">Save Changes</span>
             </button>
         </div>

--- a/src/routes/init/tickets/customize/+page.svelte
+++ b/src/routes/init/tickets/customize/+page.svelte
@@ -10,17 +10,21 @@
 
     export let data;
 
-    let name = data.ticket?.name ?? '';
-    let title = data.ticket?.title ?? '';
-    let showGitHub = data.ticket?.show_contributions ?? true;
+    let originalName = data.ticket?.name ?? '';
+    let name = originalName;
+    let originalTitle = data.ticket?.title ?? '';
+    let title = originalTitle;
+    let originalShowGitHub = data.ticket?.show_contributions ?? true;
+    let showGitHub = originalShowGitHub;
 
     let customizing = false;
+    let saving = false;
 
     $: modified = !dequal(
         {
-            name: data.ticket?.name,
-            title: data.ticket?.title,
-            showGitHub: data.ticket?.show_contributions
+            name: originalName,
+            title: originalTitle,
+            showGitHub: originalShowGitHub
         },
         { name, title, showGitHub }
     );
@@ -28,7 +32,9 @@
     async function saveTicket() {
         if (!modified) return;
 
-        await fetch(`/init/tickets/update`, {
+        saving = true;
+
+        let response = await fetch(`/init/tickets/update`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json'
@@ -39,7 +45,15 @@
                 showGitHub
             })
         });
+
+        if (response.ok) {
+            originalName = name;
+            originalTitle = title;
+            originalShowGitHub = showGitHub;
+        }
+
         customizing = false;
+        saving = false;
     }
 </script>
 
@@ -82,7 +96,7 @@
             </TicketPreview>
             <div class="item">
                 <TicketDetails bind:customizing bind:name bind:title />
-                <TicketActions {saveTicket} bind:customizing bind:showGitHub {modified} />
+                <TicketActions {saveTicket} bind:customizing bind:showGitHub {modified} {saving} />
             </div>
         </div>
     </div>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Saving can take some time and:

1. we don't want the user to click again
2. we want to give the user feedback that it's processing

so disable the button while saving.

## Test Plan

Manual:


https://github.com/user-attachments/assets/23230c2e-ec7a-49f4-b054-ef5c0d45e255



## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes