### PR TITLE
Fix pricing page to match the backend

### DIFF
--- a/src/routes/blog/post/announcing-phone-OTP-pricing/+page.markdoc
+++ b/src/routes/blog/post/announcing-phone-OTP-pricing/+page.markdoc
@@ -29,10 +29,6 @@ To help prepare for these changes, each team can visit their organization's usag
 
 ![console image](/images/blog/announcing-phone-OTP-pricing/cover.png)
 
-# Free quota available
-
-To ensure that free users can continue exploring the platform and its features, we will provide up to 10 phone OTP login attempts per month at no charge. This will allow you to continue utilizing OTP logins to evaluate Appwrite's capabilities and integration into your workflows.
-
 # We're here to help
 
 If you have any questions about this change or need assistance with adjusting your application, please don't hesitate to contact us at [billing@appwrite.io](mailto:billing@appwrite.io).

--- a/src/routes/docs/advanced/platform/phone-otp/+page.markdoc
+++ b/src/routes/docs/advanced/platform/phone-otp/+page.markdoc
@@ -12,13 +12,13 @@ Appwrite supports SMS-based OTP (One-Time Password) authentication to provide se
 
 # Free messages {% #free-messages %}
 
-All Appwrite plans include **10 free SMS messages** per month, which allows you to test and implement OTP functionality without immediate costs.
+All paid Appwrite plans include **10 free SMS messages** per month, which allows you to test and implement OTP functionality without immediate costs.
 
 In addition you can also use the [Mock phone numbers](/docs/products/auth/security#mock-phone-numbers) feature to continue testing your integrations without incurring additional costs.
 
 # Additional messages {% #additional-messages %}
 
-To send more than 10 SMS messages per month, you need to upgrade to a **paid plan**. For detailed information about the different pricing options and features, please visit the [pricing page](/pricing).
+After the first 10 free SMS messages, you'll be charged per SMS.
 
 The cost for additional messages is calculated based on two factors:
 1. The number of messages sent

--- a/src/routes/docs/products/auth/phone-sms/+page.markdoc
+++ b/src/routes/docs/products/auth/phone-sms/+page.markdoc
@@ -5,7 +5,7 @@ description: Enhance security with SMS and phone authentication in Appwrite. Add
 ---
 
 {% info title="Note" %}
-The first 10 SMS messages each month are free. Thereafter OTPs are billed per message, with rates varying by country. See the [phone OTP rates](/docs/advanced/platform/phone-otp#rates) for more information.
+Paid plans receive 10 free SMS messages each month. Thereafter OTPs are billed per message, with rates varying by country. See the [phone OTP rates](/docs/advanced/platform/phone-otp#rates) for more information.
 {% /info %}
 
 Phone authentication lets users create accounts using their phone numbers and log in through SMS messages.

--- a/src/routes/pricing/compare-plans.svelte
+++ b/src/routes/pricing/compare-plans.svelte
@@ -355,7 +355,7 @@
                     title: 'Concurrent connections',
                     free: '250',
                     pro: '500',
-                    scale: '500',
+                    scale: '750',
                     enterprise: 'Custom'
                 },
                 {

--- a/src/routes/pricing/compare-plans.svelte
+++ b/src/routes/pricing/compare-plans.svelte
@@ -163,7 +163,7 @@
                 },
                 {
                     title: 'Phone OTP',
-                    free: '10 SMS / month',
+                    free: '-',
                     pro: {
                         text: 'View rates',
                         url: '/docs/advanced/platform/phone-otp#rates',


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

* docs: don't give 10 free SMS for free plan orgs 
* docs: update concurrent connections pricing to match backend

## Test Plan

Manual

<img width="946" alt="image" src="https://github.com/user-attachments/assets/10dc0a9e-2673-41e7-aa70-762b756dc772" />

<img width="770" alt="image" src="https://github.com/user-attachments/assets/644604f3-8294-4797-ab80-6d96437eb8a2" />

<img width="728" alt="image" src="https://github.com/user-attachments/assets/20010b83-3e86-4242-9d17-8f48d5e750e6" />

<img width="1257" alt="image" src="https://github.com/user-attachments/assets/cf295710-e733-4781-bcfa-9b433aed2b70" />

<img width="1272" alt="image" src="https://github.com/user-attachments/assets/84348480-3b19-48bf-8c81-7ac5efc1bfe4" />


## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes