### PR TITLE
Add SFO to our map

### DIFF
--- a/src/lib/components/appwrite-network/data/pins.ts
+++ b/src/lib/components/appwrite-network/data/pins.ts
@@ -588,7 +588,7 @@ export const pins = {
             lng: -122.42,
             city: 'San Francisco',
             code: 'SFO',
-            date: 'Q4 2025'
+            available: true
         },
         {
             lat: 12.97,
@@ -653,7 +653,7 @@ export const pins = {
             lng: -122.42,
             city: 'San Francisco',
             code: 'SFO',
-            date: 'Q4 2025'
+            available: true
         },
         {
             lat: 12.97,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * San Francisco (SFO) is now live and selectable across both Regions and Edges. Previously shown as “Q4 2025,” it now appears as available wherever locations are listed, mapped, or filtered.
  * Availability indicators and badges reflect SFO’s live status for deployment and connectivity.

* **Chores**
  * Updated location metadata to mark SFO as available; no changes to Singapore (SIN).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->