### PR TITLE
docs: update React Native storage methods to reflect current SDK behaviour

### DIFF
--- a/src/routes/docs/products/storage/images/+page.markdoc
+++ b/src/routes/docs/products/storage/images/+page.markdoc
@@ -191,7 +191,7 @@ const client = new Client()
 
 const storage = new Storage(client);
 
-// Get image with transformations (downloads actual image data)
+// Get image with transformations (downloads image data)
 const result = await storage.getFilePreview(
     'photos',           // bucket ID
     'sunset.png',       // file ID

--- a/src/routes/docs/products/storage/images/+page.markdoc
+++ b/src/routes/docs/products/storage/images/+page.markdoc
@@ -191,8 +191,8 @@ const client = new Client()
 
 const storage = new Storage(client);
 
-// Get image with transformations
-const result = storage.getFilePreview(
+// Get image with transformations (downloads actual image data)
+const result = await storage.getFilePreview(
     'photos',           // bucket ID
     'sunset.png',       // file ID
     1800,               // width, will be resized using this value
@@ -208,12 +208,31 @@ const result = storage.getFilePreview(
     'jpg'               // output jpg format
 );
 
-console.log(result); // Resource URL
+console.log(result); // ArrayBuffer with image data
+
+// To get just the URL without downloading:
+const imageUrl = storage.getFilePreviewURL(
+    'photos',           // bucket ID
+    'sunset.png',       // file ID
+    1800,               // width, will be resized using this value
+    0,                  // height, ignored when 0
+    ImageGravity.Center,// crop center
+    90,                 // slight compression
+    5,                  // border width
+    'CDCA30',           // border color
+    15,                 // border radius
+    1,                  // full opacity
+    0,                  // no rotation
+    'FFFFFF',           // background color
+    'jpg'               // output jpg format
+);
+
+console.log(imageUrl); // URL object
 
 // Usage in a component
 const ImagePreview = () => (
     <Image
-        source={{ uri: result.toString() }}
+        source={{ uri: imageUrl.toString() }}
         style={{ width: 300, height: 200 }}
         resizeMode="contain"
     />

--- a/src/routes/docs/products/storage/upload-download/+page.markdoc
+++ b/src/routes/docs/products/storage/upload-download/+page.markdoc
@@ -611,9 +611,15 @@ const client = new Client()
 
 const storage = new Storage(client);
 
-const result = storage.getFileDownload('<BUCKET_ID>', '<FILE_ID>');
+// Downloads the file data as ArrayBuffer
+const result = await storage.getFileDownload('<BUCKET_ID>', '<FILE_ID>');
 
-console.log(result); // Resource URL
+console.log(result); // ArrayBuffer with file data
+
+// To get just the download URL without downloading:
+const downloadUrl = storage.getFileDownloadURL('<BUCKET_ID>', '<FILE_ID>');
+
+console.log(downloadUrl); // URL object
 ```
 {% /multicode %}
 
@@ -727,7 +733,8 @@ const client = new Client()
 
 const storage = new Storage(client);
 
-const result = storage.getFilePreview(
+// Downloads the preview image data as ArrayBuffer
+const result = await storage.getFilePreview(
     '<BUCKET_ID>',
     '<FILE_ID>',
     200,                    // width
@@ -736,7 +743,19 @@ const result = storage.getFilePreview(
     100                     // quality
 );
 
-console.log(result); // Resource URL
+console.log(result); // ArrayBuffer with image data
+
+// To get just the preview URL without downloading:
+const previewUrl = storage.getFilePreviewURL(
+    '<BUCKET_ID>',
+    '<FILE_ID>',
+    200,                    // width
+    200,                    // height
+    ImageGravity.Center,    // gravity
+    100                     // quality
+);
+
+console.log(previewUrl); // URL object
 ```
 {% /multicode %}
 
@@ -851,8 +870,14 @@ const client = new Client()
 
 const storage = new Storage(client);
 
-const result = storage.getFileView('<BUCKET_ID>', '<FILE_ID>');
+// Downloads the file data as ArrayBuffer
+const result = await storage.getFileView('<BUCKET_ID>', '<FILE_ID>');
 
-console.log(result); // Resource URL
+console.log(result); // ArrayBuffer with file data
+
+// To get just the view URL without downloading:
+const viewUrl = storage.getFileViewURL('<BUCKET_ID>', '<FILE_ID>');
+
+console.log(viewUrl); // URL object
 ```
 {% /multicode %}


### PR DESCRIPTION
## What does this PR do?

- Update getFileDownload/getFileView/getFilePreview to show they return ArrayBuffer.
- Add examples for URL-only methods: getFileDownloadURL/getFileViewURL/getFilePreviewURL.

## Related PRs and Issues
- DRL-1588