### PR TITLE
Set correct margin top for messaging product code snippet

### DIFF
--- a/src/routes/products/messaging/+page.svelte
+++ b/src/routes/products/messaging/+page.svelte
@@ -483,7 +483,7 @@ messaging.create_email(
                             Start today with your preferred technologies
                         </h2>
                     </div>
-                    <div class="code-snippets divide-border-primary mt-64 grid grid-cols-2 gap-16">
+                    <div class="code-snippets divide-border-primary mt-16 grid grid-cols-2 gap-16">
                         <div class="flex min-w-0 flex-col gap-2">
                             <h3 class="text-label text-primary">Subscribe to a topic</h3>
                             <p class="text-description">


### PR DESCRIPTION
## What does this PR do?

Before:
<img width="1311" alt="image" src="https://github.com/user-attachments/assets/35af78a4-e101-4258-a1db-3280f1ce9e2a">

After:
<img width="1293" alt="image" src="https://github.com/user-attachments/assets/db53d2b1-5c7a-4c6f-b425-adc973ea11e0">


### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅