### PR TITLE
Doc fix: correct bulk operations API syntax and examples

### DIFF
--- a/src/routes/docs/products/databases/bulk-operations/+page.markdoc
+++ b/src/routes/docs/products/databases/bulk-operations/+page.markdoc
@@ -33,12 +33,12 @@ const result = await databases.createDocuments(
     '[COLLECTION_ID]',
     [
         {
-            documentId: sdk.ID.unique(),
-            data: { name: 'Document 1' }
+            $id: sdk.ID.unique(),
+            name: 'Document 1'
         },
         {
-            documentId: sdk.ID.unique(),
-            data: { name: 'Document 2' }
+            $id: sdk.ID.unique(),
+            name: 'Document 2'
         }
     ]
 );
@@ -47,6 +47,7 @@ const result = await databases.createDocuments(
 ```server-python
 from appwrite.client import Client
 from appwrite.services.databases import Databases
+from appwrite.id import ID
 
 client = Client()
 client.set_endpoint('https://<REGION>.cloud.appwrite.io/v1')
@@ -60,12 +61,12 @@ result = databases.create_documents(
     collection_id = '<COLLECTION_ID>',
     documents = [
         {
-            'documentId': appwrite.ID.unique(),
-            'data': { 'name': 'Document 1' }
+            '$id': ID.unique(),
+            'name': 'Document 1'
         },
         {
-            'documentId': appwrite.ID.unique(),
-            'data': { 'name': 'Document 2' }
+            '$id': ID.unique(),
+            'name': 'Document 2'
         }
     ]
 )
@@ -96,21 +97,18 @@ const result = await databases.updateDocuments(
     '<DATABASE_ID>',
     '[COLLECTION_ID]',
     {
-        {
-            documentId: 'document-id-1',
-            data: { name: 'Updated Document 1' }
-        },
-        {
-            documentId: 'document-id-2',
-            data: { name: 'Updated Document 2' }
-        }
-    }
+        status: 'published'
+    },
+    [
+        sdk.Query.equal('status', 'draft')
+    ]
 );
 ```
 
 ```server-python
 from appwrite.client import Client
 from appwrite.services.databases import Databases
+from appwrite.query import Query
 
 client = Client()
 client.set_endpoint('https://<REGION>.cloud.appwrite.io/v1')
@@ -123,15 +121,11 @@ result = databases.update_documents(
     database_id = '<DATABASE_ID>',
     collection_id = '<COLLECTION_ID>',
     data = {
-        {
-            'documentId': 'document-id-1',
-            'data': { 'name': 'New Document 1' }
-        },
-        {
-            'documentId': 'document-id-2',
-            'data': { 'name': 'New Document 2' }
-        }
-    }
+        'status': 'published'
+    },
+    queries = [
+        Query.equal('status', 'draft')
+    ]
 )
 ```
 {% /multicode %}
@@ -161,12 +155,12 @@ const result = await databases.upsertDocuments(
     '[COLLECTION_ID]',
     [
         {
-            documentId: sdk.ID.unique(),
-            data: { name: 'New Document 1' }
+            $id: sdk.ID.unique(),
+            name: 'New Document 1'
         },
         {
-            documentId: 'document-id-2', // Existing document ID
-            data: { name: 'New Document 2' }
+            $id: 'document-id-2', // Existing document ID
+            name: 'New Document 2'
         }
     ]
 );
@@ -175,6 +169,7 @@ const result = await databases.upsertDocuments(
 ```server-python
 from appwrite.client import Client
 from appwrite.services.databases import Databases
+from appwrite.id import ID
 
 client = Client()
 client.set_endpoint('https://<REGION>.cloud.appwrite.io/v1')
@@ -188,12 +183,12 @@ result = databases.upsert_documents(
     collection_id = '<COLLECTION_ID>',
     documents = [
         {
-            'documentId': appwrite.ID.unique(),
-            'data': { 'name': 'Document 1' }
+            '$id': ID.unique(),
+            'name': 'New Document 1'
         },
         {
-            'documentId': 'document-id-2',  # Existing document ID
-            'data': { 'name': 'New Document 2' }
+            '$id': 'document-id-2',  # Existing document ID
+            'name': 'New Document 2'
         }
     ]
 )
@@ -223,13 +218,16 @@ const databases = new sdk.Databases(client);
 const result = await databases.deleteDocuments(
     '<DATABASE_ID>',
     '[COLLECTION_ID]',
-    [] // Queries
+    [
+        sdk.Query.equal('status', 'archived')
+    ]
 );
 ```
 
 ```server-python
 from appwrite.client import Client
 from appwrite.services.databases import Databases
+from appwrite.query import Query
 
 client = Client()
 client.set_endpoint('https://<REGION>.cloud.appwrite.io/v1')
@@ -241,7 +239,9 @@ databases = Databases(client)
 result = databases.delete_documents(
     database_id = '<DATABASE_ID>',
     collection_id = '<COLLECTION_ID>',
-    queries = []
+    queries = [
+        Query.equal('status', 'archived')
+    ]
 )
 ```
 {% /multicode %}


### PR DESCRIPTION
## What does this PR do?
Corrects bulk operations API syntax and examples
- Fix updateDocuments to use data + queries instead of document objects
- Change documentId to $id in createDocuments and upsertDocuments
- Remove nested data structure for flat document objects
- Add realistic query examples for deleteDocuments

## Test Plan
- `/docs/products/databases/bulk-operations`

## Related PRs and Issues
DRL-1560