### PR TITLE
Fix pricing scale button

### DIFF
--- a/src/routes/pricing/+page.svelte
+++ b/src/routes/pricing/+page.svelte
@@ -136,7 +136,7 @@
                                                 their products.
                                             </p>
                                             <a
-                                                href="https://cloud.appwrite.io/console?type=createPro"
+                                                href="{PUBLIC_APPWRITE_DASHBOARD}/console?type=createPro"
                                                 class="web-button is-full-width mt-8"
                                                 target="_blank"
                                                 rel="noopener noreferrer"

--- a/src/routes/pricing/+page.svelte
+++ b/src/routes/pricing/+page.svelte
@@ -184,14 +184,14 @@
                                                 For scaling teams and agencies that need dedicated
                                                 support.
                                             </p>
-                                            <button
+                                            <a
+                                                href="{PUBLIC_APPWRITE_DASHBOARD}/console?type=createScale"
                                                 class="web-button is-secondary is-full-width mt-8"
-                                                disabled
                                             >
                                                 <span class="text-sub-body font-medium"
-                                                    >Coming soon</span
+                                                    >Start now</span
                                                 >
-                                            </button>
+                                            </a>
                                         </header>
                                         <div class="web-pricing-cards-content">
                                             <p>Everything in Pro, plus:</p>

--- a/src/routes/pricing/compare-plans.svelte
+++ b/src/routes/pricing/compare-plans.svelte
@@ -8,6 +8,7 @@
     import { writable } from 'svelte/store';
     import { fly } from 'svelte/transition';
     import { Tooltip } from '$lib/components';
+    import { PUBLIC_APPWRITE_DASHBOARD } from '$env/static/public';
 
     type Table = {
         title: string;
@@ -479,7 +480,7 @@
                             <div class="flex items-center justify-between gap-8">
                                 <h4 class="text-label text-primary">Free</h4>
                                 <a
-                                    href="https://cloud.appwrite.io/register"
+                                    href="{PUBLIC_APPWRITE_DASHBOARD}/register"
                                     class="web-button is-secondary"
                                 >
                                     <span class="text-sub-body font-medium">Start building</span>
@@ -491,7 +492,7 @@
                                 <h4 class="text-label text-primary">Pro</h4>
                                 <a
                                     class="web-button"
-                                    href="https://cloud.appwrite.io/console?type=createPro"
+                                    href="{PUBLIC_APPWRITE_DASHBOARD}/console?type=createPro"
                                     target="_blank"
                                     rel="noopener noreferrer"
                                 >
@@ -504,7 +505,7 @@
                                 <h4 class="text-label text-primary">Scale</h4>
                                 <a
                                     class="web-button is-secondary"
-                                    href="https://cloud.appwrite.io/console?type=createScale"
+                                    href="{PUBLIC_APPWRITE_DASHBOARD}/console?type=createScale"
                                     target="_blank"
                                     rel="noopener noreferrer"
                                 >


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

The scale button says "Coming soon":

<img width="1351" alt="image" src="https://github.com/user-attachments/assets/eb01360b-0367-4b82-9adc-066bc284695c">

but then says "Start now" down below

<img width="1244" alt="image" src="https://github.com/user-attachments/assets/2132bd00-9761-43ae-8d78-46c7ca35e6df">

This PR updates the button at the top to also say "Start now".

## Test Plan

Manually tested:

<img width="1335" alt="image" src="https://github.com/user-attachments/assets/8b0ecafb-aafc-425b-a641-004038fe7d42">

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes