### PR TITLE
Add Claude Code to docs homepage

### DIFF
--- a/src/redirects.json
+++ b/src/redirects.json
@@ -723,5 +723,9 @@
     {
         "link": "/docs/tooling/mcp/mcp-for-docs",
         "redirect": "/docs/tooling/mcp/docs"
+    },
+    {
+        "link": "/docs/tooling/mcp/claude",
+        "redirect": "/docs/tooling/mcp/claude-desktop"
     }
 ]

--- a/src/routes/docs/+page.svelte
+++ b/src/routes/docs/+page.svelte
@@ -337,16 +337,30 @@
                 <ul class="grid grid-cols-1 gap-8 md:grid-cols-2">
                     <li>
                         <a
-                            href="/docs/tooling/mcp/claude"
+                            href="/docs/tooling/mcp/claude-desktop"
                             class="web-card is-normal flex flex-row! items-center gap-2!"
                             onclick={() => trackEvent(`docs-mcp-click`)}
                         >
                             <img
                                 src="/images/docs/mcp/logos/dark/claude.svg"
-                                alt="Cursor"
+                                alt="Claude"
                                 class="w-6"
                             />
                             <h4 class="text-sub-body text-primary font-medium">Claude Desktop</h4>
+                        </a>
+                    </li>
+                    <li>
+                        <a
+                            href="/docs/tooling/mcp/claude-code"
+                            class="web-card is-normal flex flex-row! items-center gap-2!"
+                            onclick={() => trackEvent(`docs-mcp-click`)}
+                        >
+                            <img
+                                src="/images/docs/mcp/logos/dark/claude.svg"
+                                alt="Claude"
+                                class="w-6"
+                            />
+                            <h4 class="text-sub-body text-primary font-medium">Claude Code</h4>
                         </a>
                     </li>
                     <li>
@@ -371,7 +385,7 @@
                         >
                             <img
                                 src="/images/docs/mcp/logos/dark/windsurf.svg"
-                                alt="Cursor"
+                                alt="Windsurf"
                                 class="w-6"
                             />
                             <h4 class="text-sub-body text-primary font-medium">Windsurf Editor</h4>
@@ -385,7 +399,7 @@
                         >
                             <img
                                 src="/images/docs/mcp/logos/dark/vscode.svg"
-                                alt="Cursor"
+                                alt="VS Code"
                                 class="w-6"
                             />
                             <h4 class="text-sub-body text-primary font-medium">VS Code</h4>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

- Adds Claude Code to docs homepage
- Adds a redirect for the `/docs/tooling/mcp/claude` path to the Claude Desktop docs

## Test Plan

- `pnpm i && pnpm dev`
- Visit `/docs` and scroll down to *Build faster with AI* section

<img width="1748" height="939" alt="image" src="https://github.com/user-attachments/assets/2ef8b198-cfb4-45d6-b27a-5870ffdafb5c" />


## Related PRs and Issues

#2338 
#2365 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added “Claude Code” entry to MCP docs with proper branding.
- Documentation
  - Updated Claude Desktop card to link to /docs/tooling/mcp/claude-desktop.
  - Improved accessibility by correcting alt text for Windsurf and VS Code icons.
- Chores
  - Added redirect from /docs/tooling/mcp/claude to /docs/tooling/mcp/claude-desktop for seamless navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->