### PR TITLE
Docs update cli 2.0

### DIFF
--- a/src/routes/docs/tooling/command-line/installation/+page.markdoc
+++ b/src/routes/docs/tooling/command-line/installation/+page.markdoc
@@ -146,10 +146,10 @@ This will create your `appwrite.json` file, where you will configure your variou
 }
 ```
 
-You can run your first CLI command after logging in. Try fetching information about your Appwrite project.
+You can run your first CLI command after logging in. Try fetching your users from your project.
 
 ```sh
-appwrite projects get --project-id "<PROJECT_ID>"
+appwrite users list
 ```
 
 {% info title="Self-signed certificates" %}

--- a/src/routes/docs/tooling/command-line/non-interactive/+page.markdoc
+++ b/src/routes/docs/tooling/command-line/non-interactive/+page.markdoc
@@ -25,6 +25,11 @@ appwrite login --email "<EMAIL>" --password "<PASSWORD>" --mfa totp
 # API Keys {% #api-keys %}
 In non-interactive mode, the CLI uses an API key to authenticate. Your API key must have sufficient permissions to execute the commands you plan to use. [Learn more about API Keys](/docs/advanced/platform/api-keys).
 
+{% info title="Using API keys with CLI" %}
+Some CLI commands won't work with an API key, like the `projects` commands
+{% /info %}
+
+
 # Deployment {% #deployment %}
 Appwrite's `push` commands can also be executed in a non-interactive mode. This applies to the following resources: functions, collections, buckets, teams, and messaging topics.
 
@@ -74,28 +79,3 @@ Use providers like Github actions to create continuous integrations and continuo
 ## Github
 
 You can use [Github actions](https://github.com/appwrite/setup-for-actions/tree/feat-cli-g2?tab=readme-ov-file#introduction) to automate your Appwrite CLI commands, allowing you to use them even in non-interactive mode.
-
-```yaml
-name: Database Migrations
-
-on:
-  release:
-    types: [ published ]
-
-jobs:
-  migrate:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Setup Appwrite
-        uses: appwrite/setup-for-appwrite@v2
-        with:
-          method: email
-          email: ${{ secrets.EMAIL }}
-          password: ${{ secrets.PASSWORD }}
-          force: true
-          all: true
-          actions: |-
-            push collections
-```

--- a/src/routes/docs/tooling/command-line/non-interactive/+page.markdoc
+++ b/src/routes/docs/tooling/command-line/non-interactive/+page.markdoc
@@ -16,6 +16,10 @@ When you set the global configuration parameters using the `appwrite client` com
 
 In this mode, the CLI can only interact with one project at a time.
 
+## Placeholder Title {% #placholder-title %}
+
+To run tests or project-per-branch previews, you will need Console SDK capabilities. To accomplish this, log in using the `appwrite login` and pass in your email, password, and OTP settings as parameters.
+
 # API Keys {% #api-keys %}
 In non-interactive mode, the CLI uses an API key to authenticate. Your API key must have sufficient permissions to execute the commands you plan to use. [Learn more about API Keys](/docs/advanced/platform/api-keys).
 
@@ -68,3 +72,28 @@ Use providers like Github actions to create continuous integrations and continuo
 ## Github
 
 You can use [Github actions](https://github.com/appwrite/setup-for-actions/tree/feat-cli-g2?tab=readme-ov-file#introduction) to automate your Appwrite CLI commands, allowing you to use them even in non-interactive mode.
+
+```yaml
+name: Database Migrations
+
+on:
+  release:
+    types: [ published ]
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Appwrite
+        uses: appwrite/setup-for-appwrite@v2
+        with:
+          method: email
+          email: ${{ secrets.EMAIL }}
+          password: ${{ secrets.PASSWORD }}
+          force: true
+          all: true
+          actions: |-
+            push collections
+```

--- a/src/routes/docs/tooling/command-line/non-interactive/+page.markdoc
+++ b/src/routes/docs/tooling/command-line/non-interactive/+page.markdoc
@@ -16,9 +16,11 @@ When you set the global configuration parameters using the `appwrite client` com
 
 In this mode, the CLI can only interact with one project at a time.
 
-## Placeholder Title {% #placholder-title %}
-
 To run tests or project-per-branch previews, you will need Console SDK capabilities. To accomplish this, log in using the `appwrite login` and pass in your email, password, and OTP settings as parameters.
+
+```sh
+appwrite login --email "<EMAIL>" --password "<PASSWORD>" --mfa totp  
+```
 
 # API Keys {% #api-keys %}
 In non-interactive mode, the CLI uses an API key to authenticate. Your API key must have sufficient permissions to execute the commands you plan to use. [Learn more about API Keys](/docs/advanced/platform/api-keys).


### PR DESCRIPTION
## What does this PR do?

- Replace `appwrite projects get --project-id "<PROJECT_ID>"` with `appwrite users list`
- add appwrite login and paragraph to non-interactive
- add note that commands won't work with an API key like project commands

## Test Plan

Tested login with non-interactive

## Related PRs and Issues

X

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes