### PR TITLE
adjust blog cta margins

### DIFF
--- a/src/lib/components/BlogCta.svelte
+++ b/src/lib/components/BlogCta.svelte
@@ -4,27 +4,17 @@
     export let label: string = 'Get started';
 </script>
 
-<div class="call-to-action">
-    <div class="details">
+<div
+    class="bg relative mt-12 !-mb-28 flex min-h-[12rem] items-center justify-center overflow-hidden border-t border-[hsl(var(--web-color-subtle))] py-12 lg:!-mb-[184px]"
+>
+    <div class="flex max-w-3xs flex-col items-center justify-center gap-5 text-center">
         <h2 class="text-label">{heading}</h2>
         <a href={url} class="web-button">{label}</a>
     </div>
 </div>
 
 <style lang="scss">
-    .call-to-action {
-        border-top: 1px solid hsl(var(--web-color-subtle));
-        padding: 48px 0;
-        min-height: 180px;
-        margin-top: 48px;
-        display: flex;
-        margin-bottom: -184px;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        position: relative;
-        overflow: hidden;
-
+    .bg {
         &::before {
             content: '';
             position: absolute;
@@ -36,22 +26,6 @@
                 rgba(253, 54, 110, 0.09),
                 transparent 85%
             );
-            //filter: blur(10px);
-        }
-
-        .details {
-            gap: 20px;
-            max-width: 250px;
-            color: #fff;
-            text-align: center;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            justify-content: center;
-
-            h2 {
-                margin: 0;
-            }
         }
     }
 </style>

--- a/src/lib/components/BlogCta.svelte
+++ b/src/lib/components/BlogCta.svelte
@@ -18,7 +18,7 @@
         min-height: 180px;
         margin-top: 48px;
         display: flex;
-        margin-bottom: -24px;
+        margin-bottom: -184px;
         flex-direction: column;
         align-items: center;
         justify-content: center;

--- a/src/markdoc/tags/Call_To_Action.svelte
+++ b/src/markdoc/tags/Call_To_Action.svelte
@@ -5,12 +5,6 @@
     export let url: string = PUBLIC_APPWRITE_DASHBOARD;
 </script>
 
-<div class="call-to-action">
+<div class="py-12">
     <a href={url} class="web-button">{label}</a>
 </div>
-
-<style lang="scss">
-    .call-to-action {
-        margin: 48px 0;
-    }
-</style>

--- a/src/routes/blog/post/case-study-kcollect/+page.markdoc
+++ b/src/routes/blog/post/case-study-kcollect/+page.markdoc
@@ -7,7 +7,6 @@ cover: /images/blog/kcollect.png
 timeToRead: 5
 author: aditya-oberai
 category: case-studies
-callToAction: true
 ---
 
 In 2019, Ryan O’Connor was a mere university student when he started exploring the world of Korean popular music, or K-pop. One of the areas within the K-pop fan ecosystem that caught his interest was the concept of photo cards. For those new to the K-pop community, K-pop photo cards are artist-specific collectible cards that are possessed and traded similarly to sports or Pokemon trading cards. These photo cards are produced and distributed by K-pop record labels and have developed a substantial interest and following over the last few years. 

--- a/src/routes/blog/post/case-study-kcollect/+page.markdoc
+++ b/src/routes/blog/post/case-study-kcollect/+page.markdoc
@@ -7,6 +7,7 @@ cover: /images/blog/kcollect.png
 timeToRead: 5
 author: aditya-oberai
 category: case-studies
+callToAction: true
 ---
 
 In 2019, Ryan O’Connor was a mere university student when he started exploring the world of Korean popular music, or K-pop. One of the areas within the K-pop fan ecosystem that caught his interest was the concept of photo cards. For those new to the K-pop community, K-pop photo cards are artist-specific collectible cards that are possessed and traded similarly to sports or Pokemon trading cards. These photo cards are produced and distributed by K-pop record labels and have developed a substantial interest and following over the last few years. 

--- a/src/routes/blog/post/defying-the-laws-of-web-animations/+page.markdoc
+++ b/src/routes/blog/post/defying-the-laws-of-web-animations/+page.markdoc
@@ -7,6 +7,7 @@ cover: /images/blog/defying-the-laws-of-web-animations/cover.png
 timeToRead: 10
 author: thomas-g-lopes
 category: website
+callToAction: true
 ---
 
 If you're a frontend developer, you know that one of the scariest tasks you can receive is coding a complex web animation. If you're not a frontend developer, I bet that sounds even harder.

--- a/src/routes/blog/post/defying-the-laws-of-web-animations/+page.markdoc
+++ b/src/routes/blog/post/defying-the-laws-of-web-animations/+page.markdoc
@@ -173,8 +173,6 @@ The video above showcases both Motion and Svelte transitions in action. The tabl
 {/if}
 ```
 
-{% call_to_action /%}
-
 ## Transitioning between sections
 
 There's one other nifty feature of Motion that I didn't mention: It can seamlessly interrupt ongoing animations.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Adjusts the margins on blog call to action sections.

<img width="1512" alt="Screenshot 2024-11-25 at 3 55 06 PM" src="https://github.com/user-attachments/assets/619a7c08-2440-4928-aa7b-52f3dc491992">


## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)