### PR TITLE
fix: added raw format

### DIFF
--- a/src/routes/products/auth/(components)/SSR.svelte
+++ b/src/routes/products/auth/(components)/SSR.svelte
@@ -4,11 +4,11 @@
     import { Button } from '$lib/components/ui';
     import { Framework, Platform } from '$lib/utils/references';
     import MultiFrameworkCode from './MultiFrameworkCode.svelte';
-    import SnippetNextJs from './(snippets)/nextjs.txt';
-    import SnippetSvelteKit from './(snippets)/sveltekit.txt';
-    import SnippetAstro from './(snippets)/astro.txt';
-    import SnippetNuxt from './(snippets)/nuxt.txt';
-    import SnippetRemix from './(snippets)/remix.txt';
+    import SnippetNextJs from './(snippets)/nextjs.txt?raw';
+    import SnippetSvelteKit from './(snippets)/sveltekit.txt?raw';
+    import SnippetAstro from './(snippets)/astro.txt?raw';
+    import SnippetNuxt from './(snippets)/nuxt.txt?raw';
+    import SnippetRemix from './(snippets)/remix.txt?raw';
 
     const codeSnippets = [
         {

--- a/src/routes/products/functions/(components)/Languages.svelte
+++ b/src/routes/products/functions/(components)/Languages.svelte
@@ -2,17 +2,17 @@
     import { Button } from '$lib/components/ui';
     import { Platform } from '$lib/utils/references';
     import MultiCodeContextless from '$routes/products/messaging/(components)/MultiCodeContextless.svelte';
-    import SnippetNodejs from './(snippets)/nodejs.txt';
-    import SnippetPhp from './(snippets)/php.txt';
-    import SnippetPython from './(snippets)/python.txt';
-    import SnippetRuby from './(snippets)/ruby.txt';
-    import SnippetDeno from './(snippets)/deno.txt';
-    import SnippetGo from './(snippets)/go.txt';
-    import SnippetDart from './(snippets)/dart.txt';
-    import SnippetKotlin from './(snippets)/kotlin.txt';
-    import SnippetJava from './(snippets)/java.txt';
-    import SnippetSwift from './(snippets)/swift.txt';
-    import SnippetCsharp from './(snippets)/csharp.txt';
+    import SnippetNodejs from './(snippets)/nodejs.txt?raw';
+    import SnippetPhp from './(snippets)/php.txt?raw';
+    import SnippetPython from './(snippets)/python.txt?raw';
+    import SnippetRuby from './(snippets)/ruby.txt?raw';
+    import SnippetDeno from './(snippets)/deno.txt?raw';
+    import SnippetGo from './(snippets)/go.txt?raw';
+    import SnippetDart from './(snippets)/dart.txt?raw';
+    import SnippetKotlin from './(snippets)/kotlin.txt?raw';
+    import SnippetJava from './(snippets)/java.txt?raw';
+    import SnippetSwift from './(snippets)/swift.txt?raw';
+    import SnippetCsharp from './(snippets)/csharp.txt?raw';
 
     const codeTopic = [
         {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixed an issue where SSR code snippets were displayed as base64 strings instead of readable code.
Updated the snippet renderer to decode and render proper code blocks.
Now users can view correct SSR examples for frameworks like Next.js.

## Test Plan

<img width="1804" height="830" alt="image" src="https://github.com/user-attachments/assets/5c67acfa-da87-4288-b9c3-2dd67d96ff30" />
<img width="1608" height="779" alt="image" src="https://github.com/user-attachments/assets/ac28dce8-9f5b-4e7c-82d6-f47bcc41cb1c" />


## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
yes