### PR TITLE
Set correct fallback transparent card padding

### DIFF
--- a/src/scss/6-elements/_card.scss
+++ b/src/scss/6-elements/_card.scss
@@ -55,7 +55,7 @@
     border-radius: var(--p-card-border-radius);
   }
   &.is-transparent {
-    --p-card-padding: var(--card-padding, #{pxToRem(32)});
+    --p-card-padding: var(--card-padding, #{pxToRem(20)});
     padding: var(--p-card-padding);
     border:solid pxToRem(1) rgba(255 255 255 / 0.12);
     border-radius:pxToRem(16);


### PR DESCRIPTION
## What does this PR do?

before:
<img width="831" alt="image" src="https://github.com/user-attachments/assets/3d29adfc-b982-4b3b-bac0-c21770fa4fbc">

After: 
<img width="815" alt="image" src="https://github.com/user-attachments/assets/232c3562-aa03-474c-b14a-68d1c5c27c61">

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
✅