### PR TITLE
docs: fix incorrect sites documentation URL

### DIFF
--- a/src/routes/blog/post/building-with-sites-templates/+page.markdoc
+++ b/src/routes/blog/post/building-with-sites-templates/+page.markdoc
@@ -132,7 +132,7 @@ Once your site is deployed, you can continue to customize it, link it to a custo
 
 # More resources
 
-- [Appwrite Sites docs](/docs/producst/sites)
+- [Appwrite Sites docs](/docs/products/sites)
 - [Appwrite compared to Vercel](/blog/post/open-source-vercel-alternative)
 - [Appwrite Sites product tour](https://youtu.be/VtDe6hDw91k)
 - [Appwrite Sites video announcement](https://youtu.be/0cERQxFjTW4)


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR corrects the URL for the Appwrite Sites documentation in the "Building with Sites Templates" blog post. The URL was previously incorrect and has been updated to make sure proper navigation.

## Test Plan

- Verified the updated URL points to the correct documentation page.
- Checked the blog post to ensure the link is functioning as expected.

## Related PRs and Issues

No related PRs or issues.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes, I have read and followed the contributing guidelines.