### PR TITLE
refactor(svelte): migrate component props to Svelte 5 syntax

### DIFF
--- a/src/routes/docs/tutorials/sveltekit/step-7/+page.markdoc
+++ b/src/routes/docs/tutorials/sveltekit/step-7/+page.markdoc
@@ -29,7 +29,7 @@ Simple as that! Now, let's create the page itself. Replace the contents in `src/
 	import { addIdea, deleteIdea } from '$lib/ideas.js';
 	import { user } from '$lib/user.js';
 
-	export let data;
+	let { data } = $props();
 
 	const add = async (e) => {
 		e.preventDefault();


### PR DESCRIPTION
### Summary
This PR updates components to use the new Svelte 5 syntax for handling props.

### Changes
- Replaced the old Svelte 4 style:
  ```svelte
  export let data;
```
- With the new Svelte 5 destructured props syntax:
 ```svelte
let { data } = $props();
```

## Why

Svelte 5 introduces a new $props() API for working with props, replacing the export let ... syntax used in Svelte 4.
This migration ensures the codebase is compatible with Svelte 5 and avoids deprecated syntax.

Additional Notes

No functional logic was changed — only syntax was updated.

All components now follow Svelte 5 standards for prop definitions
