### PR TITLE
Remove unnecessary margin

### DIFF
--- a/src/markdoc/nodes/Code.svelte
+++ b/src/markdoc/nodes/Code.svelte
@@ -8,9 +8,5 @@
     .web-inline-code {
         font-size: 0.75rem;
         line-height: 1.25rem;
-
-        @media (min-width: 1024px) {
-            margin-left: 0.5rem;
-        }
     }
 </style>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?
![image](https://github.com/user-attachments/assets/974fa754-cb50-4803-b77e-b08d8807b8d4)
There's a weird margin before code blocks that's unnecessary in docs.

![image](https://github.com/user-attachments/assets/2c772446-7681-4a6f-a7fa-6bee37deb740)
I think it's due to this margin, removing it seems to be the right fix here. No idea if this impacts other parts of the website.

## Test Plan

Manually verified changes

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)