### PR TITLE
Add missing execution info to Functions doc

### DIFF
--- a/src/routes/docs/products/functions/execute/+page.markdoc
+++ b/src/routes/docs/products/functions/execute/+page.markdoc
@@ -11,6 +11,42 @@ Appwrite Functions can be executed in several ways.
 Executions can be invoked through the Appwrite SDK and visiting its REST endpoint. Functions can also be triggered by events and scheduled executions.
 Here are all the different ways to consume your Appwrite Functions.
 
+# Execution modes {% #execution-modes %}
+
+Appwrite Functions support two execution modes: **synchronous** and **asynchronous**. Understanding the difference between these modes is important for building efficient applications.
+
+## Synchronous executions {% #synchronous-executions %}
+
+Synchronous executions are those where Appwrite makes the request to the function runtime synchronously and waits for the response. The client making the request will wait until the function completes and receives the response directly.
+
+Synchronous executions are created via:
+- The [Create execution](/docs/references/cloud/client-web/functions#createExecution) endpoint where the `async` parameter is `false`
+- Requests to custom or auto-generated [domains](/docs/products/functions/execute#domains)
+
+Synchronous executions:
+- Return response bodies and headers directly to the client
+- Have a **30-second timeout limit** to prevent long-running requests from blocking Appwrite workers
+- Are ideal for real-time operations where you need immediate response data
+- Work best for lightweight operations that complete quickly
+
+## Asynchronous executions {% #asynchronous-executions %}
+
+Asynchronous executions are added to a queue and processed by the function worker as background jobs.
+
+Asynchronous executions are created via:
+- The [Create execution](/docs/references/cloud/client-web/functions#createExecution) endpoint where the `async` parameter is `true`
+- Event triggers (when functions are triggered by [platform events](/docs/advanced/platform/events))
+- Scheduled executions (cron jobs or delayed executions)
+
+Asynchronous executions:
+- Have no timeout limitations beyond your function's configured timeout
+- Do **not store** response bodies and headers and cannot be retrieved later
+- Are ideal for long-running tasks, background processing, and event-driven workflows
+
+{% info title="Response body storage" %}
+Response bodies and headers are not stored anywhere, so they are only ever returned via synchronous executions.
+{% /info %}
+
 # Domains {% #domains %}
 You can execute a function through HTTP requests, using a browser or by sending an HTTP request.
 1. In the Appwrite Console's sidebar, click **Functions**.
@@ -35,7 +71,7 @@ curl -X POST https://64d4d22db370ae41a32e.appwrite.global \
 Notice how a `x-appwrite-user-jwt` header is passed in the request, you will use this to authenticate users.
 [Learn more about JWTs](/docs/products/auth/jwt).
 
-This unlocks ability for you to develop custom HTTP endpoints with Appwrite Functions. 
+This unlocks ability for you to develop custom HTTP endpoints with Appwrite Functions.
 It also allows accepting incoming webhooks for handling online payments, hosting social platform bots, and much more.
 
 # SDK {% #sdk %}
@@ -266,8 +302,8 @@ $client
 
 $functions = new Functions($client);
 
-$result = $functions->createExecution( 
-    functionId: '<FUNCTION_ID>', 
+$result = $functions->createExecution(
+    functionId: '<FUNCTION_ID>',
     body: '<BODY>',  // optional
     async: false,  // optional
     path: '<PATH>',  // optional
@@ -287,8 +323,8 @@ client = Client()
 
 functions = Functions(client)
 
-result = functions.create_execution( 
-    function_id = '<FUNCTION_ID>', 
+result = functions.create_execution(
+    function_id = '<FUNCTION_ID>',
     body = '<BODY>',  # optional
     async = False,  # optional
     path = '<PATH>',  # optional
@@ -307,7 +343,7 @@ client = Client.new
 functions = Functions.new(client)
 
 response = functions.create_execution(
-    function_id: '<FUNCTION_ID>', 
+    function_id: '<FUNCTION_ID>',
     body: '<BODY>',  # optional
     async: false,  # optional
     path: '<PATH>',  # optional
@@ -328,11 +364,11 @@ var client = new Client()
 var functions = new Functions(client);
 
 Execution result = await functions.CreateExecution(
-    functionId: "<FUNCTION_ID>"    
-    body: "<BODY>" // optional    
-    async: false // optional    
-    path: "<PATH>" // optional    
-    method: "GET" // optional    
+    functionId: "<FUNCTION_ID>"
+    body: "<BODY>" // optional
+    async: false // optional
+    path: "<PATH>" // optional
+    method: "GET" // optional
     headers: [object]); // optional
 ```
 ```dart
@@ -439,8 +475,8 @@ let execution = try await functions.createExecution(
 {% /tabs %}
 
 # Console {% #console %}
-Another easy way to test a function is directly in the Appwrite Console. 
-You test a function by hitting the **Execute now** button, which will display with modal below. 
+Another easy way to test a function is directly in the Appwrite Console.
+You test a function by hitting the **Execute now** button, which will display with modal below.
 
 You'll be able to mock executions by configuring the path, method, headers, and body.
 
@@ -784,7 +820,7 @@ $client
 
 $functions = new Functions($client);
 
-$result = $functions->createExecution( 
+$result = $functions->createExecution(
     '<FUNCTION_ID>', // functionId
     '<BODY>', // body (optional)
     true, // Scheduled executions need to be async
@@ -806,7 +842,7 @@ client = Client()
 
 functions = Functions(client)
 
-result = functions.create_execution( 
+result = functions.create_execution(
     function_id = '<FUNCTION_ID>', # functionId
     body = '<BODY>', # body (optional)
     async = True, # Scheduled executions need to be async

--- a/src/routes/docs/products/functions/executions/+page.markdoc
+++ b/src/routes/docs/products/functions/executions/+page.markdoc
@@ -82,6 +82,10 @@ This ensures that developers do not see user data by default and no sensitive da
 If you need to log debug data or audit logs, you can use [function logging features](/docs/products/functions/develop#logging)
 to explicitly log the information you need.
 
+{% info title="Access control" %}
+Only the user who created an execution can retrieve it using the [Get execution](/docs/references/cloud/client-web/functions#getExecution) endpoint.
+{% /info %}
+
 # Log retention {% #log-retention %}
 
 Logs are not retained forever in order to be compliant with GDPR and other data privacy standards.

--- a/src/routes/docs/tooling/command-line/functions/+page.markdoc
+++ b/src/routes/docs/tooling/command-line/functions/+page.markdoc
@@ -120,64 +120,64 @@ appwrite functions [COMMAND] [OPTIONS]
 * Command
 * Description
 ---
-* `list [options]`                   
+* `list [options]`
 * Get a list of all the project's functions. You can use the query params to filter your results.
 ---
 * `create [options]`
 * Create a new function. You can pass a list of [permissions](https://appwrite.io/docs/permissions) to allow different project users or teams with access to execute the function using the client API.
 ---
-* `list-runtimes`                    
+* `list-runtimes`
 * Get a list of all runtimes that are currently active on your instance.
 ---
-* `get [options]`                    
+* `get [options]`
 * Get a function by its unique ID.
 ---
-* `update [options]`                 
+* `update [options]`
 * Update function by its unique ID.
 ---
-* `delete [options]`                 
+* `delete [options]`
 * Delete a function by its unique ID.
 ---
-* `list-deployments [options]`        
+* `list-deployments [options]`
 * Get a list of all the project's code deployments. You can use the query params to filter your results.
 ---
-* `create-deployment [options]`       
+* `create-deployment [options]`
 * Create a new function code deployment. Use this endpoint to upload a new version of your code function. To execute your newly uploaded code, you'll need to update the function's deployment to use your new deployment UID. This endpoint accepts a tar.gz file compressed with your code. Make sure to include any dependencies your code has within the compressed file. You can learn more about code packaging in the [Appwrite Cloud Functions tutorial](https://appwrite.io/docs/functions). Use the "command" param to set the entrypoint used to execute your code.
 ---
-* `get-deployment [options]`          
+* `get-deployment [options]`
 * Get a code deployment by its unique ID.
 ---
-* `update-deployment [options]`       
+* `update-deployment [options]`
 * Update the function code deployment ID using the unique function ID. Use this endpoint to switch the code deployment that should be executed by the execution endpoint.
 ---
-* `delete-deployment [options]`       
+* `delete-deployment [options]`
 * Delete a code deployment by its unique ID.
 ---
-* `download-deployment [options]`    
+* `download-deployment [options]`
 * Get a Deployment's contents by its unique ID. This endpoint supports range requests for partial or streaming file download.
 ---
-* `list-executions [options]`         
+* `list-executions [options]`
 * Get a list of all the current user function execution logs. You can use the query params to filter your results.
 ---
-* `create-execution [options]`    
-* Trigger a function execution. The returned object will return you the current execution status. You can ping the 'Get Execution' endpoint to get updates on the current execution status. Once this endpoint is called, your function execution process will start asynchronously.
+* `create-execution [options]`
+* Trigger a function execution. The returned object will return you the current execution status. You can ping the 'Get Execution' endpoint to get updates on the current execution status.
 ---
-* `get-execution [options]`           
+* `get-execution [options]`
 * Get a function execution log by its unique ID.
 ---
-* `list-variables [options]`          
+* `list-variables [options]`
 * Get a list of all variables of a specific function.
 ---
-* `create-variable [options]`         
+* `create-variable [options]`
 * Create a new function environment variable. These variables can be accessed in the function at runtime as environment variables.
 ---
-* `get-variable [options]`            
+* `get-variable [options]`
 * Get a variable by its unique ID.
 ---
-* `update-variable [options]`         
+* `update-variable [options]`
 * Update a variable by its unique ID.
 ---
-* `delete-variable [options]`        
+* `delete-variable [options]`
 * Delete a variable by its unique ID.
 ---
 {% /table %}


### PR DESCRIPTION
## What does this PR do?
Updates Functions documentation to include some missing info about executions

## Test Plan
- `/docs/products/functions/executions`
- `/docs/products/functions/execute`
- `/docs/tooling/command-line/functions#commands`

## Related PRs and Issues
DRL-1514