### PR TITLE
doc fix: correct InputFile import path in Node.js examples

### DIFF
--- a/src/routes/docs/products/ai/integrations/elevenlabs/+page.markdoc
+++ b/src/routes/docs/products/ai/integrations/elevenlabs/+page.markdoc
@@ -201,7 +201,8 @@ Add methods necessary to integrate with the ElevenLabs API:
 Import `fetch`, and the required features from the Appwrite Node.js SDK at the top of the `main.js` file
 
 ```js
-import { Client, Storage, ID, InputFile, Permission, Role } from "node-appwrite";
+import { Client, Storage, ID, Permission, Role } from "node-appwrite";
+import { InputFile } from "node-appwrite/file";
 import { fetch } from "undici";
 ```
 

--- a/src/routes/docs/products/ai/integrations/lmnt/+page.markdoc
+++ b/src/routes/docs/products/ai/integrations/lmnt/+page.markdoc
@@ -209,7 +209,8 @@ Next, you'll add the methods necessary to integrate with the LMNT API.
 Import the `Speech` class from `lmnt-node`, and the required features from the Appwrite Node.js SDK at the top of the `main.js` file.
 
 ```js
-import { Client, Storage, ID, InputFile, Permission, Role } from "node-appwrite";
+import { Client, Storage, ID, Permission, Role } from "node-appwrite";
+import { InputFile } from "node-appwrite/file";
 import Speech from 'lmnt-node';
 ```
 

--- a/src/routes/docs/products/ai/integrations/togetherai/+page.markdoc
+++ b/src/routes/docs/products/ai/integrations/togetherai/+page.markdoc
@@ -196,7 +196,8 @@ Now that you're serving a basic HTML page add methods necessary to integrate wit
 
 ```js
 import { fetch } from 'undici'
-import { Client, ID, InputFile, Storage } from 'node-appwrite';
+import { Client, ID, Storage } from 'node-appwrite';
+import { InputFile } from 'node-appwrite/file';
 ```
 
 To handle the `POST` request, add the following code to the end of the request handler in the `src/main.js` file to validate the request body and define the models:

--- a/src/routes/docs/products/ai/tutorials/music-generation/+page.markdoc
+++ b/src/routes/docs/products/ai/tutorials/music-generation/+page.markdoc
@@ -51,7 +51,10 @@ To make this easier, create a service class that will handle all the Appwrite in
 Create a file called `src/appwrite.js` and implement the following class:
 
 ```js
-import { Client, ID, InputFile, Storage } from 'node-appwrite';
+```js
+import { Client, ID, Storage } from 'node-appwrite';
+import { InputFile } from 'node-appwrite/file';
+```
 
 class AppwriteService {
   constructor() {

--- a/src/routes/docs/products/ai/tutorials/text-to-speech/+page.markdoc
+++ b/src/routes/docs/products/ai/tutorials/text-to-speech/+page.markdoc
@@ -51,7 +51,10 @@ To make this easier, create a service class that will handle all the Appwrite in
 Create a file called `src/appwrite.js` and implement the following class:
 
 ```js
-import { Client, ID, InputFile, Storage } from 'node-appwrite';
+```js
+import { Client, ID, Storage } from 'node-appwrite';
+import { InputFile } from 'node-appwrite/file';
+```
 
 class AppwriteService {
   constructor() {


### PR DESCRIPTION
## What does this PR do?
- Updates import statements from 'node-appwrite' to 'node-appwrite/file' for InputFile in AI integration tutorials and examples

## Related PRs and Issues
DRL-1589