### PR TITLE
Add url param and explanation to magic url doc

### DIFF
--- a/src/routes/docs/products/auth/magic-url/+page.markdoc
+++ b/src/routes/docs/products/auth/magic-url/+page.markdoc
@@ -47,7 +47,6 @@ mutation {
 
 The `url` parameter specifies where users will be redirected after clicking the magic link.
 The secret and userId will be automatically appended as query parameters to this URL.
-If you're building a mobile app, you can leave the URL parameter empty to use your Appwrite instance's default handling.
 
 # Login {% #login %}
 

--- a/src/routes/docs/products/auth/magic-url/+page.markdoc
+++ b/src/routes/docs/products/auth/magic-url/+page.markdoc
@@ -20,14 +20,19 @@ const client = new Client()
 
 const account = new Account(client);
 
-const token = await account.createMagicURLToken(ID.unique(), 'email@example.com');
+const token = await account.createMagicURLToken(
+    ID.unique(),
+    'email@example.com',
+    'https://example.com/verify'
+);
 ```
 
 ```graphql
 mutation {
     accountCreateMagicURLToken(
         userId: "ID.unique()",
-        email: "email@example.com"
+        email: "email@example.com",
+        url: "https://example.com/verify"
     ) {
         _id
         _createdAt
@@ -40,9 +45,13 @@ mutation {
 
 {% /multicode %}
 
+The `url` parameter specifies where users will be redirected after clicking the magic link.
+The secret and userId will be automatically appended as query parameters to this URL.
+If you're building a mobile app, you can leave the URL parameter empty to use your Appwrite instance's default handling.
+
 # Login {% #login %}
 
-After receiving your secret from an email, you can create a session.
+After the user clicks the magic link in their email, they will be redirected to your specified URL with the secret and userId as query parameters. Use these parameters to create a session.
 
 {% multicode %}
 


### PR DESCRIPTION
## What does this PR do?

- Adds missing URL param with explanation to doc

## Test Plan

- Run the app and navigate to `/docs/products/auth/magic-url`
- Confirm that new information is accurate and displayed correctly