### PR TITLE
feat: decouple support from billing plan

### DIFF
--- a/src/routes/docs/advanced/platform/support-sla/+page.markdoc
+++ b/src/routes/docs/advanced/platform/support-sla/+page.markdoc
@@ -8,7 +8,7 @@ This Support Service Level Agreement ("SLA") describes the support services prov
 
 # Scope
 
-This SLA outlines our commitments for providing support services via email, including response and resolution processes based on issue severity. The specific response times depend on the support tier associated with your subscription: **Pro**, **Scale**, or **Enterprise**.
+This SLA outlines our commitments for providing support services via email, including response and resolution processes based on issue severity. The specific response times depend on the support tier associated with your support plan: **Silver**, **Gold**, or **Platinum**.
 
 # Severity levels
 
@@ -22,7 +22,7 @@ Support issues are categorized into the following severity levels:
 
 # Response time targets
 
-| Severity | Pro | Scale | Enterprise |
+| Severity | Silver | Gold | Platinum |
 | --- | --- | --- | --- |
 | Critical | Unsupported | 1 hour (24/7/365) | 15 minutes (24/7/365) |
 | High | Unsupported | 4 hours (24/7/365) | 1 hour (24/7/365) |
@@ -32,7 +32,7 @@ Support issues are categorized into the following severity levels:
 
 # Business hours and days
 
-Our standard business hours are from **9:00 AM to 5:00 PM Pacific Time**, Monday through Friday, excluding public holidays. Enterprise and Scale customers receive extended support 24/7/365.
+Our standard business hours are from **9:00 AM to 5:00 PM Pacific Time**, Monday through Friday, excluding public holidays. Platinum and Gold support plan customers receive extended support 24/7/365.
 
 # User responsibilities
 

--- a/src/routes/pricing/+page.svelte
+++ b/src/routes/pricing/+page.svelte
@@ -279,7 +279,6 @@
                                                 <li><span>SSO</span></li>
                                                 <li><span>Activity logs</span></li>
                                                 <li><span>Custom backup policies</span></li>
-                                                <li><span>Priority support</span></li>
                                             </ul>
                                         </div>
                                     </div>
@@ -324,8 +323,10 @@
                                             <ul class="web-checked-list-circle">
                                                 <li><span>Uptime SLAs</span></li>
                                                 <li><span>Designated Success Manager</span></li>
-                                                <li><span>24/7 enterprise support</span></li>
-                                                <li><span>Private Slack channel</span></li>
+                                                <li><span>Up to 24/7 support</span></li>
+                                                <li>
+                                                    <span>Option for private Slack channel</span>
+                                                </li>
                                                 <li><span>Volume discounts</span></li>
                                                 <li><span>Log drains</span></li>
                                                 <li><span>90-day log retention</span></li>

--- a/src/routes/pricing/compare-plans.svelte
+++ b/src/routes/pricing/compare-plans.svelte
@@ -515,13 +515,6 @@
                     enterprise: true
                 },
                 {
-                    title: 'Priority',
-                    free: '-',
-                    pro: '-',
-                    scale: 'Custom',
-                    enterprise: 'Custom'
-                },
-                {
                     title: 'SLA',
                     free: '-',
                     pro: '-',

--- a/src/routes/pricing/compare-plans.svelte
+++ b/src/routes/pricing/compare-plans.svelte
@@ -518,22 +518,22 @@
                     title: 'Priority',
                     free: '-',
                     pro: '-',
-                    scale: true,
-                    enterprise: true
+                    scale: 'Custom',
+                    enterprise: 'Custom'
                 },
                 {
                     title: 'SLA',
                     free: '-',
                     pro: '-',
-                    scale: true,
-                    enterprise: true
+                    scale: 'Custom',
+                    enterprise: 'Custom'
                 },
                 {
                     title: 'Private Slack channel',
                     free: '-',
                     pro: '-',
-                    scale: true,
-                    enterprise: true
+                    scale: 'Custom',
+                    enterprise: 'Custom'
                 }
             ]
         }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

There are orgs who are on lower billing plans, but want higher support levels.

There are orgs who are on higher billing plans, but don't care about support.

This change allows us to decouple the two so that customers can get the right support level for their needs, regardless of their billing plan.

## Test Plan

Pricing summary before:

<img width="1236" height="941" alt="image" src="https://github.com/user-attachments/assets/a9136cc7-e712-468e-ad6e-94b7a66f346e" />

Pricing summary after:

<img width="1195" height="951" alt="image" src="https://github.com/user-attachments/assets/e94ae9f0-6bac-4de3-8068-a45b1e2bd94e" />

Support details before:

<img width="1318" height="460" alt="image" src="https://github.com/user-attachments/assets/1895a13f-93f1-49e6-a91c-2edac886a8ab" />

Support details after:

<img width="1192" height="287" alt="image" src="https://github.com/user-attachments/assets/1ac152ec-933c-41dd-b0a1-37e93a173a6c" />

Support SLA before:

<img width="743" height="1028" alt="image" src="https://github.com/user-attachments/assets/714901ac-a999-482e-b968-125a3e8e3dcb" />

Support SLA after:

<img width="702" height="1121" alt="image" src="https://github.com/user-attachments/assets/9cd36bc3-f201-4308-ad4f-7a5f5e1584be" />

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes