### PR TITLE
fixed syntax in line 14 of code in heading Schedule emails

### DIFF
--- a/src/routes/docs/products/messaging/send-email-messages/+page.markdoc
+++ b/src/routes/docs/products/messaging/send-email-messages/+page.markdoc
@@ -808,7 +808,7 @@ client
     .setKey('919c2d18fb5d4...a2ae413da83346ad2') // Your secret API key
 ;
 
-const message - await messaging.createEmail(
+const message = await messaging.createEmail(
         '[MESSAGE_ID]',            // messageId
         '[SUBJECT]',               // subject
         '[CONTENT]',               // content


### PR DESCRIPTION
While going through the documentation on below link https://appwrite.io/docs/products/messaging/send-email-messages  I noticed that for the last heading "Schedule emails" , the Node.js code snippet had "const message - await messaging.createEmail" while the correct syntax is "const message = await messaging.createEmail"

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)