### PR TITLE
docs: correct unmatched code block tilde in Go example

### DIFF
--- a/src/routes/docs/products/databases/queries/+page.markdoc
+++ b/src/routes/docs/products/databases/queries/+page.markdoc
@@ -1835,6 +1835,7 @@ results = tablesDB.list_rows(
     ]
 )
 ```
+```go
 rows, err := tablesDB.ListRows(
     "<DATABASE_ID>",
     "<TABLE_ID>",


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

It fixes markdown code block tilde which was unmatched for 'Go' example which showed it without selecting the 'Go' from dropdown


<img width="906" height="905" alt="Screenshot 2025-09-13 154940" src="https://github.com/user-attachments/assets/0f094d98-9fc5-427f-81f8-39a1f843aa28" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Go code example for Complex queries in TablesDB docs, demonstrating nested OR/AND logic in a single ListRows call: (category == "books" AND price < 20) OR (category == "magazines" AND price < 10). Aligns with existing language samples and includes basic error handling to help Go developers implement advanced filtering patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->