### PR TITLE
Docs: fix broken cloud console links in blog post documentation

### DIFF
--- a/src/routes/blog/post/adding-url-shortener-function/+page.markdoc
+++ b/src/routes/blog/post/adding-url-shortener-function/+page.markdoc
@@ -20,7 +20,7 @@ In this blog, we’ll learn to build a URL shortener using Appwrite Functions te
 You can find the source code on our [templates GitHub repository](https://github.com/appwrite/templates/tree/main/node/url-shortener).
 
 # Setting up the Template
-To get started, you need to navigate to the functions page on the **[Appwrite](https://appwrite.io/cloud)** console. From there, we will select the **Templates** tab, search for and select the **URL Shortener** function template.
+To get started, you need to navigate to the functions page on the **[Appwrite](https://cloud.appwrite.io/)** console. From there, we will select the **Templates** tab, search for and select the **URL Shortener** function template.
 
 ![Function template](/images/blog/adding-url-shortener/functions.png)
 

--- a/src/routes/blog/post/deploy-a-pdf-generation-service-with-appwrite-functions/+page.markdoc
+++ b/src/routes/blog/post/deploy-a-pdf-generation-service-with-appwrite-functions/+page.markdoc
@@ -62,5 +62,5 @@ We’ve covered the basics, and now it’s your time to shine! With a few change
 For more information about Appwrite and Appwrite Functions:
 
 1. **[Appwrite Function Docs](https://appwrite.io/docs/functions)**: These documents provide more information on how to use Appwrite Functions.
-2. **[Appwrite Cloud](https://appwrite.io/cloud)**: Try our cloud service to get started quickly.
+2. **[Appwrite Cloud](https://cloud.appwrite.io/)**: Try our cloud service to get started quickly.
 3. **[Appwrite Discord](https://discord.com/invite/appwrite)**: Connect with other developers and the Appwrite team for discussion, questions, and collaboration.


### PR DESCRIPTION
### **PR Description:**  
This PR updates incorrect links in the blog post documentation to ensure proper redirection.  

#### **Changes Made:**  
- Replaced `https://appwrite.io/cloud` with `https://cloud.appwrite.io/` in the following files:  
  - `src/routes/blog/post/adding-url-shortener-function/+page.markdoc` 
  - `src/routes/blog/post/deploy-a-pdf-generation-service-with-appwrite-functions/+page.markdoc` 


### **Test Plan:**  
- Manually checked the updated links to confirm they redirect correctly.  

### **Related PRs and Issues:**  
- Resolves #1733  

### **Have you read the [[Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?**  
Yes ✅