### PR TITLE
Disable scale plan button as the plan is not available yet

### DIFF
--- a/src/routes/pricing/compare-plans.svelte
+++ b/src/routes/pricing/compare-plans.svelte
@@ -502,14 +502,9 @@
                         <div class="web-mini-card">
                             <div class="flex items-center justify-between gap-8">
                                 <h4 class="text-label text-primary">Scale</h4>
-                                <a
-                                    class="web-button is-secondary"
-                                    href="https://cloud.appwrite.io/console?type=createScale"
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                >
-                                    <span class="text-sub-body font-medium">Start now</span>
-                                </a>
+                                <button class="web-button is-secondary" disabled>
+                                    <span class="text-sub-body font-medium">Coming soon</span>
+                                </button>
                             </div>
                         </div>
                         <div class="web-mini-card">


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Updates the pricing page to disable the Scale plan button since it's not available yet.

## Test Plan

Before:

![image](https://github.com/user-attachments/assets/aa477548-e797-4bc4-a9c4-cd3cfba4e4f4)

After:

<img width="1204" alt="image" src="https://github.com/user-attachments/assets/540467ca-1cb7-496d-94cb-8b3ef420e6e3">

## Related PRs and Issues

PR to enable the buttons once Scale plan is available:

* https://github.com/appwrite/website/pull/1361

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes