### PR TITLE
fix giveaway image

### DIFF
--- a/src/routes/init/(components)/Giveaway.svelte
+++ b/src/routes/init/(components)/Giveaway.svelte
@@ -76,7 +76,7 @@
                 }
                 img {
                     border-radius: 12px;
-                    height: 100%;
+
                     display: block;
                 }
             }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fix weird stretching on Init image:

| Before | After |
|--------|--------|
| ![IMG_8287](https://github.com/user-attachments/assets/4a5b21ca-7cd3-4c51-a3ac-438d793eadc1)| ![IMG_8288](https://github.com/user-attachments/assets/109dbcb9-2d44-4c75-aaf0-9b4ff8806278)| 

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)