### PR TITLE
feat: fix blog TOC sidebar height & visibility Closes #2160

### DIFF
--- a/src/lib/components/blog/table-of-contents.svelte
+++ b/src/lib/components/blog/table-of-contents.svelte
@@ -40,7 +40,7 @@
     >
     <div class="relative">
         <ul
-            class="mask text-caption flex max-h-[600px] flex-col gap-4 overflow-scroll pb-11 [scrollbar-width:none]"
+            class="mask text-caption flex max-h-[700px] flex-col gap-4 overflow-scroll pb-11 [scrollbar-width:none]"
         >
             {#each toc as parent (parent.href)}
                 <li


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?
This PR resolve issue: #2160 from the "On this page" blog sidebar (table of contents) and adjusts the overflow behavior. Previously, long tables of contents were cut off, hiding headings and making the sidebar look broken. The fix allows the sidebar to expand & visible as per needed, ensuring all headings are accessible.

## Updated:


https://github.com/user-attachments/assets/4ed9a9eb-f903-4150-8deb-8b59dbffd4ea




## Test Plan
- Run the website locally using `pnpm run dev`

## Related PRs and Issues
Closes #2160


### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes