### PR TITLE
fix: buttons not working in our plan section

### DIFF
--- a/src/lib/components/PreFooter.svelte
+++ b/src/lib/components/PreFooter.svelte
@@ -116,6 +116,7 @@
                             {plan.description}
                         </p>
                         <Button
+                            href={plan.buttonLink}
                             event={plan.eventName}
                             variant={plan.buttonVariant}
                             class="w-full! flex-3 self-end md:w-fit"


### PR DESCRIPTION
## What does this PR do?
Fixes the unresponsive *Get Started* and *Start Building* buttons in the **Our Plans** section on the `/pricing` page.
The buttons were missing the href attribute linking to their respective URLs, which caused them to be non-functional. This PR adds the correct links, ensuring they now work as intended and enhance the user experience and navigation.

## Test Plan
1. Navigate to the /pricing page.
2. Scroll to the "Our Plans" section.
3. Click on the "Get Started" and "Start Building" buttons.
4. Confirm that each button correctly redirects to its intended URL.

## Video of the changes
## Before

https://github.com/user-attachments/assets/a16bc6a3-f4c6-478b-8093-03918c283c56


## After


https://github.com/user-attachments/assets/4fa25a47-e4dc-4e0d-a2d3-227372cf7d8b


## Related PRs and Issues
#2093 


### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] Yes
- [ ] No