### PR TITLE
Update dynamic api keys docs

### DIFF
--- a/src/routes/docs/products/functions/develop/+page.markdoc
+++ b/src/routes/docs/products/functions/develop/+page.markdoc
@@ -1552,6 +1552,8 @@ However, you can only use dynamic API keys inside Appwrite functions.
 
 During the build process, dynamic API keys are automatically provided as the environment variable `APPWRITE_FUNCTION_API_KEY`. This environment variable doesn't need to be initialized.
 
+During execution, dynamic API keys are automatically provided in the `x-appwrite-key` [header](#headers).
+
 Dynamic API keys grant access and operate without sessions.
 They allow your function to act as an admin-type role instead of acting on behalf of a user.
 Update the function settings to configure the scopes of the function.


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

If someone were to jump to the [dynamic API key docs](https://appwrite.io/docs/products/functions/develop#dynamic-api-key) and read it quickly, they would only see the `APPWRITE_FUNCTION_API_KEY` env variable mentioned and might miss the `x-appwrite-key` header mentioned in the code snippet.

This PR clarifies that the dynamic API key is in the header for executions.

## Test Plan

Manual

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes