### PR TITLE
Fix weird scrollbars shown on mac systems due to system settings

### DIFF
--- a/src/lib/components/MultiCodeContextless.svelte
+++ b/src/lib/components/MultiCodeContextless.svelte
@@ -86,10 +86,17 @@
         </div>
     </header>
     <div
-        class="web-code-snippet-content"
+        class="web-code-snippet-content overflow-auto"
         style={`height: ${height ? height / 16 + 'rem' : 'inherit'}`}
     >
         <!-- eslint-disable-next-line svelte/no-at-html-tags -->
         {@html result}
     </div>
 </section>
+
+<style>
+    /* system breaks the corners */
+    .overflow-auto::-webkit-scrollbar {
+        display: none;
+    }
+</style>

--- a/src/routes/products/storage/(components)/multicode-tabs/Tabs.svelte
+++ b/src/routes/products/storage/(components)/multicode-tabs/Tabs.svelte
@@ -27,7 +27,7 @@
 </script>
 
 <div {...$root} use:root>
-    <div class="flex gap-4 overflow-scroll">
+    <div class="flex gap-4 overflow-auto">
         <ul class="flex items-center gap-2" {...$list} use:list>
             {#each $ctx.triggers.entries() as [id, title]}
                 <li


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixes a scrollbar issue where if the mac systems have Show scrollbars set to Active, it would show wide black rectangles. This PR tries to address that.

## Test Plan

Manual.

Before -

![image](https://github.com/user-attachments/assets/37c62c26-20ed-40ef-93d6-c77d024af5a0)

After -

![image](https://github.com/user-attachments/assets/5f447be3-94cb-4309-8e32-29c2191711c3)

## Related PRs and Issues

N/A.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.