### PR TITLE
Fix(carousel): Simplify scrolling logic to fix arrow buttons

### DIFF
--- a/src/lib/components/Carousel.svelte
+++ b/src/lib/components/Carousel.svelte
@@ -14,15 +14,15 @@
 
     function next() {
         carousel.scrollBy({
-			left: carousel.clientWidth,
-			behavior: 'smooth'
-		});
+            left: carousel.clientWidth,
+            behavior: 'smooth'
+        });
     }
     function prev() {
         carousel.scrollBy({
-			left: -carousel.clientWidth,
-			behavior: 'smooth'
-		});
+            left: -carousel.clientWidth,
+            behavior: 'smooth'
+        });
     }
 
     let isEnd = $state(false);

--- a/src/lib/components/Carousel.svelte
+++ b/src/lib/components/Carousel.svelte
@@ -11,33 +11,18 @@
     }
 
     const { size = 'default', gap = 32, header, children }: Props = $props();
-    let scroll = 0;
-
-    function calculateScrollAmount(prev = false) {
-        const direction = prev ? -1 : 1;
-        const carouselSize = carousel?.clientWidth;
-        const childSize = (carousel.childNodes[0] as HTMLUListElement)?.clientWidth + gap;
-
-        scroll = scroll || carouselSize;
-
-        const numberOfItems = Math.floor(carouselSize / childSize);
-        const overflow = scroll % childSize;
-        const amount = numberOfItems * childSize - overflow * direction;
-        scroll += amount * direction;
-        return amount * direction;
-    }
 
     function next() {
         carousel.scrollBy({
-            left: calculateScrollAmount(),
-            behavior: 'smooth'
-        });
+			left: carousel.clientWidth,
+			behavior: 'smooth'
+		});
     }
     function prev() {
         carousel.scrollBy({
-            left: calculateScrollAmount(true),
-            behavior: 'smooth'
-        });
+			left: -carousel.clientWidth,
+			behavior: 'smooth'
+		});
     }
 
     let isEnd = $state(false);


### PR DESCRIPTION
### Description of the Change

This pull request fixes a bug in the `Carousel.svelte` component where the arrow buttons were not working correctly.

The original implementation used complex and unreliable state management to calculate the scroll distance. This fix simplifies the logic entirely by removing the manual scroll tracking and using a direct `carousel.scrollBy({ left: carousel.clientWidth })` call. This approach is more robust, simpler to maintain, and ensures the carousel scrolls as expected.

### Local Build Environment

The contribution guide asks to run `pnpm run build` before submitting. Unfortunately, I was unable to get a successful build on my local Windows machine due to a persistent `EMFILE: too many open files` error, which is a known OS limitation with very large projects. I have made several attempts to resolve it (memory increase, clean installs) without success.

As this change is a small, self-contained UI fix to a single component, I am confident it will not break the production build, which will be verified by the CI pipeline.

### How to Test

1.  Navigate to the `/docs` page.
2.  Scroll down to the "Show me some code" section.
3.  Click the right arrow button on the carousel.
4.  **Expected behavior:** The carousel smoothly slides to the next set of cards.
5.  Click the left arrow button.
6.  **Expected behavior:** The carousel smoothly slides back.

### Contributor Checklist

- [x] I have read the [Documentation Contributing Guide](https://github.com/appwrite/website/blob/main/STYLE.md).
- [x] I was unable to complete the `pnpm run build` step due to a local environment issue (`EMFILE`). I am relying on the CI to validate the build.
- [x] My branch is up-to-date with the `main` branch of `appwrite/website`.