### PR TITLE
Bg blur image on docs stays within the frame and not goes all the way to the side

### DIFF
--- a/src/lib/layouts/Docs.svelte
+++ b/src/lib/layouts/Docs.svelte
@@ -48,7 +48,7 @@
     export let isReferences = false;
 
     const variantClasses: Record<DocsLayoutVariant, string> = {
-        default: 'web-grid-side-nav [max-inline-size: 90rem] mx-auto',
+        default: 'web-grid-side-nav max-w-[90rem] mx-auto',
         expanded: 'web-grid-huge-navs',
         'two-side-navs': 'web-grid-two-side-navs'
     };

--- a/src/routes/docs/+page.svelte
+++ b/src/routes/docs/+page.svelte
@@ -68,8 +68,10 @@
     <Sidebar />
 
     <main class="web-main-section relative lg:overflow-hidden" id="main">
-        <div class="web-u-opacity-40-mobile bg-blur absolute">
-            <img src="/images/bgs/docs-blur-1.svg" alt="" />
+        <div class="web-u-opacity-40-mobile bg-blur absolute w-[calc(50%-18rem)]" style="right: 0;">
+            <div class="left-0">
+                <img src="/images/bgs/docs-blur-1.svg" alt="" class="max-w-max"/>
+            </div>
         </div>
 
         <div class="web-u-opacity-40-mobile absolute top-4 left-0">
@@ -386,7 +388,6 @@
     }
 
     .bg-blur {
-        inset-inline-end: -300px;
         inset-block-start: -100px;
     }
 


### PR DESCRIPTION
Before:
<img width="1726" alt="image" src="https://github.com/user-attachments/assets/e930d35e-b597-46f7-bae6-27b7e76eef02">


After:
<img width="1394" alt="image" src="https://github.com/user-attachments/assets/a0a8b781-37a1-4e8f-be7e-60875b1a608d">


### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
✅