### PR TITLE
docs: add upsert event to databases documentation

### DIFF
--- a/src/partials/databases-events.md
+++ b/src/partials/databases-events.md
@@ -71,6 +71,12 @@
 
 ---
 
+- `databases.*.collections.*.documents.*.upsert`
+- This event triggers when a document is upserted.
+  Returns [Document Object](/docs/references/cloud/models/document)
+
+---
+
 - `databases.*.collections.*.indexes.*`
 - This event triggers on any indexes event.
   Returns [Index Object](/docs/references/cloud/models/index)

--- a/src/routes/docs/advanced/platform/events/+page.markdoc
+++ b/src/routes/docs/advanced/platform/events/+page.markdoc
@@ -9,7 +9,7 @@ A event will fire when a change occurs in your Appwrite project, like when a new
 You can subscribe to these events with Appwrite [Functions](/docs/products/functions), [Realtime](/docs/apis/realtime), or [Webhooks](/docs/advanced/platform/webhooks).
 
 You can subscribe to events for specific resources using their ID or subscribe to changes of all resources of the same type by using a wildcard character * instead of an ID.
-You can also filter for events of specific actions like create, update, or delete.
+You can also filter for events of specific actions like create, update, upsert, or delete.
 
 
 You can find a list of events for Storage, Databases, Functions, and Authentication services below.

--- a/src/routes/docs/products/databases/documents/+page.markdoc
+++ b/src/routes/docs/products/databases/documents/+page.markdoc
@@ -654,7 +654,7 @@ Users only need to be granted access at either the collection or document level 
 
 # Bulk operations {% #bulk-operations %}
 
-In Appwrite, you can perform bulk operations on documents within a collection. This allows you to create, update, or delete multiple documents in a single request.
+In Appwrite, you can perform bulk operations on documents within a collection. This allows you to create, update, upsert, or delete multiple documents in a single request.
 
 As of now, bulk operations can only be performed via the server-side SDKs. The client-side SDKs do not support bulk operations.
 


### PR DESCRIPTION
## What does this PR do?
Adds upsert event to databases documentation

- Add databases.*.collections.*.documents.*.upsert event to events list
- Update bulk operations description to include upsert
- Update events intro to mention upsert