### PR TITLE
Add link to Identities in OAuth2 login doc

### DIFF
--- a/src/routes/docs/products/auth/identities/+page.markdoc
+++ b/src/routes/docs/products/auth/identities/+page.markdoc
@@ -16,9 +16,9 @@ An identity is another way to refer to a user account. A single user can have mu
 
 Identities are primarily used in the following scenarios:
 
-1. **OAuth2 Authentication**: When users authenticate through any OAuth2 provider
-2. **Account Management**: When users want to link or unlink external provider accounts
-3. **User Profile Consolidation**: When maintaining a single user profile across multiple authentication methods
+1. **OAuth2 authentication**: When users authenticate through any OAuth2 provider
+2. **Account management**: When users want to link or unlink external provider accounts
+3. **User profile consolidation**: When maintaining a single user profile across multiple authentication methods
 
 # Create new identities {% #create-new-identities %}
 

--- a/src/routes/docs/products/auth/oauth2/+page.markdoc
+++ b/src/routes/docs/products/auth/oauth2/+page.markdoc
@@ -8,6 +8,10 @@ OAuth authentication allows users to log in using accounts from other popular se
 
 When using OAuth to authenticate, the authentication request is initiated from the client application. The user is then redirected to an OAuth 2 provider to complete the authentication step, and finally, the user is redirected back to the client application.
 
+{% info title="Identities and OAuth2" %}
+OAuth2 login creates an **identity** in Appwrite, allowing users to connect multiple providers to a single account. Learn more in [Identities](/docs/products/auth/identities).
+{% /info %}
+
 # Configure OAuth 2 login {% #configure %}
 
 Before using OAuth 2 login, you need to enable and configure an OAuth 2 login provider.


### PR DESCRIPTION
## What does this PR do?
Link to Identities doc from the OAuth 2 login doc to improve visibility

## Test Plan
- Visit `/docs/products/auth/oauth2`

<img width="671" alt="Screenshot 2025-03-07 at 21 29 44" src="https://github.com/user-attachments/assets/0a9414a8-39da-4c22-9480-0634a63d6390" />
