### PR TITLE
feat: require feedback message

### DIFF
--- a/src/lib/components/Feedback.svelte
+++ b/src/lib/components/Feedback.svelte
@@ -129,13 +129,14 @@
             <div class="flex flex-col gap-2">
                 <label for="message">
                     <span class="text-primary">
-                        What did you {feedbackType === 'negative' ? 'dislike' : 'like'}? (optional)
+                        What did you {feedbackType === 'negative' ? 'dislike' : 'like'}?
                     </span>
                 </label>
                 <textarea
                     class="web-input-text"
                     id="message"
                     placeholder="Write your message"
+                    required
                     bind:value={comment}
                 ></textarea>
                 <label for="message" class="mt-2">


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Because the server requires a message, the feedback submission will fail. This updates the website to match the backend to require a message.

This will also help us get more detailed feedback.

## Test Plan

Manually tested to confirm I get an error when I don't include a message:

<img width="735" alt="image" src="https://github.com/user-attachments/assets/be37cb22-d4e1-4dd2-b9a9-c739ab5bf57d" />


## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes