### PR TITLE
Docs: Clarify SendGrid SMTP username

### DIFF
--- a/src/routes/docs/advanced/self-hosting/email/+page.markdoc
+++ b/src/routes/docs/advanced/self-hosting/email/+page.markdoc
@@ -40,6 +40,8 @@ _APP_SMTP_PASSWORD=YOUR-SMTP-PASSWORD
 _APP_SYSTEM_EMAIL_ADDRESS=YOUR-SENDER-EMAIL
 ```
 
+When using SendGrid, the SMTP username should be set to the literal string "apikey".
+
 {% partial file="update-variables.md" /%}
 
 # Debugging {% #debugging %}


### PR DESCRIPTION
## What does this PR do?
Add note specifying SendGrid SMTP username should be "apikey"