### PR TITLE
Add link to phone OTP rates page from otp pricing update

### DIFF
--- a/src/routes/blog/post/announcing-phone-OTP-pricing/+page.markdoc
+++ b/src/routes/blog/post/announcing-phone-OTP-pricing/+page.markdoc
@@ -23,7 +23,7 @@ It's been incredibly rewarding to see teams successfully implement phone OTP log
 
 As Appwrite continues to grow, we need to ensure that the platform remains sustainable and that we can provide the best possible service to all our users. Starting February 10th, we will begin charging for phone OTP login attempts. This change will help cover the costs associated with providing this valuable service and allow us to keep improving and expanding the platform.
 
-Please refer to our rates page for a breakdown of the new pricing, including rates by region and specific SMS costs.
+Please refer to our [rates page](/docs/advanced/platform/phone-otp#rates) for a breakdown of the new pricing, including rates by region and specific SMS costs.
 
 To help prepare for these changes, each team can visit their organization's usage page or the usage section of a specific project to review their current phone OTP usage. This will help you better understand your usage patterns and plan accordingly.
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Add a link to the rates from the blog post.

## Test Plan

Manually tested: 

<img width="1435" alt="image" src="https://github.com/user-attachments/assets/5d615c6c-7288-4767-b0a4-b5027a79c5c1" />


## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes