### PR TITLE
Fix: Posthog dual feature flag hits

### DIFF
--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -6,9 +6,11 @@ export const load = async ({ data }) => {
     if (browser) {
         posthog.init(PUBLIC_POSTHOG_API_KEY, {
             api_host: 'https://eu.i.posthog.com',
-            persistence: 'memory'
+            persistence: 'memory',
+            bootstrap: {
+                distinctID: data.distinctId
+            }
         });
-        posthog.identify(data.distinctId);
     }
 
     return data;


### PR DESCRIPTION
## What does this PR do?

This PR addresses an issue where `posthog.identify(data.distinctId);` causes duplicate requests to be fired—one for an anonymous user and another for the identified user.

Refer similar issue: https://github.com/PostHog/posthog-js/issues/720

I was able to verify dual callback hits with -
```js
posthog.identify(data.distinctId);
posthog.onFeatureFlags((flags, variants) => {
    console.log(JSON.stringify({
        flags: flags,
        variants: variants,
    }, null, 2));
});
```

## Test Plan

Verified manually.

https://github.com/user-attachments/assets/95195636-0ce5-4cce-b6d6-d70be2178388

## Related PRs and Issues

N/A.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.