### PR TITLE
Fix missing Deployments category in Integrations page sidebar

### DIFF
--- a/src/routes/integrations/deployments-github/+page.markdoc
+++ b/src/routes/integrations/deployments-github/+page.markdoc
@@ -7,7 +7,7 @@ featured: false
 isPartner: true
 isNew: true
 cover: /images/integrations/deployments-github/cover.png
-category: Deployments
+category: deployments
 product: 
     avatar: '/images/integrations/avatars/github.png'
     vendor: GitHub


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Wrong case in the category slug of the Deployments with GitHub integration was preventing the category from being loaded in the sidebar

This PR fixes the case of the category slug in the integration page to fix this issue

## Test Plan

Tested locally

- Before

![image](https://github.com/user-attachments/assets/e9995a6b-d133-4ca7-92f6-bdb9fc5a7122)

- After

![image](https://github.com/user-attachments/assets/8d3ec93b-9f2d-47b9-a87d-b8251ce8d434)

## Related PRs and Issues

No

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes