### PR TITLE
Implement dofollow backlink support

### DIFF
--- a/src/markdoc/nodes/Link.svelte
+++ b/src/markdoc/nodes/Link.svelte
@@ -6,7 +6,13 @@
 
     const isExternal = ['http://', 'https://'].some((prefix) => href.startsWith(prefix));
     const target = isExternal ? '_blank' : undefined;
-    const rel = isExternal ? 'noopener nofollow' : undefined;
+
+    const doFollow = href.includes('?dofollow=true') || href.includes('&dofollow=true');
+    if (doFollow) {
+        href = href.replace(/[?&]dofollow=true/g, '').replace(/[?&]$/, '');
+    }
+
+    const rel = isExternal ? `noopener${doFollow ? '' : ' nofollow'}` : undefined;
 
     const inChangelog = isInChangelog();
 

--- a/src/routes/blog/post/startups-ideas-for-developers-2024/+page.markdoc
+++ b/src/routes/blog/post/startups-ideas-for-developers-2024/+page.markdoc
@@ -47,8 +47,8 @@ Focus on areas where you have expertise and passion. Building a business around 
 ## Explore market trends
 
 Keeping an eye on market trends can help you identify emerging opportunities.
-You will see countless reasons why tools like [AI video editors](https://www.veed.io/tools/ai-video/ai-video-editor) are emerging in the market and why these products keep on adding advanced features,
-such as [screen recorders](https://www.veed.io/tools/screen-recorder), subtitle generators, music visualizers, voice dubbers and translators, teleprompters, and [AI avatar](https://www.veed.io/tools/ai-avatar) generator to their library.
+You will see countless reasons why tools like [AI video editors](https://www.veed.io/tools/ai-video/ai-video-editor?dofollow=true) are emerging in the market and why these products keep on adding advanced features,
+such as [screen recorders](https://www.veed.io/tools/screen-recorder?dofollow=true  ), subtitle generators, music visualizers, voice dubbers and translators, teleprompters, and [AI avatar](https://www.veed.io/tools/ai-avatar?dofollow=true) generator to their library.
 
 Use tools like Google Trends, industry reports, and social media to track what's gaining popularity. By tapping into a growing trend, you can position yourself ahead of the competition.
 


### PR DESCRIPTION
## What does this PR do?

Adds support for selective dofollow backlinks while maintaining secure defaults for external links.

Changes:
- Modified Link component to support dofollow parameter
- Maintains noopener security attribute
- Cleans up URL parameters after processing
- Keeps nofollow as default for external links

This enables proper backlink implementation for partnership content (e.g., veed.io collaboration) in the updated `+page.markdoc` file in this PR

## Test plan
- [ ] Verify external links default to nofollow
- [ ] Verify `?dofollow=true` removes nofollow
- [ ] Verify `noopener` is maintained
- [ ] Verify URL parameters are cleaned up