### PR TITLE
fix: api reference docs rendering on navigation

### DIFF
--- a/src/lib/layouts/SidebarNavButton.svelte
+++ b/src/lib/layouts/SidebarNavButton.svelte
@@ -10,6 +10,7 @@
     class:is-selected={page.url?.pathname === groupItem.href}
     href={groupItem.href}
     target={groupItem.openInNewTab ? '_blank' : undefined}
+    data-sveltekit-reload
 >
     {#if groupItem.icon}
         <span class="icon {groupItem.icon}" aria-hidden="true"></span>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

docs were rendered like this on navigation:
<img width="1470" alt="Screenshot 2025-06-04 at 7 37 46 PM" src="https://github.com/user-attachments/assets/8133216c-5940-4de2-89ee-10941d6748bd" />

## Test Plan

after the fix:
<img width="1470" alt="Screenshot 2025-06-04 at 7 38 12 PM" src="https://github.com/user-attachments/assets/a5b1898b-3985-468e-9474-b17a4fd0acdd" />

## Related PRs and Issues

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes.