### PR TITLE
Update redirect in SvelteKit SSR auth tutorial

### DIFF
--- a/src/routes/docs/tutorials/sveltekit-ssr-auth/step-5/+page.markdoc
+++ b/src/routes/docs/tutorials/sveltekit-ssr-auth/step-5/+page.markdoc
@@ -51,7 +51,7 @@ export const actions = {
     });
 
     // Redirect to the account page.
-    redirect(301, "/account");
+    redirect(302, "/account");
   },
 };
 ```

--- a/src/routes/docs/tutorials/sveltekit-ssr-auth/step-6/+page.markdoc
+++ b/src/routes/docs/tutorials/sveltekit-ssr-auth/step-6/+page.markdoc
@@ -15,7 +15,7 @@ import { redirect } from "@sveltejs/kit";
 
 export async function load({ locals }) {
   // Logged out users can't access this page.
-  if (!locals.user) redirect(301, "/signup");
+  if (!locals.user) redirect(302, "/signup");
 
   // Pass the stored user local to the page.
   return {
@@ -34,7 +34,7 @@ export const actions = {
     event.cookies.delete(SESSION_COOKIE, { path: "/" });
 
     // Redirect to the sign up page.
-    redirect(301, "/signup");
+    redirect(302, "/signup");
   },
 };
 ```

--- a/src/routes/docs/tutorials/sveltekit-ssr-auth/step-7/+page.markdoc
+++ b/src/routes/docs/tutorials/sveltekit-ssr-auth/step-7/+page.markdoc
@@ -39,7 +39,7 @@ export const actions = {
       `${event.url.origin}/signup`
     );
 
-    redirect(301, redirectUrl);
+    redirect(302, redirectUrl);
   },
 };
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

The current redirect status code is 301, but that is a permanent
redirect. The problem with this is the browser will cache the redirect
and redirect for every request without even making a request to the
server.

Instead, we should use a 302 status code, which is a temporary redirect.
So, when the user hits the home page, the browser will hit the server
so that the server checks whether the user is logged in or not and
redirect accordingly instead of always redirecting to the same page.

## Test Plan

Manually tested the tutorial code

## Related PRs and Issues

Related thread that raised this issue: https://discord.com/channels/564160730845151244/1273816855177597051

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes