### PR TITLE
Fix table cell min width

### DIFF
--- a/src/markdoc/nodes/Th.svelte
+++ b/src/markdoc/nodes/Th.svelte
@@ -9,7 +9,7 @@
     style:width={width ? `${width}px` : undefined}
     style:min-inline-size={width ? 'unset' : undefined}
     role="columnheader"
-    class="py-[0.5625rem] px-3"
+    class="min-w-44 py-[0.5625rem] px-3"
     {align}
 >
     <span class="text-sm leading-[1.375rem] text-[hsl(var(--web-color-primary))]">


### PR DESCRIPTION
After removing class in previous PR the min-width value disappeared, this is fixed now.

Before:
<img width="693" alt="image" src="https://github.com/user-attachments/assets/4dfea3e7-be19-4e87-8fb6-9d8c436c2ccb">

After:
<img width="686" alt="image" src="https://github.com/user-attachments/assets/833e8341-8fe9-4dbe-9df4-ae0d659bcdf0">


### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
✅