### PR TITLE
Update +page.markdoc due to mistake in the"docker compose" command name

### DIFF
--- a/src/routes/docs/advanced/self-hosting/update/+page.markdoc
+++ b/src/routes/docs/advanced/self-hosting/update/+page.markdoc
@@ -77,7 +77,7 @@ We can now start the migration. Navigate to the `appwrite` directory where your 
 
 ```sh
 cd appwrite/
-docker compose exec appwrite migrate
+docker-compose exec appwrite migrate
 ```
 
 The data migration can take longer depending on the amount of data your Appwrite instance contains. The Appwrite migration command uses multi-threading to speed up the process, meaning that adding more CPU cores can help speed up the process.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

There is a typo in the name of the "docker compose" command. The correct way to call the command is "docker-compose exec appwrite migrate" instead of "docker compose exec appwrite migrate".

## Test Plan

No testing required, just some editing of the documentation text.

## Related PRs and Issues

No related PRs or issues

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes