### PR TITLE
fix: added await in session call in nextjs-ssr-auth tutorial (step3)

### DIFF
--- a/src/routes/docs/tutorials/nextjs-ssr-auth/step-3/+page.markdoc
+++ b/src/routes/docs/tutorials/nextjs-ssr-auth/step-3/+page.markdoc
@@ -20,7 +20,7 @@ export async function createSessionClient() {
     .setEndpoint(process.env.NEXT_PUBLIC_APPWRITE_ENDPOINT)
     .setProject(process.env.NEXT_PUBLIC_APPWRITE_PROJECT);
 
-  const session = cookies().get("my-custom-session");
+  const session = await cookies().get("my-custom-session");
   if (!session || !session.value) {
     throw new Error("No session");
   }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Added missing await while fetching the session via `cookies().get("my-custom-session")` in `nextjs-ssr-auth` tutorial, step 3.

## Test Plan

Documentation is now correct for this.

## Related PRs and Issues

#1365 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.