### PR TITLE
add missing icons to providers page

### DIFF
--- a/src/routes/docs/products/messaging/providers/+page.markdoc
+++ b/src/routes/docs/products/messaging/providers/+page.markdoc
@@ -13,17 +13,17 @@ of events or updates. Configure one of the following providers to send push noti
 {% cards_item href="/docs/products/messaging/apns" title="APNS" icon="icon-apple" %}
 Send push notifications to apps on Apple devices through Apple Push Notification service (APNs).
 {% /cards_item %}
-{% cards_item href="/docs/products/messaging/fcm" title="FCM" icon="icon-firebase" %}
+{% cards_item href="/docs/products/messaging/fcm" title="FCM" icon="web-icon-firebase" %}
 Send push notifications to Android, Apple, or Web app with Firebase Cloud Messaging (FCM).
 {% /cards_item %}
 {% /cards %}
 # Email {% #email %}
 Deliver customized emails to users to send reminders, updates, promotions, and custom authentication logic.
 {% cards %}
-{% cards_item href="/docs/products/messaging/mailgun" title="Mailgun" icon="icon-mailgun" %}
+{% cards_item href="/docs/products/messaging/mailgun" title="Mailgun" icon="web-icon-mailgun" %}
 Deliver custom email messages to users using Mailgun.
 {% /cards_item %}
-{% cards_item href="/docs/products/messaging/sendgrid" title="SendGrid" icon="icon-sendgrid" %}
+{% cards_item href="/docs/products/messaging/sendgrid" title="SendGrid" icon="web-icon-sendgrid" %}
 Deliver custom email messages to users using SendGrid.
 {% /cards_item %}
 {% /cards %}


### PR DESCRIPTION
specific icons require the use of the prefix web-, which explains some of the icons missing

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Page: https://appwrite.io/docs/products/messaging/providers

Icons missing for FCM, Mailgun, and SendGrid.

I updated it with the proper icon class name  using the missing web- prefix.

<img width="505" alt="image" src="https://github.com/user-attachments/assets/87de423d-1b70-4d15-82e0-981ab346b4eb" />


## Test Plan

Verified using chrome developer tools and also studying the codebase , see here:

<img width="532" alt="image" src="https://github.com/user-attachments/assets/c90c0a9e-d7a8-4029-b130-f3765cac9956" />


## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)