### PR TITLE
fix: improve contact form validation to prevent whitespace-only inputs (#2234)

### DIFF
--- a/src/routes/contact-us/+page.svelte
+++ b/src/routes/contact-us/+page.svelte
@@ -21,6 +21,39 @@
 
     async function handleSubmit() {
         error = undefined;
+
+        const trimmedFirstName = firstName.trim();
+        const trimmedEmail = email.trim();
+        const trimmedSubject = subject.trim();
+        const trimmedMessage = message.trim();
+
+        const validationRules = {
+            required: [
+                { value: trimmedFirstName, name: 'Name' },
+                { value: trimmedEmail, name: 'Email' },
+                { value: trimmedSubject, name: 'Subject' },
+                { value: trimmedMessage, name: 'Message' }
+            ],
+            textOnly: [
+                { value: trimmedFirstName, name: 'Name' },
+                { value: trimmedSubject, name: 'Subject' }
+            ]
+        };
+
+        for (const field of validationRules.required) {
+            if (!field.value) {
+                error = `${field.name} cannot be empty or contain only spaces.`;
+                return;
+            }
+        }
+
+        for (const field of validationRules.textOnly) {
+            if (!/\D/.test(field.value)) {
+                error = `${field.name} cannot contain only numbers.`;
+                return;
+            }
+        }
+
         submitting = true;
 
         const response = await fetch(`${PUBLIC_GROWTH_ENDPOINT}/feedback`, {
@@ -29,10 +62,10 @@
                 'Content-Type': 'application/json'
             },
             body: JSON.stringify({
-                email,
-                firstName,
-                subject,
-                message,
+                email: trimmedEmail,
+                firstName: trimmedFirstName,
+                subject: trimmedSubject,
+                message: trimmedMessage,
                 ...getReferrerAndUtmSource()
             })
         });


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR Fixes issue: #2234 ,basically improves the form validation on the `/contact-us` page. Previously, the form allowed users to submit fields with only whitespace `(e.g., "     ") and numeric data` which could lead to inconsistent submissions.

## Update


<img width="1907" height="820" alt="Screenshot 2025-08-02 161526" src="https://github.com/user-attachments/assets/3c80c777-d3fa-4faf-9eee-5ca2d930fefd" />


## Test Plan

- Manually tested the form by submitting valid and invalid inputs


## Related PRs and Issues

Closes #2234


### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes