### PR TITLE
Fix: `notEqual` doesn't take an array

### DIFF
--- a/src/routes/docs/products/databases/queries/+page.markdoc
+++ b/src/routes/docs/products/databases/queries/+page.markdoc
@@ -214,28 +214,28 @@ Returns document if attribute is not equal to any value in the provided array.
 
 {% multicode %}
 ```client-web
-Query.notEqual("title", ["Iron Man"])
+Query.notEqual("title", "Iron Man")
 ```
 ```client-flutter
-Query.notEqual("title", ["Iron Man"])
+Query.notEqual("title", "Iron Man")
 ```
 ```python
-Query.not_equal("title", ["Iron Man"])
+Query.not_equal("title", "Iron Man")
 ```
 ```ruby
-Query.not_equal("title", ["Iron Man"])
+Query.not_equal("title", "Iron Man")
 ```
 ```deno
-Query.notEqual("title", ["Iron Man"])
+Query.notEqual("title", "Iron Man")
 ```
 ```php
-Query::notEqual("title", ["Iron Man"])
+Query::notEqual("title", "Iron Man")
 ```
 ```swift
-Query.notEqual("title", value: ["Iron Man"])
+Query.notEqual("title", value: "Iron Man")
 ```
 ```http
-{"method":"notEqual","attribute":"title","values":["Iron Man"]}
+{"method":"notEqual","attribute":"title","values":"Iron Man"}
 ```
 {% /multicode %}
 


### PR DESCRIPTION
## What does this PR do?

Source - https://github.com/utopia-php/database/blob/main/README.md#document-methods

## Test Plan

N/A.

## Related PRs and Issues

Discord - https://discord.com/channels/564160730845151244/1375735071671189574

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.