### PR TITLE
Update +page.markdoc

### DIFF
--- a/src/routes/docs/quick-starts/sveltekit/+page.markdoc
+++ b/src/routes/docs/quick-starts/sveltekit/+page.markdoc
@@ -35,7 +35,7 @@ You can skip optional steps.
 Create a SvelteKit project.
 
 ```sh
-npm create svelte@latest my-app && cd my-app && npm install
+npx sv create
 ```
 {% /section %}
 {% section #step-3 step=3 title="Install Appwrite" %}


### PR DESCRIPTION
Issue: 'npm create svelte' has been replaced with 'npx sv create'

Replaced old script with new, updated script. This will prevent users following your instructions from running into this error now and in the future.

## What does this PR do?

Updates the SvleteKit walkthrough documentation to fix an issue with the walkthrough that will be a roadblock to every user currently trying to follow the existing instructions.

## Test Plan

No test plan required. You can try `npm create svelte` on your own to see the issue.

## Related PRs and Issues

No issue was created. This seemed like a quick, simple fix that didn't require one.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Sure.