### PR TITLE
Set correct padding on mobile for integrations image

### DIFF
--- a/src/routes/integrations/+page.svelte
+++ b/src/routes/integrations/+page.svelte
@@ -79,7 +79,7 @@
 <!-- binding for fuse -->
 <Fuse list={data.list} options={fuseOptions} bind:query={$query} bind:result />
 <Main>
-    <header class="web-u-sep-block-end relative overflow-hidden pb-0">
+    <header class="web-u-sep-block-end relative overflow-hidden pb-0 web-u-padding-block-end-0">
         <div class="container hero web-u-padding-block-end-0 relative">
             <img
                 src="/images/pages/integration/integration-bg-top-1.png"


### PR DESCRIPTION
## What does this PR do?
Before:
<img width="436" alt="image" src="https://github.com/user-attachments/assets/89bcda62-b846-4f82-acfc-6455261db85b">

After:
<img width="493" alt="image" src="https://github.com/user-attachments/assets/aa64a443-1652-42eb-be07-6a56aa965a91">

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅