### PR TITLE
feat:added a line in free pricing component

### DIFF
--- a/src/routes/pricing/+page.svelte
+++ b/src/routes/pricing/+page.svelte
@@ -141,7 +141,9 @@
                                                     >
                                                 </li>
                                             </ul>
-
+                                            <hr
+                                                class="mt-6 mb-3 border-t border-gray-600 opacity-12"
+                                            />
                                             <p class="text-caption text-secondary font-small mt-4">
                                                 Limit of two projects. Never paused
                                             </p>

--- a/src/routes/pricing/+page.svelte
+++ b/src/routes/pricing/+page.svelte
@@ -145,7 +145,8 @@
                                                 class="mt-6 mb-3 border-t border-gray-600 opacity-12"
                                             />
                                             <p class="text-caption text-secondary font-small mt-4">
-                                                Limit of two projects. Never paused
+                                                Limit of two projects.<br />
+                                                Never paused.
                                             </p>
                                         </div>
                                     </div>

--- a/src/routes/pricing/+page.svelte
+++ b/src/routes/pricing/+page.svelte
@@ -141,6 +141,10 @@
                                                     >
                                                 </li>
                                             </ul>
+
+                                            <p class="text-caption text-secondary font-small mt-4">
+                                                Limit of two projects. Never paused
+                                            </p>
                                         </div>
                                     </div>
                                 </article>


### PR DESCRIPTION
### Add pricing page note

This PR adds the following text to the **Free** plan section at the bottom of the pricing page:

After: 
<img width="1879" height="761" alt="image" src="https://github.com/user-attachments/assets/c90e1fe9-073b-4bb3-9a39-46db257bf0ad" />



