### PR TITLE
Fix: Entire file content being used for SEO descriptions

### DIFF
--- a/src/routes/docs/references/[version]/[platform]/[service]/+page.svelte
+++ b/src/routes/docs/references/[version]/[platform]/[service]/+page.svelte
@@ -70,13 +70,13 @@
         preferredPlatform.set($page.params.platform as Platform);
     });
 
-    // clean, markdown-less service description.
+    // cleaned service description without Markdown links.
     $: serviceDescription = (data.service?.description ?? '').replace(
         /\[([^\]]+)]\([^)]+\)/g,
         '$1'
     );
 
-    // the service description until the first full-stop which has enough info.
+    // the service description up to the first full stop, providing sufficient information.
     $: shortenedDescription = serviceDescription.substring(0, serviceDescription.indexOf('.') + 1);
 
     $: platform = $page.params.platform as Platform;

--- a/src/routes/docs/references/[version]/[platform]/[service]/+page.svelte
+++ b/src/routes/docs/references/[version]/[platform]/[service]/+page.svelte
@@ -70,11 +70,20 @@
         preferredPlatform.set($page.params.platform as Platform);
     });
 
+    // clean, markdown-less service description.
+    $: serviceDescription = (data.service?.description ?? '').replace(
+        /\[([^\]]+)]\([^)]+\)/g,
+        '$1'
+    );
+
+    // the service description until the first full-stop which has enough info.
+    $: shortenedDescription = serviceDescription.substring(0, serviceDescription.indexOf('.') + 1);
+
     $: platform = $page.params.platform as Platform;
     $: platformType = platform.startsWith('client-') ? 'CLIENT' : 'SERVER';
     $: serviceName = serviceMap[data.service?.name];
     $: title = serviceName + API_REFERENCE_TITLE_SUFFIX;
-    $: description = data.service?.description;
+    $: description = shortenedDescription;
     $: ogImage = DEFAULT_HOST + '/images/open-graph/docs.png';
 </script>
 

--- a/src/routes/docs/references/[version]/[platform]/[service]/descriptions/teams.md
+++ b/src/routes/docs/references/[version]/[platform]/[service]/descriptions/teams.md
@@ -1,3 +1,3 @@
-The Teams service allows you to group users of your project and to enable them to share [read and write](/docs/advanced/platform/permissions) access to your project resources, such as database documents or storage files.
+The Teams service allows you to group users of your project and share [read and write](/docs/advanced/platform/permissions) access to resources like database documents or storage files.
 
 Each user who creates a team becomes the team owner and can delegate the ownership role by inviting a new team member. Only team owners can invite new users to their team.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Trims the service description till the first full-stop to use it for a service's SEO description.

## Test Plan

Manual.

## Related PRs and Issues

N/A.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.