### PR TITLE
fix: remove bottom padding from blog post layout

### DIFF
--- a/src/markdoc/layouts/Post.svelte
+++ b/src/markdoc/layouts/Post.svelte
@@ -236,7 +236,7 @@
         </div>
     </div>
 
-    <div class="web-u-sep-block-start py-10">
+    <div class="web-u-sep-block-start pt-10">
         <div class="web-big-padding-section-level-2">
             <div class="container">
                 <h3 class="text-label text-primary">Read next</h3>


### PR DESCRIPTION
## What does this PR do?

- changes `py-10` to `pt-10` to remove bottom padding

## Test Plan

<img width="1301" alt="Bildschirmfoto 2024-11-12 um 17 08 12" src="https://github.com/user-attachments/assets/5e7e65e9-f24e-4e25-aa2c-033d8626c6d7">

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅ 