### PR TITLE
Fix CLI command param to be kebab case

### DIFF
--- a/src/routes/blog/post/introducing-new-appwrite-cli/+page.markdoc
+++ b/src/routes/blog/post/introducing-new-appwrite-cli/+page.markdoc
@@ -122,7 +122,7 @@ You can add the `--force` flag to any command that may ask you questions, such a
 Till this generation, Appwrite CLI supported non-interactive login for API-key-based authorization only, as follows:
 
 ```bash
-appwrite client --projectId PROJECT_ID --key APY_KEY
+appwrite client --project-id PROJECT_ID --key APY_KEY
 ```
 
 In this version, we've added a headless login, which allows users to log in and execute commands from the user level.


### PR DESCRIPTION

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

We changed the parameters to be kebab case rather than camel case so the blog should be updated to reflect that.

## Test Plan

Local test:

<img width="795" alt="image" src="https://github.com/user-attachments/assets/4a299784-343b-4a7f-8a53-726b0328d31f">

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes