### PR TITLE
Update +page.markdoc

### DIFF
--- a/src/routes/docs/quick-starts/sveltekit/+page.markdoc
+++ b/src/routes/docs/quick-starts/sveltekit/+page.markdoc
@@ -43,7 +43,7 @@ npx sv create
 Install the JavaScript Appwrite SDK.
 
 ```sh
-npm install appwrite@14.0.1
+npm install appwrite@latest
 ```
 {% /section %}
 {% section #step-4 step=4 title="Import Appwrite" %}


### PR DESCRIPTION
instead of npm install appwrite@14.0.1 i made a change to npm install appwrite@latest because the 14.0.1 is older version of appwrite, this is future proof because no matter how many new versions come out it would always install the newest one

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This line change would prevent svelte/sveltekit users from downloading an older version of appwrite 

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)