### PR TITLE
Bump appwrite dependency to fix <YOUR_PROJECT_ID> in API references

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
         version: 0.26.0
       '@appwrite.io/repo':
         specifier: github:appwrite/appwrite#1.6.x
-        version: https://codeload.github.com/appwrite/appwrite/tar.gz/cdef3e0cde06bbd45dcf4b0fae492825d22ac291
+        version: https://codeload.github.com/appwrite/appwrite/tar.gz/9c71f5acad4d8385273b48d91b0ee0e5d837e60c
       '@internationalized/date':
         specifier: 3.5.0
         version: 3.5.0
@@ -181,8 +181,8 @@ packages:
   '@appwrite.io/pink@0.26.0':
     resolution: {integrity: sha512-iPeGE56pauzxuIXt15ZswjKCErwp3QdF3XOlJZfyYY7J2nirra85JNTL+3lWuFIf8yYWL7NbvCjhf8ig79TgwA==}
 
-  '@appwrite.io/repo@https://codeload.github.com/appwrite/appwrite/tar.gz/cdef3e0cde06bbd45dcf4b0fae492825d22ac291':
-    resolution: {tarball: https://codeload.github.com/appwrite/appwrite/tar.gz/cdef3e0cde06bbd45dcf4b0fae492825d22ac291}
+  '@appwrite.io/repo@https://codeload.github.com/appwrite/appwrite/tar.gz/9c71f5acad4d8385273b48d91b0ee0e5d837e60c':
+    resolution: {tarball: https://codeload.github.com/appwrite/appwrite/tar.gz/9c71f5acad4d8385273b48d91b0ee0e5d837e60c}
     version: 0.0.0
 
   '@babel/code-frame@7.24.7':
@@ -4193,7 +4193,7 @@ snapshots:
       normalize.css: 8.0.1
       the-new-css-reset: 1.11.2
 
-  '@appwrite.io/repo@https://codeload.github.com/appwrite/appwrite/tar.gz/cdef3e0cde06bbd45dcf4b0fae492825d22ac291': {}
+  '@appwrite.io/repo@https://codeload.github.com/appwrite/appwrite/tar.gz/9c71f5acad4d8385273b48d91b0ee0e5d837e60c': {}
 
   '@babel/code-frame@7.24.7':
     dependencies:


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixes encoding problem of `<YOUR_PROJECT_ID>` in the API references:

![image](https://github.com/user-attachments/assets/2d871003-2ef4-444b-aa95-0e5e71fe7068)


## Test Plan

Tested locally:

<img width="1493" alt="image" src="https://github.com/user-attachments/assets/27c03ded-4b99-42bd-abd4-b8927e1679c7">


## Related PRs and Issues

* https://github.com/appwrite/sdk-generator/pull/952
* https://github.com/appwrite/appwrite/pull/8567

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes