### PR TITLE
Fix: Platform icon sizes on docs

### DIFF
--- a/src/markdoc/tags/Icon_Image.svelte
+++ b/src/markdoc/tags/Icon_Image.svelte
@@ -19,4 +19,5 @@
     height={sizes[size]}
     style:width={sizes[size]}
     style:vertical-align="middle"
+    style:min-width={sizes[size]}
 />


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixes the icon sizing.

## Test Plan

Manual.

Before -

![platform icons before](https://github.com/user-attachments/assets/d0d179b7-8e57-412d-88e9-98112561b6d7)

After -

![platform icons after](https://github.com/user-attachments/assets/c4825f25-0316-4467-ba01-23cf0fe37a4f)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)