### PR TITLE
Add default CTA to blogs when field is missing in frontmatter

### DIFF
--- a/src/markdoc/layouts/Post.svelte
+++ b/src/markdoc/layouts/Post.svelte
@@ -35,9 +35,7 @@
     const categories = getValidCategories();
     const posts = getContext<PostsData[]>('posts');
 
-    if (callToAction === undefined) {
-        callToAction = true;
-    }
+    callToAction ??= true;
 
     function getValidCategories() {
         if (!category) return undefined;

--- a/src/markdoc/layouts/Post.svelte
+++ b/src/markdoc/layouts/Post.svelte
@@ -35,6 +35,10 @@
     const categories = getValidCategories();
     const posts = getContext<PostsData[]>('posts');
 
+    if (callToAction === undefined) {
+        callToAction = true;
+    }
+
     function getValidCategories() {
         if (!category) return undefined;
         const cats = category.split(',');


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Ensures that the default CTA loads for blogs if the `callToAction` field is missing in the Markdoc page's frontmatter

## Test Plan

- `pnpm i && pnpm run dev`
- Visit `/blog/post/hooks-appwrite-databases`

### Before

![image](https://github.com/user-attachments/assets/5f8ed888-f82d-401c-bcd7-d76bf693c0ff)

### After

![image](https://github.com/user-attachments/assets/8a9c07aa-3817-4c75-ae32-b5c4296e2cb6)

## Related PRs and Issues

N/A

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes