### PR TITLE
fix: remove trailing back ticks from some changelogs

### DIFF
--- a/src/routes/changelog/(entries)/2025-07-01.markdoc
+++ b/src/routes/changelog/(entries)/2025-07-01.markdoc
@@ -20,4 +20,4 @@ You can do it all with a simple CSV file.
 {% arrow_link href="/blog/post/announcing-csv-imports" %}
 Read the announcement to learn more
 {% /arrow_link %}
-`
+

--- a/src/routes/changelog/(entries)/2025-07-08.markdoc
+++ b/src/routes/changelog/(entries)/2025-07-08.markdoc
@@ -14,4 +14,3 @@ This feature can help reduce the number of network calls and allow race-free wri
 {% arrow_link href="/blog/post/announcing-database-upsert" %}
 Read the announcement to learn more
 {% /arrow_link %}
-`

--- a/src/routes/changelog/(entries)/2025-07-10.markdoc
+++ b/src/routes/changelog/(entries)/2025-07-10.markdoc
@@ -21,4 +21,4 @@ Available on Appwrite Cloud Pro and Scale plan, and self-hosted.
 {% arrow_link href="/blog/post/announcing-encrypted-string-attributes" %}
 Read the announcement to learn more
 {% /arrow_link %}
-`
+


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

remove backticks

## Test Plan
before:
<img width="369" height="141" alt="Screenshot 2025-07-18 at 1 31 46 PM" src="https://github.com/user-attachments/assets/bc1885f3-1815-4abb-ae5a-90206b16918e" />

## Related PRs and Issues

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes.