### PR TITLE
Add CCPA link to navigation

### DIFF
--- a/src/routes/docs/advanced/security/+layout.svelte
+++ b/src/routes/docs/advanced/security/+layout.svelte
@@ -25,6 +25,10 @@
                     href: '/docs/advanced/security/gdpr'
                 },
                 {
+                    label: 'PCI',
+                    href: '/docs/advanced/security/pci'
+                },
+                {
                     label: 'SOC 2',
                     href: '/docs/advanced/security/soc2'
                 },
@@ -33,8 +37,8 @@
                     href: '/docs/advanced/security/hipaa'
                 },
                 {
-                    label: 'PCI',
-                    href: '/docs/advanced/security/pci'
+                    label: 'CCPA',
+                    href: '/docs/advanced/security/ccpa'
                 }
             ]
         },


### PR DESCRIPTION
This PR adds the CCPA link to the security sidebar in the docs

To test, run the website or open the preview link below and navigate to `/docs/advanced/security/gdpr`
- On the left sidebar, under **compliances**, you should see the **CCPA** link. Click on it and confirm that it navigates to the CCPA page.