### PR TITLE
fix: handle base64 decoding properly in code preview components on function page

### DIFF
--- a/src/routes/products/functions/(components)/Languages.svelte
+++ b/src/routes/products/functions/(components)/Languages.svelte
@@ -2,17 +2,17 @@
     import { Button } from '$lib/components/ui';
     import { Platform } from '$lib/utils/references';
     import MultiCodeContextless from '$routes/products/messaging/(components)/MultiCodeContextless.svelte';
-    import SnippetNodejs from './(snippets)/nodejs.txt';
-    import SnippetPhp from './(snippets)/php.txt';
-    import SnippetPython from './(snippets)/python.txt';
-    import SnippetRuby from './(snippets)/ruby.txt';
-    import SnippetDeno from './(snippets)/deno.txt';
-    import SnippetGo from './(snippets)/go.txt';
-    import SnippetDart from './(snippets)/dart.txt';
-    import SnippetKotlin from './(snippets)/kotlin.txt';
-    import SnippetJava from './(snippets)/java.txt';
-    import SnippetSwift from './(snippets)/swift.txt';
-    import SnippetCsharp from './(snippets)/csharp.txt';
+    import SnippetNodejs from './(snippets)/nodejs.txt?raw';
+    import SnippetPhp from './(snippets)/php.txt?raw';
+    import SnippetPython from './(snippets)/python.txt?raw';
+    import SnippetRuby from './(snippets)/ruby.txt?raw';
+    import SnippetDeno from './(snippets)/deno.txt?raw';
+    import SnippetGo from './(snippets)/go.txt?raw';
+    import SnippetDart from './(snippets)/dart.txt?raw';
+    import SnippetKotlin from './(snippets)/kotlin.txt?raw';
+    import SnippetJava from './(snippets)/java.txt?raw';
+    import SnippetSwift from './(snippets)/swift.txt?raw';
+    import SnippetCsharp from './(snippets)/csharp.txt?raw';
 
     const codeTopic = [
         {

--- a/src/routes/products/messaging/(components)/MultiCodeContextless.svelte
+++ b/src/routes/products/messaging/(components)/MultiCodeContextless.svelte
@@ -10,9 +10,50 @@
     export let width: number | null = null;
     export let height: number | null = null;
 
+    function decodeContent(content: string): string {
+        let decodedContent = content;
+        
+        if (content.startsWith('data:text/plain;base64,')) {
+            try {
+                const base64Content = content.replace('data:text/plain;base64,', '');
+                decodedContent = atob(base64Content);
+            } catch (err) {
+                console.warn('Failed to decode data content:', err);
+                return content;
+            }
+        }
+        
+        if (isBase64(content)) {
+            try {
+                decodedContent = atob(content);
+            } catch (err) {
+                console.warn('Failed to decode base64 content:', err);
+                return content;
+            }
+        }
+        
+        return decodedContent
+            .replace(/\r\n/g, '\n')  
+            .replace(/\r/g, '\n')    
+            .replace(/\n{3,}/g, '\n\n'); 
+    }
+
+    function isBase64(str: string): boolean {
+        if (!str || str.length === 0) return false;
+        try {
+            const decoded = atob(str);
+            const reencoded = btoa(decoded);
+            return reencoded === str;
+        } catch (err) {
+            return false;
+        }
+    }
+
     $: snippets = writable(new Set(data.map((d) => d.language)));
 
-    $: content = data.find((d) => d.language === selected)?.content ?? '';
+    $: rawContent = data.find((d) => d.language === selected)?.content ?? '';
+
+    $: content = decodeContent(rawContent);
 
     $: platform = data.find((d) => d.language === selected)?.platform ?? '';
 


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR fixes issue: #2180  a decoding issue with base64-encoded code snippets in the following components:
- `MultiCodeContextless.svelte`
- `Languages.svelte`

The issue was reported in [Issue #2180](https://github.com/appwrite/appwrite/issues/2180) where the actual content not rendered properly rather base64 content seen.

## Test Plan
- changes are seen locally `pnpm run dev ` & `pnpm run build`

## Update:

https://github.com/user-attachments/assets/0fa344a3-4388-4943-b54c-9d929692f54e



## Related PRs and Issues

Closes #2180 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
Yes