### PR TITLE
fix(docs): clarify the need for a session when verifying email

### DIFF
--- a/src/routes/docs/products/auth/verify-user/+page.markdoc
+++ b/src/routes/docs/products/auth/verify-user/+page.markdoc
@@ -8,7 +8,7 @@ User verification in Appwrite allows you to verify user email addresses and phon
 
 # Verify email {% #verify-email %}
 
-To verify a user's email, first ensure the user is logged in. Then send a verification email with a redirect URL. The verification secrets will be appended as query parameters to the redirect URL.
+To verify a user's email, first ensure the user is logged in so that the verification email can be sent to the user who created the account. Then, send the verification email specifying a redirect URL. The verification secrets will be appended as query parameters to the redirect URL.
 
 {% multicode %}
 ```client-web


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Explain why a session is needed before calling account.createverification() so that developers know to create a session first.

## Test Plan

http://1975.gkswsco.37.27.92.31.sslip.io/docs/products/auth/verify-user

<img width="714" alt="image" src="https://github.com/user-attachments/assets/58990eec-9aff-4383-9985-255d11bc8f17" />


## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes