### PR TITLE
Update order documentation to include $sequence field for numeric ordering

### DIFF
--- a/src/routes/docs/products/databases/order/+page.markdoc
+++ b/src/routes/docs/products/databases/order/+page.markdoc
@@ -4,12 +4,12 @@ title: Order
 description: Understand how to do data ordering in Appwrite Databases. Learn how to order and sort your database records for efficient data retrieval."
 ---
 
-You can order results returned by Appwrite Databases by using an order query. 
+You can order results returned by Appwrite Databases by using an order query.
 For best performance, create an [index](/docs/products/databases/collections#indexes) on the column you plan to order by.
 
 # Ordering one column {% #one-column %}
 
-When querying using the [listDocuments](/docs/references/cloud/client-web/databases#listDocuments) endpoint, 
+When querying using the [listDocuments](/docs/references/cloud/client-web/databases#listDocuments) endpoint,
 you can specify the order of the documents returned using the `Query.orderAsc()` and `Query.orderDesc()` query methods.
 
 {% multicode %}
@@ -214,3 +214,125 @@ query {
 }
 ```
 {% /multicode %}
+
+# Ordering by sequence {% #sequence-ordering %}
+
+For numeric ordering based on insertion order, you can use the `$sequence` field, which Appwrite automatically adds to all documents. This field increments with each new insert.
+
+{% multicode %}
+```client-web
+import { Client, Databases, Query } from "appwrite";
+
+const client = new Client()
+    .setEndpoint('https://<REGION>.cloud.appwrite.io/v1')
+    .setProject('<PROJECT_ID>');
+
+const databases = new Databases(client);
+
+databases.listDocuments(
+    '<DATABASE_ID>',
+    '[COLLECTION_ID]',
+    [
+        Query.orderAsc('$sequence'),
+    ]
+);
+```
+
+```client-flutter
+import 'package:appwrite/appwrite.dart';
+
+void main() async {
+    final client = Client()
+        .setEndpoint('https://<REGION>.cloud.appwrite.io/v1')
+        .setProject('<PROJECT_ID>');
+
+    final databases = Databases(client);
+
+    try {
+        final documents = await databases.listDocuments(
+            databaseId: '<DATABASE_ID>',
+            collectionId: '[COLLECTION_ID]',
+            queries: [
+                Query.orderAsc('\$sequence')
+            ]
+        );
+    } on AppwriteException catch(e) {
+        print(e);
+    }
+}
+```
+
+```client-apple
+import Appwrite
+import AppwriteModels
+
+func main() async throws {
+    let client = Client()
+        .setEndpoint("https://<REGION>.cloud.appwrite.io/v1")
+        .setProject("<PROJECT_ID>")
+
+    let databases = Databases(client)
+
+    do {
+        let documents = try await databases.listDocuments(
+            databaseId: "<DATABASE_ID>",
+            collectionId: "[COLLECTION_ID]",
+            queries: [
+                Query.orderAsc("$sequence")
+            ]
+        )
+    } catch {
+        print(error.localizedDescription)
+    }
+}
+```
+
+```client-android-kotlin
+import io.appwrite.Client
+import io.appwrite.Query
+import io.appwrite.services.Databases
+
+suspend fun main() {
+    val client = Client(applicationContext)
+        .setEndpoint("https://<REGION>.cloud.appwrite.io/v1")
+        .setProject("<PROJECT_ID>")
+
+    val databases = Databases(client)
+
+    try {
+        val documents = databases.listDocuments(
+            databaseId = "<DATABASE_ID>",
+            collectionId = "[COLLECTION_ID]",
+            queries = listOf(
+                Query.orderAsc("\$sequence")
+            )
+        )
+    } catch (e: AppwriteException) {
+        Log.e("Appwrite", e.message)
+    }
+}
+```
+
+```graphql
+query {
+    databasesListDocuments(
+        databaseId: "<DATABASE_ID>",
+        collectionId: "<COLLECTION_ID>"
+        queries: ["orderAsc(\"$sequence\")"]
+    ) {
+        total
+        documents {
+            _id
+            data
+        }
+    }
+}
+```
+{% /multicode %}
+
+The `$sequence` field is useful when you need:
+- Consistent ordering for pagination, especially with high-frequency inserts
+- Reliable insertion order tracking when timestamps might not be precise enough
+- Simple numeric ordering without managing custom counter fields
+
+[Learn more about system-generated fields](/docs/products/databases/documents#system-generated-fields)


### PR DESCRIPTION
## What does this PR do?
Updates order documentation to include `$sequence` field

## Test Plan
- `/docs/products/databases/order`

## Related PRs and Issues
DRL-1457