### PR TITLE
Add Refetch to footer

### DIFF
--- a/src/lib/components/FooterNav.svelte
+++ b/src/lib/components/FooterNav.svelte
@@ -61,6 +61,12 @@
                     href: 'https://github.com/appwrite',
                     target: '_blank',
                     rel: 'noopener noreferrer'
+                },
+                {
+                    label: 'Tech news',
+                    href: 'https://refetch.io',
+                    target: '_blank',
+                    rel: 'noopener noreferrer'
                 }
                 // {
                 //     label: 'Status',


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Adds Refetch to the footer under the Learn header

## Test Plan

- Visit the footer on the landing page and click on **Tech news** under the Learn heading.

<img width="1870" height="748" alt="image" src="https://github.com/user-attachments/assets/8860d972-46f0-4aea-acbd-17c392a2e889" />

## Related PRs and Issues

- N/A

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Tech news” link to the footer’s Learn section, directing to https://refetch.io.
  * Opens in a new tab and uses safe rel attributes to prevent tab-nabbing.
  * Placed after the “Source code” item to keep related resources grouped.
  * No other UI or behavioral changes; existing footer links and layout remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->