### PR TITLE
Fix grammatical error in API key generation instruction

### DIFF
--- a/src/routes/docs/products/auth/server-side-rendering/+page.markdoc
+++ b/src/routes/docs/products/auth/server-side-rendering/+page.markdoc
@@ -46,7 +46,7 @@ Admin clients should only be used if you need to perform admin actions that bypa
 or [unauthenticated requests that bypass rate limits](#rate-limits).
 {% /info %}
 
-To initialize the admin client, we'll need to first [generated an API key](/docs/advanced/platform/api-keys#create-api-key).
+To initialize the admin client, we'll need to first [generate an API key](/docs/advanced/platform/api-keys#create-api-key).
 The API key should have the following scope in order to perform authentication:
 
 | Category  {% width=120 %} | Required scopes    | Purpose |


### PR DESCRIPTION
Corrected the verb tense in the sentence: 'we'll need to first generated an API key.' The word 'generated' has been changed to 'generate' to maintain proper grammar with the infinitive form ('to generate').
