### PR TITLE
Await cookies() Before Accessing Session Data

### DIFF
--- a/src/routes/docs/tutorials/nextjs-ssr-auth/step-3/+page.markdoc
+++ b/src/routes/docs/tutorials/nextjs-ssr-auth/step-3/+page.markdoc
@@ -20,7 +20,7 @@ export async function createSessionClient() {
     .setEndpoint(process.env.NEXT_PUBLIC_APPWRITE_ENDPOINT)
     .setProject(process.env.NEXT_PUBLIC_APPWRITE_PROJECT);
 
-  const session = await cookies().get("my-custom-session");
+  const session = (await cookies()).get("my-custom-session");
   if (!session || !session.value) {
     throw new Error("No session");
   }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Updating the code to explicitly wrap await cookies() in parentheses to resolve the Next.js error:

cookies().get('my-custom-session') should be awaited before using its value.

This solved the current error provided:
`cookies().get('my-custom-session')`. `cookies()` should be awaited before using its value. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis

## Test Plan

Changed the code and refreshed my page.tsx component, no error being shown in logs after change.