### PR TITLE
Fix windows, mac (It's the opposite)

### DIFF
--- a/src/routes/docs/tooling/appwriter/+page.markdoc
+++ b/src/routes/docs/tooling/appwriter/+page.markdoc
@@ -69,8 +69,8 @@ To connect to a device, short press the `FN + 1/2/3` keys depending on the devic
 |---|---|
 | `FN + Esc` | Hold for 3 seconds to reset to factory defaults |
 | `FN + Win` | Disable/enable Win key |
-| `FN + S`   | Set keyboard to Mac mode |
-| `FN + A`   | Set keyboard to Windows mode |
+| `FN + A`   | Set keyboard to Mac mode |
+| `FN + S`   | Set keyboard to Windows mode |
 | `FN + Backspace` | System power/sleep |
 | `FN + Delete` | Change keyboard backlight effect |
 | `FN + Home` | Change keyboard backlight color |
@@ -82,11 +82,11 @@ To connect to a device, short press the `FN + 1/2/3` keys depending on the devic
 
 ## Windows mode {% #windows-mode %}
 
-To switch to Windows mode, switch the preinstalled macOS keycap with the Windows keycap and use the `FN + A` shortcut to enable Windows mode; this will enable Windows-specific keyboard commands to work, like `Ctrl + C` or `Ctrl + A`.
+To switch to Windows mode, switch the preinstalled macOS keycap with the Windows keycap and use the `FN + S` shortcut to enable Windows mode; this will enable Windows-specific keyboard commands to work, like `Ctrl + C` or `Ctrl + A`.
 
 ## MacOS mode {% #macos-mode %}
 
-To use macOS-specific keyboard commands such as `Command + C` or `Command + A`, keep the preinstalled macOS keycaps in and use the `FN + S` shortcut to enable macOS mode.
+To use macOS-specific keyboard commands such as `Command + C` or `Command + A`, keep the preinstalled macOS keycaps in and use the `FN + A` shortcut to enable macOS mode.
 
 # How to get the Appwriter {% #how-to-get-the-appwriter %}
 


### PR DESCRIPTION
After trying the appwriter, looks like it's the opposite. If you do FN+S, you enable the windows mode since you can use the CMD key as the windows key.