### PR TITLE
Add Flutter setup instructions for FCM in documentation

### DIFF
--- a/src/routes/docs/products/messaging/fcm/+page.markdoc
+++ b/src/routes/docs/products/messaging/fcm/+page.markdoc
@@ -82,6 +82,7 @@ Some additional configuration is required to enable push notifications in your m
 1. Add the Firebase core plugin if not already added with `flutter pub add firebase_core`.
 1. Initialize Firebase in your `lib/main.dart` file:
 ```dart
+import 'package:flutter/widgets.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'firebase_options.dart';
 


### PR DESCRIPTION
## What does this PR do?
- Adds Flutter setup instructions for FCM in documentation

## Test Plan
- `/docs/products/messaging/fcm#configure-app`

## Related PRs and Issues
DRL-1451