### PR TITLE
Fix input file reference in docs, tutorials

### DIFF
--- a/src/routes/docs/products/ai/integrations/elevenlabs/+page.markdoc
+++ b/src/routes/docs/products/ai/integrations/elevenlabs/+page.markdoc
@@ -259,7 +259,7 @@ const storage = new Storage(client);
 const file = await storage.createFile(
   process.env.APPWRITE_BUCKET_ID,
   ID.unique(),
-  InputFile.fromBlob(await response.blob(), "audio.mp3"),
+  InputFile.fromBuffer(await response.blob(), "audio.mp3"),
   [Permission.read(Role.any())],
 );
 ```

--- a/src/routes/docs/products/ai/integrations/lmnt/+page.markdoc
+++ b/src/routes/docs/products/ai/integrations/lmnt/+page.markdoc
@@ -248,7 +248,7 @@ const storage = new Storage(client);
 const file = await storage.createFile(
   process.env.APPWRITE_BUCKET_ID,
   ID.unique(),
-  InputFile.fromBlob(new Blob([response.audio]), "audio.mp3"),
+  InputFile.fromBuffer(new Blob([response.audio]), "audio.mp3"),
   [Permission.read(Role.any())],
 );
 ```

--- a/src/routes/docs/products/ai/tutorials/music-generation/+page.markdoc
+++ b/src/routes/docs/products/ai/tutorials/music-generation/+page.markdoc
@@ -68,7 +68,7 @@ class AppwriteService {
   }
 
   async createFile(bucketId, blob) {
-    const file = await InputFile.fromBlob(blob, 'audio.flac');
+    const file = await InputFile.fromBuffer(blob, 'audio.flac');
     return await this.storage.createFile(bucketId, ID.unique(), file);
   }
 }

--- a/src/routes/docs/products/ai/tutorials/text-to-speech/+page.markdoc
+++ b/src/routes/docs/products/ai/tutorials/text-to-speech/+page.markdoc
@@ -67,7 +67,7 @@ class AppwriteService {
   }
 
   async createFile(bucketId, blob) {
-    const file = await InputFile.fromBlob(blob, 'audio.flac');
+    const file = await InputFile.fromBuffer(blob, 'audio.flac');
     return await this.storage.createFile(bucketId, ID.unique(), file);
   }
 }

--- a/src/routes/docs/products/storage/upload-download/+page.markdoc
+++ b/src/routes/docs/products/storage/upload-download/+page.markdoc
@@ -126,7 +126,7 @@ If you're using an Appwrite SDK, this is handled automatically.
 If you're not using an SDK, you can [learn more about REST API file handling](/docs/apis/rest#files).
 
 # InputFile {% #input-file %}
-Every language and platform handles file inputs differently. This section documents the expected input type of each SDK. Where applicable, Appwrite provides an `InputFile` class to accept multiple file sources, like paths, buffers, streams, or plain text.
+Every language and platform handles file inputs differently. This section documents the expected input type of each SDK. Where applicable, Appwrite provides an `InputFile` class to accept multiple file sources, like paths, buffers, or plain text.
 
 # Client SDKs {% #client-sdks %}
 
@@ -188,8 +188,6 @@ The Appwrite NodeJS SDK expects an `InputFile` class for file inputs.
 | ------------------------------------------ | ------------------------------------------------------------ |
 | `InputFile.fromPath(filePath, filename)`     | Used to upload files from a provided path.                  |
 | `InputFile.fromBuffer(buffer, filename)`     | Used to upload files from a [Buffer](https://nodejs.org/api/buffer.html#buffer) object. |
-| `InputFile.fromBlob(blob, filename)`         | Used to upload files from a [Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob) object. |
-| `InputFile.fromStream(stream, filename, size)` | Used to upload files from a [Readable Stream](https://nodejs.org/api/stream.html#readable-streams) object. |
 | `InputFile.fromPlainText(content, filename)`  | Used to upload files in plain text. Expects a string encoded in UTF-8. |
 {% /tabsitem %}
 {% tabsitem #php title="PHP" %}
@@ -268,7 +266,6 @@ The Appwrite .NET SDK expects an `InputFile` class for file inputs.
 | Method                                     | Description                                                  |
 | ------------------------------------------ | ------------------------------------------------------------ |
 | `InputFile.FromPath(string path)`           | Used to upload files from a provided path.                  |
-| `InputFile.FromStream(Stream stream, string filename, string mimeType)` | Used to upload files from a [Stream](https://learn.microsoft.com/en-us/dotnet/api/system.io.stream?view=net-7.0) object. Specify the file [MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) using the `mimeType` param. |
 | `InputFile.FromBytes(byte[] bytes, string filename, string mimeType)` | Used to upload files from an array of bytes. Specify the file [MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) using the `mimeType` param. |
 {% /tabsitem %}
 {% /tabs %}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixes the legacy mentions of `InputFile.fromStream` and `InputFile.fromBlob` for `node-appwrite` based tutorials/docs.

## Test Plan

N/A.

## Related PRs and Issues

N/A.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.