### PR TITLE
Update queries docs page to have section for each operator

### DIFF
--- a/src/routes/docs/products/databases/queries/+page.markdoc
+++ b/src/routes/docs/products/databases/queries/+page.markdoc
@@ -6,11 +6,11 @@ description: Harness the power of querying with Appwrite Databases. Discover var
 
 Many list endpoints in Appwrite allow you to filter, sort, and paginate results using queries. Appwrite provides a common set of syntax to build queries.
 
-# Query Class {% #query-class %}
+# Query class {% #query-class %}
 
 Appwrite SDKs provide a `Query` class to help you build queries. The `Query` class has methods for each type of supported query operation.
 
-# Building Queries {% #building-queries %}
+# Building queries {% #building-queries %}
 
 Queries are passed to an endpoint through the `queries` parameter as an array of query strings, which can be generated using the `Query` class.
 
@@ -137,7 +137,7 @@ query {
 ```
 {% /multicode %}
 
-# Query Operators {% #query-operators %}
+# Query operators {% #query-operators %}
 
 ## Select {% #select %}
 
@@ -167,7 +167,7 @@ Query.select(["name", "title"])
 ```
 {% /multicode %}
 
-## Comparison Operators {% #comparison %}
+## Comparison operators {% #comparison %}
 
 ### Equal {% #equal %}
 
@@ -197,7 +197,7 @@ Query.equal("title", value: ["Iron Man"])
 ```
 {% /multicode %}
 
-### Not Equal {% #not-equal %}
+### Not equal {% #not-equal %}
 
 Returns document if attribute is not equal to any value in the provided array.
 
@@ -225,7 +225,7 @@ Query.notEqual("title", value: ["Iron Man"])
 ```
 {% /multicode %}
 
-### Less Than {% #less-than %}
+### Less than {% #less-than %}
 
 Returns document if attribute is less than the provided value.
 
@@ -253,7 +253,7 @@ Query.lessThan("score", value: 10)
 ```
 {% /multicode %}
 
-### Less Than or Equal {% #less-than-equal %}
+### Less than or equal {% #less-than-equal %}
 
 Returns document if attribute is less than or equal to the provided value.
 
@@ -281,7 +281,7 @@ Query.lessThanEqual("score", value: 10)
 ```
 {% /multicode %}
 
-### Greater Than {% #greater-than %}
+### Greater than {% #greater-than %}
 
 Returns document if attribute is greater than the provided value.
 
@@ -309,7 +309,7 @@ Query.greaterThan("score", value: 10)
 ```
 {% /multicode %}
 
-### Greater Than or Equal {% #greater-than-equal %}
+### Greater than or equal {% #greater-than-equal %}
 
 Returns document if attribute is greater than or equal to the provided value.
 
@@ -365,9 +365,9 @@ Query.between("price", start: 5, end: 10)
 ```
 {% /multicode %}
 
-## Null Checks {% #null-checks %}
+## Null checks {% #null-checks %}
 
-### Is Null {% #is-null %}
+### Is null {% #is-null %}
 
 Returns documents where attribute value is null.
 
@@ -395,7 +395,7 @@ Query.isNull("name")
 ```
 {% /multicode %}
 
-### Is Not Null {% #is-not-null %}
+### Is not null {% #is-not-null %}
 
 Returns documents where attribute value is **not** null.
 
@@ -423,9 +423,9 @@ Query.isNotNull("name")
 ```
 {% /multicode %}
 
-## String Operations {% #string-operations %}
+## String operations {% #string-operations %}
 
-### Starts With {% #starts-with %}
+### Starts with {% #starts-with %}
 
 Returns documents if a string attribute starts with a substring.
 
@@ -453,7 +453,7 @@ Query.startsWith("name", value: "Once upon a time")
 ```
 {% /multicode %}
 
-### Ends With {% #ends-with %}
+### Ends with {% #ends-with %}
 
 Returns documents if a string attribute ends with a substring.
 
@@ -565,7 +565,7 @@ Query.search("text", value: "key words")
 ```
 {% /multicode %}
 
-## Logical Operators {% #logical-operators %}
+## Logical operators {% #logical-operators %}
 
 ### AND {% #and %}
 
@@ -667,7 +667,7 @@ Query.or([
 
 ## Ordering {% #ordering %}
 
-### Order Descending {% #order-desc %}
+### Order descending {% #order-desc %}
 
 Orders results in descending order by attribute. Attribute must be indexed.
 
@@ -695,7 +695,7 @@ Query.orderDesc("attribute")
 ```
 {% /multicode %}
 
-### Order Ascending {% #order-asc %}
+### Order ascending {% #order-asc %}
 
 Orders results in ascending order by attribute. Attribute must be indexed.
 
@@ -781,7 +781,7 @@ Query.offset(0)
 ```
 {% /multicode %}
 
-### Cursor After {% #cursor-after %}
+### Cursor after {% #cursor-after %}
 
 Places the cursor after the specified resource ID. Used for [pagination](/docs/products/databases/pagination).
 
@@ -809,7 +809,7 @@ Query.cursorAfter("62a7...f620")
 ```
 {% /multicode %}
 
-### Cursor Before {% #cursor-before %}
+### Cursor before {% #cursor-before %}
 
 Places the cursor before the specified resource ID. Used for [pagination](/docs/products/databases/pagination).
 
@@ -837,7 +837,7 @@ Query.cursorBefore("62a7...a600")
 ```
 {% /multicode %}
 
-# Complex Queries {% #complex-queries %}
+# Complex queries {% #complex-queries %}
 
 You can create complex queries by combining AND and OR operations. For example, to find items that are either books under $20 or magazines under $10:
 

--- a/src/routes/docs/products/databases/queries/+page.markdoc
+++ b/src/routes/docs/products/databases/queries/+page.markdoc
@@ -8,289 +8,7 @@ Many list endpoints in Appwrite allow you to filter, sort, and paginate results 
 
 # Query Class {% #query-class %}
 
-Appwrite SDKs provide a `Query` class to help you build queries. The `Query` class has a method for each type of supported query.
-
-{% tabs %}
-{% tabsitem #nodejs title="Node.js" %}
-| Example                 | Description                                                                                                           |
-|------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
-| `Query.select(["name", "title"])`  | Select which attributes should be returned from a document.                                                            |
-| `Query.and([Query.lessThan("size", 10), Query.greaterThan("size", 5)])`  | Returns document if it matches all of the nested sub-queries in the array passed in. |
-| `Query.or([Query.lessThan("size", 5), Query.greaterThan("size", 10)])`  | Returns document if it matches any of the nested sub-queries in the array passed in. |
-| `Query.equal("title", ["Iron Man"])` | Returns document if attribute is equal to any value in the provided array.                                             |
-| `Query.notEqual("title", ["Iron Man"])` | Returns document if attribute is not equal to any value in the provided array.                                        |
-| `Query.lessThan("score", 10)`      | Returns document if attribute is less than the provided value.                                                         |
-| `Query.lessThanEqual("score", 10)` | Returns document if attribute is less than or equal to the provided value.                                             |
-| `Query.greaterThan("score", 10)`   | Returns document if attribute is greater than the provided value.                                                      |
-| `Query.greaterThanEqual("score", 10)` | Returns document if attribute is greater than or equal to the provided value.                                         |
-| `Query.between("price", 5, 10)`    | Returns document if attribute value falls between the two values. The boundary values are inclusive and can be strings or numbers. |
-| `Query.isNull("name")`             | Returns documents where attribute value is null.                                                                      |
-| `Query.isNotNull("name")`          | Returns documents where attribute value is **not** null.                                                              |
-| `Query.startsWith("name", "Once upon a time")` | Returns documents if a string attributes starts with a substring.                                                     |
-| `Query.endsWith("name", "happily ever after.")` | Returns documents if a string attributes ends with a substring.                                                       |
-| `Query.contains("ingredients", ['apple', 'banana'])` | Returns documents if the array attribute contains the specified elements.                                                       |
-| `Query.contains("name", "Tom")` | Returns documents if a string attributes is like the pattern specified.                                                       |
-| `Query.search("text", "key words")` | Searches string attributes for provided keywords. Requires a [full-text index](/docs/products/databases/collections#indexes) on queried attributes. |
-| `Query.orderDesc("attribute")`     | Orders results in descending order by attribute. Attribute must be indexed. Pass in an empty string to return in natural order. |
-| `Query.orderAsc("attribute")`      | Orders results in ascending order by attribute. Attribute must be indexed. Pass in an empty string to return in natural order. |
-| `Query.limit(25)`                  | Limits the number of results returned by the query. Used for [pagination](/docs/products/databases/pagination). If the limit query is not used, the limit defaults to 25 results. |
-| `Query.offset(0)`                  | Offset the results returned by skipping some of the results. Used for [pagination](/docs/products/databases/pagination). |
-| `Query.cursorAfter("62a7...f620")` | Places the cursor after the specified resource ID. Used for [pagination](/docs/products/databases/pagination).         |
-| `Query.cursorBefore("62a7...a600")` | Places the cursor before the specified resource ID. Used for [pagination](/docs/products/databases/pagination).   |
-{% /tabsitem %}
-
-{% tabsitem #php title="PHP" %}
-| Example                 | Description                                                                                                           |
-|------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
-| `Query::select(["name", "title"])`  | Select which attributes should be returned from a document.                                                            |
-| `Query::or([Query::lessThan("size", 5), Query::greaterThan("size", 10)])`  | Returns document if it matches any of the nested sub-queries in the array passed in. |
-| `Query::and([Query::lessThan("size", 10), Query::greaterThan("size", 5)])`  | Returns document if it matches all of the nested sub-queries in the array passed in. |
-| `Query::equal("title", ["Iron Man"])` | Returns document if attribute is equal to any value in the provided array.                                             |
-| `Query::notEqual("title", ["Iron Man"])` | Returns document if attribute is not equal to any value in the provided array.                                        |
-| `Query::lessThan("score", 10)`      | Returns document if attribute is less than the provided value.                                                         |
-| `Query::lessThanEqual("score", 10)` | Returns document if attribute is less than or equal to the provided value.                                             |
-| `Query::greaterThan("score", 10)`   | Returns document if attribute is greater than the provided value.                                                      |
-| `Query::greaterThanEqual("score", 10)` | Returns document if attribute is greater than or equal to the provided value.                                         |
-| `Query::between("price", 5, 10)`    | Returns document if attribute value falls between the two values. The boundary values are inclusive and can be strings or numbers. |
-| `Query::isNull("name")`             | Returns documents where attribute value is null.                                                                      |
-| `Query::isNotNull("name")`          | Returns documents where attribute value is **not** null.                                                              |
-| `Query::startsWith("name", "Once upon a time")` | Returns documents if a string attributes starts with a substring.                                                     |
-| `Query::endsWith("name", "happily ever after.")` | Returns documents if a string attributes ends with a substring.                                                       |
-| `Query::contains("ingredients", ['apple', 'banana'])` | Returns documents if the array attribute contains the specified elements.                                                       |
-| `Query::contains("name", "Tom")` | Returns documents if a string attributes is like the pattern specified.                                                       |
-| `Query::search("text", "key words")` | Searches string attributes for provided keywords. Requires a [full-text index](/docs/products/databases/collections#indexes) on queried attributes. |
-| `Query::orderDesc("attribute")`     | Orders results in descending order by attribute. Attribute must be indexed. Pass in an empty string to return in natural order. |
-| `Query::orderAsc("attribute")`      | Orders results in ascending order by attribute. Attribute must be indexed. Pass in an empty string to return in natural order. |
-| `Query::limit(25)`                  | Limits the number of results returned by the query. Used for [pagination](/docs/products/databases/pagination). If the limit query is not used, the limit defaults to 25 results. |
-| `Query::offset(0)`                  | Offset the results returned by skipping some of the results. Used for [pagination](/docs/products/databases/pagination). |
-| `Query::cursorAfter("62a7...f620")` | Places the cursor after the specified resource ID. Used for [pagination](/docs/products/databases/pagination).         |
-| `Query::cursorBefore("62a7...a600")` | Places the cursor before the specified resource ID. Used for [pagination](/docs/products/databases/pagination).   |
-{% /tabsitem %}
-
-{% tabsitem #python title="Python" %}
-| Example                 | Description                                                                                                           |
-|------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
-| `Query.select(["name", "title"])`  | Select which attributes should be returned from a document.                                                            |
-| `Query.or_queries([Query.less_than("size", 5), Query.greater_than("size", 10)])`  | Returns document if it matches any of the nested sub-queries in the array passed in. |
-| `Query.and_queries([Query.less_than("size", 10), Query.greater_than("size", 5)])`  | Returns document if it matches all of the nested sub-queries in the array passed in. |
-| `Query.equal("title", ["Iron Man"])` | Returns document if attribute is equal to any value in the provided array.                                             |
-| `Query.not_equal("title", ["Iron Man"])` | Returns document if attribute is not equal to any value in the provided array.                                        |
-| `Query.less_than("score", 10)`      | Returns document if attribute is less than the provided value.                                                         |
-| `Query.less_than_equal("score", 10)` | Returns document if attribute is less than or equal to the provided value.                                             |
-| `Query.greater_than("score", 10)`   | Returns document if attribute is greater than the provided value.                                                      |
-| `Query.greater_than_equal("score", 10)` | Returns document if attribute is greater than or equal to the provided value.                                         |
-| `Query.between("price", 5, 10)`    | Returns document if attribute value falls between the two values. The boundary values are inclusive and can be strings or numbers. |
-| `Query.is_null("name")`             | Returns documents where attribute value is null.                                                                      |
-| `Query.is_not_null("name")`          | Returns documents where attribute value is **not** null.                                                              |
-| `Query.starts_with("name", "Once upon a time")` | Returns documents if a string attributes starts with a substring.                                                     |
-| `Query.ends_with("name", "happily ever after.")` | Returns documents if a string attributes ends with a substring.                                                       |
-| `Query.contains("ingredients", ['apple', 'banana'])` | Returns documents if the array attribute contains the specified elements.                                                       |
-| `Query.contains("name", "Tom")` | Returns documents if a string attributes is like the pattern specified.                                                       |
-| `Query.search("text", "key words")` | Searches string attributes for provided keywords. Requires a [full-text index](/docs/products/databases/collections#indexes) on queried attributes. |
-| `Query.order_desc("attribute")`     | Orders results in descending order by attribute. Attribute must be indexed. Pass in an empty string to return in natural order. |
-| `Query.order_asc("attribute")`      | Orders results in ascending order by attribute. Attribute must be indexed. Pass in an empty string to return in natural order. |
-| `Query.limit(25)`                  | Limits the number of results returned by the query. Used for [pagination](/docs/products/databases/pagination). If the limit query is not used, the limit defaults to 25 results. |
-| `Query.offset(0)`                  | Offset the results returned by skipping some of the results. Used for [pagination](/docs/products/databases/pagination). |
-| `Query.cursor_after("62a7...f620")` | Places the cursor after the specified resource ID. Used for [pagination](/docs/products/databases/pagination).         |
-| `Query.cursor_before("62a7...a600")` | Places the cursor before the specified resource ID. Used for [pagination](/docs/products/databases/pagination).   |
-{% /tabsitem %}
-
-{% tabsitem #ruby title="Ruby" %}
-| Example                 | Description                                                                                                           |
-|------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
-| `Query.select(["name", "title"])`  | Select which attributes should be returned from a document.                                                            |
-| `Query.or([Query.less_than("size", 5), Query.greater_than("size", 10)])`  | Returns document if it matches any of the nested sub-queries in the array passed in. |
-| `Query.and([Query.less_than("size", 10), Query.greater_than("size", 5)])`  | Returns document if it matches all of the nested sub-queries in the array passed in. |
-| `Query.equal("title", ["Iron Man"])` | Returns document if attribute is equal to any value in the provided array.                                             |
-| `Query.not_equal("title", ["Iron Man"])` | Returns document if attribute is not equal to any value in the provided array.                                        |
-| `Query.less_than("score", 10)`      | Returns document if attribute is less than the provided value.                                                         |
-| `Query.less_than_equal("score", 10)` | Returns document if attribute is less than or equal to the provided value.                                             |
-| `Query.greater_than("score", 10)`   | Returns document if attribute is greater than the provided value.                                                      |
-| `Query.greater_than_equal("score", 10)` | Returns document if attribute is greater than or equal to the provided value.                                         |
-| `Query.between("price", 5, 10)`    | Returns document if attribute value falls between the two values. The boundary values are inclusive and can be strings or numbers. |
-| `Query.is_null("name")`             | Returns documents where attribute value is null.                                                                      |
-| `Query.is_not_null("name")`          | Returns documents where attribute value is **not** null.                                                              |
-| `Query.starts_with("name", "Once upon a time")` | Returns documents if a string attributes starts with a substring.                                                     |
-| `Query.ends_with("name", "happily ever after.")` | Returns documents if a string attributes ends with a substring.                                                       |
-| `Query.contains("ingredients", ['apple', 'banana'])` | Returns documents if the array attribute contains the specified elements.                                                       |
-| `Query.contains("name", "Tom")` | Returns documents if a string attributes is like the pattern specified.                                                       |
-| `Query.search("text", "key words")` | Searches string attributes for provided keywords. Requires a [full-text index](/docs/products/databases/collections#indexes) on queried attributes. |
-| `Query.order_desc("attribute")`     | Orders results in descending order by attribute. Attribute must be indexed. Pass in an empty string to return in natural order. |
-| `Query.order_asc("attribute")`      | Orders results in ascending order by attribute. Attribute must be indexed. Pass in an empty string to return in natural order. |
-| `Query.limit(25)`                  | Limits the number of results returned by the query. Used for [pagination](/docs/products/databases/pagination). If the limit query is not used, the limit defaults to 25 results. |
-| `Query.offset(0)`                  | Offset the results returned by skipping some of the results. Used for [pagination](/docs/products/databases/pagination). |
-| `Query.cursor_after("62a7...f620")` | Places the cursor after the specified resource ID. Used for [pagination](/docs/products/databases/pagination).         |
-| `Query.cursor_before("62a7...a600")` | Places the cursor before the specified resource ID. Used for [pagination](/docs/products/databases/pagination).   |
-{% /tabsitem %}
-
-{% tabsitem #deno title="Deno" %}
-| Example                 | Description                                                                                                           |
-|------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
-| `Query.select(["name", "title"])`  | Select which attributes should be returned from a document.                                                            |
-| `Query.and([Query.lessThan("size", 10), Query.greaterThan("size", 5)])`  | Returns document if it matches all of the nested sub-queries in the array passed in. |
-| `Query.or([Query.lessThan("size", 5), Query.greaterThan("size", 10)])`  | Returns document if it matches any of the nested sub-queries in the array passed in. |
-| `Query.equal("title", ["Iron Man"])` | Returns document if attribute is equal to any value in the provided array.                                             |
-| `Query.notEqual("title", ["Iron Man"])` | Returns document if attribute is not equal to any value in the provided array.                                        |
-| `Query.lessThan("score", 10)`      | Returns document if attribute is less than the provided value.                                                         |
-| `Query.lessThanEqual("score", 10)` | Returns document if attribute is less than or equal to the provided value.                                             |
-| `Query.greaterThan("score", 10)`   | Returns document if attribute is greater than the provided value.                                                      |
-| `Query.greaterThanEqual("score", 10)` | Returns document if attribute is greater than or equal to the provided value.                                         |
-| `Query.between("price", 5, 10)`    | Returns document if attribute value falls between the two values. The boundary values are inclusive and can be strings or numbers. |
-| `Query.isNull("name")`             | Returns documents where attribute value is null.                                                                      |
-| `Query.isNotNull("name")`          | Returns documents where attribute value is **not** null.                                                              |
-| `Query.startsWith("name", "Once upon a time")` | Returns documents if a string attributes starts with a substring.                                                     |
-| `Query.endsWith("name", "happily ever after.")` | Returns documents if a string attributes ends with a substring.                                                       |
-| `Query.contains("ingredients", ['apple', 'banana'])` | Returns documents if the array attribute contains the specified elements.                                                       |
-| `Query.contains("name", "Tom")` | Returns documents if a string attributes is like the pattern specified.                                                       |
-| `Query.search("text", "key words")` | Searches string attributes for provided keywords. Requires a [full-text index](/docs/products/databases/collections#indexes) on queried attributes. |
-| `Query.orderDesc("attribute")`     | Orders results in descending order by attribute. Attribute must be indexed. Pass in an empty string to return in natural order. |
-| `Query.orderAsc("attribute")`      | Orders results in ascending order by attribute. Attribute must be indexed. Pass in an empty string to return in natural order. |
-| `Query.limit(25)`                  | Limits the number of results returned by the query. Used for [pagination](/docs/products/databases/pagination). If the limit query is not used, the limit defaults to 25 results. |
-| `Query.offset(0)`                  | Offset the results returned by skipping some of the results. Used for [pagination](/docs/products/databases/pagination). |
-| `Query.cursorAfter("62a7...f620")` | Places the cursor after the specified resource ID. Used for [pagination](/docs/products/databases/pagination).         |
-| `Query.cursorBefore("62a7...a600")` | Places the cursor before the specified resource ID. Used for [pagination](/docs/products/databases/pagination).   |
-{% /tabsitem %}
-
-{% tabsitem #dart title="Dart" %}
-| Example                 | Description                                                                                                           |
-|------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
-| `Query.select(["name", "title"])`  | Select which attributes should be returned from a document.                                                            |
-| `Query.and([Query.lessThan("size", 10), Query.greaterThan("size", 5)])`  | Returns document if it matches all of the nested sub-queries in the array passed in. |
-| `Query.or([Query.lessThan("size", 5), Query.greaterThan("size", 10)])`  | Returns document if it matches any of the nested sub-queries in the array passed in. |
-| `Query.equal("title", ["Iron Man"])` | Returns document if attribute is equal to any value in the provided array.                                             |
-| `Query.notEqual("title", ["Iron Man"])` | Returns document if attribute is not equal to any value in the provided array.                                        |
-| `Query.lessThan("score", 10)`      | Returns document if attribute is less than the provided value.                                                         |
-| `Query.lessThanEqual("score", 10)` | Returns document if attribute is less than or equal to the provided value.                                             |
-| `Query.greaterThan("score", 10)`   | Returns document if attribute is greater than the provided value.                                                      |
-| `Query.greaterThanEqual("score", 10)` | Returns document if attribute is greater than or equal to the provided value.                                         |
-| `Query.between("price", 5, 10)`    | Returns document if attribute value falls between the two values. The boundary values are inclusive and can be strings or numbers. |
-| `Query.isNull("name")`             | Returns documents where attribute value is null.                                                                      |
-| `Query.isNotNull("name")`          | Returns documents where attribute value is **not** null.                                                              |
-| `Query.startsWith("name", "Once upon a time")` | Returns documents if a string attributes starts with a substring.                                                     |
-| `Query.endsWith("name", "happily ever after.")` | Returns documents if a string attributes ends with a substring.                                                       |
-| `Query.contains("ingredients", ['apple', 'banana'])` | Returns documents if the array attribute contains the specified elements.                                                       |
-| `Query.contains("name", "Tom")` | Returns documents if a string attributes is like the pattern specified.                                                       |
-| `Query.search("text", "key words")` | Searches string attributes for provided keywords. Requires a [full-text index](/docs/products/databases/collections#indexes) on queried attributes. |
-| `Query.orderDesc("attribute")`     | Orders results in descending order by attribute. Attribute must be indexed. Pass in an empty string to return in natural order. |
-| `Query.orderAsc("attribute")`      | Orders results in ascending order by attribute. Attribute must be indexed. Pass in an empty string to return in natural order. |
-| `Query.limit(25)`                  | Limits the number of results returned by the query. Used for [pagination](/docs/products/databases/pagination). If the limit query is not used, the limit defaults to 25 results. |
-| `Query.offset(0)`                  | Offset the results returned by skipping some of the results. Used for [pagination](/docs/products/databases/pagination). |
-| `Query.cursorAfter("62a7...f620")` | Places the cursor after the specified resource ID. Used for [pagination](/docs/products/databases/pagination).         |
-| `Query.cursorBefore("62a7...a600")` | Places the cursor before the specified resource ID. Used for [pagination](/docs/products/databases/pagination).   |
-{% /tabsitem %}
-
-{% tabsitem #swift title="Swift" %}
-| Example                 | Description                                                                                                           |
-|------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
-| `Query.select(["name", "title"])`  | Select which attributes should be returned from a document.                                                            |
-| `Query.and([Query.lessThan("size", 10), Query.greaterThan("size", 5)])`  | Returns document if it matches all of the nested sub-queries in the array passed in. |
-| `Query.or([Query.lessThan("size", 5), Query.greaterThan("size", 10)])`  | Returns document if it matches any of the nested sub-queries in the array passed in. |
-| `Query.equal("title", value: ["Iron Man"])` | Returns document if attribute is equal to any value in the provided array.                                             |
-| `Query.notEqual("title", value: ["Iron Man"])` | Returns document if attribute is not equal to any value in the provided array.                                        |
-| `Query.lessThan("score", value: 10)`      | Returns document if attribute is less than the provided value.                                                         |
-| `Query.lessThanEqual("score", value: 10)` | Returns document if attribute is less than or equal to the provided value.                                             |
-| `Query.greaterThan("score",value:  10)`   | Returns document if attribute is greater than the provided value.                                                      |
-| `Query.greaterThanEqual("score", value: 10)` | Returns document if attribute is greater than or equal to the provided value.                                         |
-| `Query.between("price", start: 5, end: 10)`    | Returns document if attribute value falls between the two values. The boundary values are inclusive and can be strings or numbers. |
-| `Query.isNull("name")`             | Returns documents where attribute value is null.                                                                      |
-| `Query.isNotNull("name")`          | Returns documents where attribute value is **not** null.                                                              |
-| `Query.startsWith("name", value: "Once upon a time")` | Returns documents if a string attributes starts with a substring.                                                     |
-| `Query.endsWith("name", value: "happily ever after.")` | Returns documents if a string attributes ends with a substring.                                                       |
-| `Query.contains("ingredients", value: ['apple', 'banana'])` | Returns documents if the array attribute contains the specified elements.                                                       |
-| `Query.contains("name", value: "Tom")` | Returns documents if a string attributes is like the pattern specified.                                                       |
-| `Query.search("text", value: "key words")` | Searches string attributes for provided keywords. Requires a [full-text index](/docs/products/databases/collections#indexes) on queried attributes. |
-| `Query.orderDesc("attribute")`     | Orders results in descending order by attribute. Attribute must be indexed. Pass in an empty string to return in natural order. |
-| `Query.orderAsc("attribute")`      | Orders results in ascending order by attribute. Attribute must be indexed. Pass in an empty string to return in natural order. |
-| `Query.limit(25)`                  | Limits the number of results returned by the query. Used for [pagination](/docs/products/databases/pagination). If the limit query is not used, the limit defaults to 25 results. |
-| `Query.offset(0)`                  | Offset the results returned by skipping some of the results. Used for [pagination](/docs/products/databases/pagination). |
-| `Query.cursorAfter("62a7...f620")` | Places the cursor after the specified resource ID. Used for [pagination](/docs/products/databases/pagination).         |
-| `Query.cursorBefore("62a7...a600")` | Places the cursor before the specified resource ID. Used for [pagination](/docs/products/databases/pagination).   |
-{% /tabsitem %}
-
-{% tabsitem #dotnet title=".NET" %}
-| Example                 | Description                                                                                                           |
-|------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
-| `Query.select(["name", "title"])`  | Select which attributes should be returned from a document.                                                            |
-| `Query.and([Query.lessThan("size", 10), Query.greaterThan("size", 5)])`  | Returns document if it matches all of the nested sub-queries in the array passed in. |
-| `Query.or([Query.lessThan("size", 5), Query.greaterThan("size", 10)])`  | Returns document if it matches any of the nested sub-queries in the array passed in. |
-| `Query.equal("title", ["Iron Man"])` | Returns document if attribute is equal to any value in the provided array.                                             |
-| `Query.notEqual("title", ["Iron Man"])` | Returns document if attribute is not equal to any value in the provided array.                                        |
-| `Query.lessThan("score", 10)`      | Returns document if attribute is less than the provided value.                                                         |
-| `Query.lessThanEqual("score", 10)` | Returns document if attribute is less than or equal to the provided value.                                             |
-| `Query.greaterThan("score", 10)`   | Returns document if attribute is greater than the provided value.                                                      |
-| `Query.greaterThanEqual("score", 10)` | Returns document if attribute is greater than or equal to the provided value.                                         |
-| `Query.between("price", 5, 10)`    | Returns document if attribute value falls between the two values. The boundary values are inclusive and can be strings or numbers. |
-| `Query.isNull("name")`             | Returns documents where attribute value is null.                                                                      |
-| `Query.isNotNull("name")`          | Returns documents where attribute value is **not** null.                                                              |
-| `Query.startsWith("name", "Once upon a time")` | Returns documents if a string attributes starts with a substring.                                                     |
-| `Query.endsWith("name", "happily ever after.")` | Returns documents if a string attributes ends with a substring.                                                       |
-| `Query.contains("ingredients", ['apple', 'banana'])` | Returns documents if the array attribute contains the specified elements.                                                       |
-| `Query.contains("name", "Tom")` | Returns documents if a string attributes is like the pattern specified.                                                       |
-| `Query.search("text", "key words")` | Searches string attributes for provided keywords. Requires a [full-text index](/docs/products/databases/collections#indexes) on queried attributes. |
-| `Query.orderDesc("attribute")`     | Orders results in descending order by attribute. Attribute must be indexed. Pass in an empty string to return in natural order. |
-| `Query.orderAsc("attribute")`      | Orders results in ascending order by attribute. Attribute must be indexed. Pass in an empty string to return in natural order. |
-| `Query.limit(25)`                  | Limits the number of results returned by the query. Used for [pagination](/docs/products/databases/pagination). If the limit query is not used, the limit defaults to 25 results. |
-| `Query.offset(0)`                  | Offset the results returned by skipping some of the results. Used for [pagination](/docs/products/databases/pagination). |
-| `Query.cursorAfter("62a7...f620")` | Places the cursor after the specified resource ID. Used for [pagination](/docs/products/databases/pagination).         |
-| `Query.cursorBefore("62a7...a600")` | Places the cursor before the specified resource ID. Used for [pagination](/docs/products/databases/pagination).   |
-{% /tabsitem %}
-
-{% tabsitem #kotlin title="Kotlin" %}
-| Example                 | Description                                                                                                           |
-|------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
-| `Query.select(["name", "title"])`  | Select which attributes should be returned from a document.                                                            |
-| `Query.and([Query.lessThan("size", 10), Query.greaterThan("size", 5)])`  | Returns document if it matches all of the nested sub-queries in the array passed in. |
-| `Query.or([Query.lessThan("size", 5), Query.greaterThan("size", 10)])`  | Returns document if it matches any of the nested sub-queries in the array passed in. |
-| `Query.equal("title", ["Iron Man"])` | Returns document if attribute is equal to any value in the provided array.                                             |
-| `Query.notEqual("title", ["Iron Man"])` | Returns document if attribute is not equal to any value in the provided array.                                        |
-| `Query.lessThan("score", 10)`      | Returns document if attribute is less than the provided value.                                                         |
-| `Query.lessThanEqual("score", 10)` | Returns document if attribute is less than or equal to the provided value.                                             |
-| `Query.greaterThan("score", 10)`   | Returns document if attribute is greater than the provided value.                                                      |
-| `Query.greaterThanEqual("score", 10)` | Returns document if attribute is greater than or equal to the provided value.                                         |
-| `Query.between("price", 5, 10)`    | Returns document if attribute value falls between the two values. The boundary values are inclusive and can be strings or numbers. |
-| `Query.isNull("name")`             | Returns documents where attribute value is null.                                                                      |
-| `Query.isNotNull("name")`          | Returns documents where attribute value is **not** null.                                                              |
-| `Query.startsWith("name", "Once upon a time")` | Returns documents if a string attributes starts with a substring.                                                     |
-| `Query.endsWith("name", "happily ever after.")` | Returns documents if a string attributes ends with a substring.                                                       |
-| `Query.contains("ingredients", ['apple', 'banana'])` | Returns documents if the array attribute contains the specified elements.                                                       |
-| `Query.contains("name", "Tom")` | Returns documents if a string attributes is like the pattern specified.                                                       |
-| `Query.search("text", "key words")` | Searches string attributes for provided keywords. Requires a [full-text index](/docs/products/databases/collections#indexes) on queried attributes. |
-| `Query.orderDesc("attribute")`     | Orders results in descending order by attribute. Attribute must be indexed. Pass in an empty string to return in natural order. |
-| `Query.orderAsc("attribute")`      | Orders results in ascending order by attribute. Attribute must be indexed. Pass in an empty string to return in natural order. |
-| `Query.limit(25)`                  | Limits the number of results returned by the query. Used for [pagination](/docs/products/databases/pagination). If the limit query is not used, the limit defaults to 25 results. |
-| `Query.offset(0)`                  | Offset the results returned by skipping some of the results. Used for [pagination](/docs/products/databases/pagination). |
-| `Query.cursorAfter("62a7...f620")` | Places the cursor after the specified resource ID. Used for [pagination](/docs/products/databases/pagination).         |
-| `Query.cursorBefore("62a7...a600")` | Places the cursor before the specified resource ID. Used for [pagination](/docs/products/databases/pagination).   |
-{% /tabsitem %}
-
-{% tabsitem #java title="Java" %}
-| Example                 | Description                                                                                                           |
-|------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
-| `Query.select(["name", "title"])`  | Select which attributes should be returned from a document.                                                            |
-| `Query.and([Query.lessThan("size", 10), Query.greaterThan("size", 5)])`  | Returns document if it matches all of the nested sub-queries in the array passed in. |
-| `Query.or([Query.lessThan("size", 5), Query.greaterThan("size", 10)])`  | Returns document if it matches any of the nested sub-queries in the array passed in. |
-| `Query.equal("title", ["Iron Man"])` | Returns document if attribute is equal to any value in the provided array.                                             |
-| `Query.notEqual("title", ["Iron Man"])` | Returns document if attribute is not equal to any value in the provided array.                                        |
-| `Query.lessThan("score", 10)`      | Returns document if attribute is less than the provided value.                                                         |
-| `Query.lessThanEqual("score", 10)` | Returns document if attribute is less than or equal to the provided value.                                             |
-| `Query.greaterThan("score", 10)`   | Returns document if attribute is greater than the provided value.                                                      |
-| `Query.greaterThanEqual("score", 10)` | Returns document if attribute is greater than or equal to the provided value.                                         |
-| `Query.between("price", 5, 10)`    | Returns document if attribute value falls between the two values. The boundary values are inclusive and can be strings or numbers. |
-| `Query.isNull("name")`             | Returns documents where attribute value is null.                                                                      |
-| `Query.isNotNull("name")`          | Returns documents where attribute value is **not** null.                                                              |
-| `Query.startsWith("name", "Once upon a time")` | Returns documents if a string attributes starts with a substring.                                                     |
-| `Query.endsWith("name", "happily ever after.")` | Returns documents if a string attributes ends with a substring.                                                       |
-| `Query.contains("ingredients", ['apple', 'banana'])` | Returns documents if the array attribute contains the specified elements.                                                       |
-| `Query.contains("name", "Tom")` | Returns documents if a string attributes is like the pattern specified.                                                       |
-| `Query.search("text", "key words")` | Searches string attributes for provided keywords. Requires a [full-text index](/docs/products/databases/collections#indexes) on queried attributes. |
-| `Query.orderDesc("attribute")`     | Orders results in descending order by attribute. Attribute must be indexed. Pass in an empty string to return in natural order. |
-| `Query.orderAsc("attribute")`      | Orders results in ascending order by attribute. Attribute must be indexed. Pass in an empty string to return in natural order. |
-| `Query.limit(25)`                  | Limits the number of results returned by the query. Used for [pagination](/docs/products/databases/pagination). If the limit query is not used, the limit defaults to 25 results. |
-| `Query.offset(0)`                  | Offset the results returned by skipping some of the results. Used for [pagination](/docs/products/databases/pagination). |
-| `Query.cursorAfter("62a7...f620")` | Places the cursor after the specified resource ID. Used for [pagination](/docs/products/databases/pagination).         |
-| `Query.cursorBefore("62a7...a600")` | Places the cursor before the specified resource ID. Used for [pagination](/docs/products/databases/pagination).   |
-{% /tabsitem %}
-{% /tabs %}
+Appwrite SDKs provide a `Query` class to help you build queries. The `Query` class has methods for each type of supported query operation.
 
 # Building Queries {% #building-queries %}
 
@@ -419,8 +137,709 @@ query {
 ```
 {% /multicode %}
 
-## Complex Queries
-You can create complex queries by combining AND and OR operations. For example, to find items that are either books under $20 or magazines under $10.
+# Query Operators {% #query-operators %}
+
+## Select {% #select %}
+
+The `select` operator allows you to specify which attributes should be returned from a document. This is useful for optimizing response size and only retrieving the data you need.
+
+{% multicode %}
+```client-web
+Query.select(["name", "title"])
+```
+```client-flutter
+Query.select(["name", "title"])
+```
+```python
+Query.select(["name", "title"])
+```
+```ruby
+Query.select(["name", "title"])
+```
+```deno
+Query.select(["name", "title"])
+```
+```php
+Query::select(["name", "title"])
+```
+```swift
+Query.select(["name", "title"])
+```
+{% /multicode %}
+
+## Comparison Operators {% #comparison %}
+
+### Equal {% #equal %}
+
+Returns document if attribute is equal to any value in the provided array.
+
+{% multicode %}
+```client-web
+Query.equal("title", ["Iron Man"])
+```
+```client-flutter
+Query.equal("title", ["Iron Man"])
+```
+```python
+Query.equal("title", ["Iron Man"])
+```
+```ruby
+Query.equal("title", ["Iron Man"])
+```
+```deno
+Query.equal("title", ["Iron Man"])
+```
+```php
+Query::equal("title", ["Iron Man"])
+```
+```swift
+Query.equal("title", value: ["Iron Man"])
+```
+{% /multicode %}
+
+### Not Equal {% #not-equal %}
+
+Returns document if attribute is not equal to any value in the provided array.
+
+{% multicode %}
+```client-web
+Query.notEqual("title", ["Iron Man"])
+```
+```client-flutter
+Query.notEqual("title", ["Iron Man"])
+```
+```python
+Query.not_equal("title", ["Iron Man"])
+```
+```ruby
+Query.not_equal("title", ["Iron Man"])
+```
+```deno
+Query.notEqual("title", ["Iron Man"])
+```
+```php
+Query::notEqual("title", ["Iron Man"])
+```
+```swift
+Query.notEqual("title", value: ["Iron Man"])
+```
+{% /multicode %}
+
+### Less Than {% #less-than %}
+
+Returns document if attribute is less than the provided value.
+
+{% multicode %}
+```client-web
+Query.lessThan("score", 10)
+```
+```client-flutter
+Query.lessThan("score", 10)
+```
+```python
+Query.less_than("score", 10)
+```
+```ruby
+Query.less_than("score", 10)
+```
+```deno
+Query.lessThan("score", 10)
+```
+```php
+Query::lessThan("score", 10)
+```
+```swift
+Query.lessThan("score", value: 10)
+```
+{% /multicode %}
+
+### Less Than or Equal {% #less-than-equal %}
+
+Returns document if attribute is less than or equal to the provided value.
+
+{% multicode %}
+```client-web
+Query.lessThanEqual("score", 10)
+```
+```client-flutter
+Query.lessThanEqual("score", 10)
+```
+```python
+Query.less_than_equal("score", 10)
+```
+```ruby
+Query.less_than_equal("score", 10)
+```
+```deno
+Query.lessThanEqual("score", 10)
+```
+```php
+Query::lessThanEqual("score", 10)
+```
+```swift
+Query.lessThanEqual("score", value: 10)
+```
+{% /multicode %}
+
+### Greater Than {% #greater-than %}
+
+Returns document if attribute is greater than the provided value.
+
+{% multicode %}
+```client-web
+Query.greaterThan("score", 10)
+```
+```client-flutter
+Query.greaterThan("score", 10)
+```
+```python
+Query.greater_than("score", 10)
+```
+```ruby
+Query.greater_than("score", 10)
+```
+```deno
+Query.greaterThan("score", 10)
+```
+```php
+Query::greaterThan("score", 10)
+```
+```swift
+Query.greaterThan("score", value: 10)
+```
+{% /multicode %}
+
+### Greater Than or Equal {% #greater-than-equal %}
+
+Returns document if attribute is greater than or equal to the provided value.
+
+{% multicode %}
+```client-web
+Query.greaterThanEqual("score", 10)
+```
+```client-flutter
+Query.greaterThanEqual("score", 10)
+```
+```python
+Query.greater_than_equal("score", 10)
+```
+```ruby
+Query.greater_than_equal("score", 10)
+```
+```deno
+Query.greaterThanEqual("score", 10)
+```
+```php
+Query::greaterThanEqual("score", 10)
+```
+```swift
+Query.greaterThanEqual("score", value: 10)
+```
+{% /multicode %}
+
+### Between {% #between %}
+
+Returns document if attribute value falls between the two values. The boundary values are inclusive and can be strings or numbers.
+
+{% multicode %}
+```client-web
+Query.between("price", 5, 10)
+```
+```client-flutter
+Query.between("price", 5, 10)
+```
+```python
+Query.between("price", 5, 10)
+```
+```ruby
+Query.between("price", 5, 10)
+```
+```deno
+Query.between("price", 5, 10)
+```
+```php
+Query::between("price", 5, 10)
+```
+```swift
+Query.between("price", start: 5, end: 10)
+```
+{% /multicode %}
+
+## Null Checks {% #null-checks %}
+
+### Is Null {% #is-null %}
+
+Returns documents where attribute value is null.
+
+{% multicode %}
+```client-web
+Query.isNull("name")
+```
+```client-flutter
+Query.isNull("name")
+```
+```python
+Query.is_null("name")
+```
+```ruby
+Query.is_null("name")
+```
+```deno
+Query.isNull("name")
+```
+```php
+Query::isNull("name")
+```
+```swift
+Query.isNull("name")
+```
+{% /multicode %}
+
+### Is Not Null {% #is-not-null %}
+
+Returns documents where attribute value is **not** null.
+
+{% multicode %}
+```client-web
+Query.isNotNull("name")
+```
+```client-flutter
+Query.isNotNull("name")
+```
+```python
+Query.is_not_null("name")
+```
+```ruby
+Query.is_not_null("name")
+```
+```deno
+Query.isNotNull("name")
+```
+```php
+Query::isNotNull("name")
+```
+```swift
+Query.isNotNull("name")
+```
+{% /multicode %}
+
+## String Operations {% #string-operations %}
+
+### Starts With {% #starts-with %}
+
+Returns documents if a string attribute starts with a substring.
+
+{% multicode %}
+```client-web
+Query.startsWith("name", "Once upon a time")
+```
+```client-flutter
+Query.startsWith("name", "Once upon a time")
+```
+```python
+Query.starts_with("name", "Once upon a time")
+```
+```ruby
+Query.starts_with("name", "Once upon a time")
+```
+```deno
+Query.startsWith("name", "Once upon a time")
+```
+```php
+Query::startsWith("name", "Once upon a time")
+```
+```swift
+Query.startsWith("name", value: "Once upon a time")
+```
+{% /multicode %}
+
+### Ends With {% #ends-with %}
+
+Returns documents if a string attribute ends with a substring.
+
+{% multicode %}
+```client-web
+Query.endsWith("name", "happily ever after.")
+```
+```client-flutter
+Query.endsWith("name", "happily ever after.")
+```
+```python
+Query.ends_with("name", "happily ever after.")
+```
+```ruby
+Query.ends_with("name", "happily ever after.")
+```
+```deno
+Query.endsWith("name", "happily ever after.")
+```
+```php
+Query::endsWith("name", "happily ever after.")
+```
+```swift
+Query.endsWith("name", value: "happily ever after.")
+```
+{% /multicode %}
+
+### Contains {% #contains %}
+
+Returns documents if the array attribute contains the specified elements or if a string attribute contains the specified substring.
+
+{% multicode %}
+```client-web
+// For arrays
+Query.contains("ingredients", ['apple', 'banana'])
+
+// For strings
+Query.contains("name", "Tom")
+```
+```client-flutter
+// For arrays
+Query.contains("ingredients", ['apple', 'banana'])
+
+// For strings
+Query.contains("name", "Tom")
+```
+```python
+# For arrays
+Query.contains("ingredients", ['apple', 'banana'])
+
+# For strings
+Query.contains("name", "Tom")
+```
+```ruby
+# For arrays
+Query.contains("ingredients", ['apple', 'banana'])
+
+# For strings
+Query.contains("name", "Tom")
+```
+```deno
+// For arrays
+Query.contains("ingredients", ['apple', 'banana'])
+
+// For strings
+Query.contains("name", "Tom")
+```
+```php
+// For arrays
+Query::contains("ingredients", ['apple', 'banana'])
+
+// For strings
+Query::contains("name", "Tom")
+```
+```swift
+// For arrays
+Query.contains("ingredients", value: ['apple', 'banana'])
+
+// For strings
+Query.contains("name", value: "Tom")
+```
+{% /multicode %}
+
+### Search {% #search %}
+
+Searches string attributes for provided keywords. Requires a [full-text index](/docs/products/databases/collections#indexes) on queried attributes.
+
+{% multicode %}
+```client-web
+Query.search("text", "key words")
+```
+```client-flutter
+Query.search("text", "key words")
+```
+```python
+Query.search("text", "key words")
+```
+```ruby
+Query.search("text", "key words")
+```
+```deno
+Query.search("text", "key words")
+```
+```php
+Query::search("text", "key words")
+```
+```swift
+Query.search("text", value: "key words")
+```
+{% /multicode %}
+
+## Logical Operators {% #logical-operators %}
+
+### AND {% #and %}
+
+Returns document if it matches all of the nested sub-queries in the array passed in.
+
+{% multicode %}
+```client-web
+Query.and([
+    Query.lessThan("size", 10),
+    Query.greaterThan("size", 5)
+])
+```
+```client-flutter
+Query.and([
+    Query.lessThan("size", 10),
+    Query.greaterThan("size", 5)
+])
+```
+```python
+Query.and_queries([
+    Query.less_than("size", 10),
+    Query.greater_than("size", 5)
+])
+```
+```ruby
+Query.and([
+    Query.less_than("size", 10),
+    Query.greater_than("size", 5)
+])
+```
+```deno
+Query.and([
+    Query.lessThan("size", 10),
+    Query.greaterThan("size", 5)
+])
+```
+```php
+Query::and([
+    Query::lessThan("size", 10),
+    Query::greaterThan("size", 5)
+])
+```
+```swift
+Query.and([
+    Query.lessThan("size", value: 10),
+    Query.greaterThan("size", value: 5)
+])
+```
+{% /multicode %}
+
+### OR {% #or %}
+
+Returns document if it matches any of the nested sub-queries in the array passed in.
+
+{% multicode %}
+```client-web
+Query.or([
+    Query.lessThan("size", 5),
+    Query.greaterThan("size", 10)
+])
+```
+```client-flutter
+Query.or([
+    Query.lessThan("size", 5),
+    Query.greaterThan("size", 10)
+])
+```
+```python
+Query.or_queries([
+    Query.less_than("size", 5),
+    Query.greater_than("size", 10)
+])
+```
+```ruby
+Query.or([
+    Query.less_than("size", 5),
+    Query.greater_than("size", 10)
+])
+```
+```deno
+Query.or([
+    Query.lessThan("size", 5),
+    Query.greaterThan("size", 10)
+])
+```
+```php
+Query::or([
+    Query::lessThan("size", 5),
+    Query::greaterThan("size", 10)
+])
+```
+```swift
+Query.or([
+    Query.lessThan("size", value: 5),
+    Query.greaterThan("size", value: 10)
+])
+```
+{% /multicode %}
+
+## Ordering {% #ordering %}
+
+### Order Descending {% #order-desc %}
+
+Orders results in descending order by attribute. Attribute must be indexed.
+
+{% multicode %}
+```client-web
+Query.orderDesc("attribute")
+```
+```client-flutter
+Query.orderDesc("attribute")
+```
+```python
+Query.order_desc("attribute")
+```
+```ruby
+Query.order_desc("attribute")
+```
+```deno
+Query.orderDesc("attribute")
+```
+```php
+Query::orderDesc("attribute")
+```
+```swift
+Query.orderDesc("attribute")
+```
+{% /multicode %}
+
+### Order Ascending {% #order-asc %}
+
+Orders results in ascending order by attribute. Attribute must be indexed.
+
+{% multicode %}
+```client-web
+Query.orderAsc("attribute")
+```
+```client-flutter
+Query.orderAsc("attribute")
+```
+```python
+Query.order_asc("attribute")
+```
+```ruby
+Query.order_asc("attribute")
+```
+```deno
+Query.orderAsc("attribute")
+```
+```php
+Query::orderAsc("attribute")
+```
+```swift
+Query.orderAsc("attribute")
+```
+{% /multicode %}
+
+## Pagination {% #pagination %}
+
+### Limit {% #limit %}
+
+Limits the number of results returned by the query. Used for [pagination](/docs/products/databases/pagination).
+
+{% multicode %}
+```client-web
+Query.limit(25)
+```
+```client-flutter
+Query.limit(25)
+```
+```python
+Query.limit(25)
+```
+```ruby
+Query.limit(25)
+```
+```deno
+Query.limit(25)
+```
+```php
+Query::limit(25)
+```
+```swift
+Query.limit(25)
+```
+{% /multicode %}
+
+### Offset {% #offset %}
+
+Offset the results returned by skipping some of the results. Used for [pagination](/docs/products/databases/pagination).
+
+{% multicode %}
+```client-web
+Query.offset(0)
+```
+```client-flutter
+Query.offset(0)
+```
+```python
+Query.offset(0)
+```
+```ruby
+Query.offset(0)
+```
+```deno
+Query.offset(0)
+```
+```php
+Query::offset(0)
+```
+```swift
+Query.offset(0)
+```
+{% /multicode %}
+
+### Cursor After {% #cursor-after %}
+
+Places the cursor after the specified resource ID. Used for [pagination](/docs/products/databases/pagination).
+
+{% multicode %}
+```client-web
+Query.cursorAfter("62a7...f620")
+```
+```client-flutter
+Query.cursorAfter("62a7...f620")
+```
+```python
+Query.cursor_after("62a7...f620")
+```
+```ruby
+Query.cursor_after("62a7...f620")
+```
+```deno
+Query.cursorAfter("62a7...f620")
+```
+```php
+Query::cursorAfter("62a7...f620")
+```
+```swift
+Query.cursorAfter("62a7...f620")
+```
+{% /multicode %}
+
+### Cursor Before {% #cursor-before %}
+
+Places the cursor before the specified resource ID. Used for [pagination](/docs/products/databases/pagination).
+
+{% multicode %}
+```client-web
+Query.cursorBefore("62a7...a600")
+```
+```client-flutter
+Query.cursorBefore("62a7...a600")
+```
+```python
+Query.cursor_before("62a7...a600")
+```
+```ruby
+Query.cursor_before("62a7...a600")
+```
+```deno
+Query.cursorBefore("62a7...a600")
+```
+```php
+Query::cursorBefore("62a7...a600")
+```
+```swift
+Query.cursorBefore("62a7...a600")
+```
+{% /multicode %}
+
+# Complex Queries {% #complex-queries %}
+
+You can create complex queries by combining AND and OR operations. For example, to find items that are either books under $20 or magazines under $10:
 
 {% multicode %}
 ```client-web
@@ -475,42 +894,6 @@ results = databases.list_documents(
             ])
         ])
     ]
-)
-```
-```client-apple
-let results = try await databases.listDocuments(
-    databaseId: '<DATABASE_ID>',
-    collectionId: '<COLLECTION_ID>',
-    queries: [
-        Query.or([
-            Query.and([
-                Query.equal("category", value: ["books"]),
-                Query.lessThan("price", value: 20)
-            ]),
-            Query.and([
-                Query.equal("category", value: ["magazines"]),
-                Query.lessThan("price", value: 10)
-            ])
-        ])
-    ]
-)
-```
-```kotlin
-val results = databases.listDocuments(
-    databaseId = '<DATABASE_ID>',
-    collectionId = '<COLLECTION_ID>',
-    queries = listOf(
-        Query.or(listOf(
-            Query.and(listOf(
-                Query.equal("category", ["books"]),
-                Query.lessThan("price", 20)
-            )),
-            Query.and(listOf(
-                Query.equal("category", ["magazines"]),
-                Query.lessThan("price", 10)
-            ))
-        ))
-    )
 )
 ```
 {% /multicode %}


### PR DESCRIPTION
## What does this PR do?
Currently, all operators are crumbled into a table. This changes it so we have a section for each operator. 

## Test Plan
- `/docs/products/databases/queries`

## Related PRs and Issues
DRL-1351