### PR TITLE
docs: correct unmatched code fence in Go example

### DIFF
--- a/src/routes/docs/products/databases/queries/+page.markdoc
+++ b/src/routes/docs/products/databases/queries/+page.markdoc
@@ -1835,6 +1835,7 @@ results = tablesDB.list_rows(
     ]
 )
 ```
+```go
 rows, err := tablesDB.ListRows(
     "<DATABASE_ID>",
     "<TABLE_ID>",


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

It fixes markdown code block tilde which was unmatched for 'Go' example in [complex queries](https://appwrite.io/docs/products/databases/queries#complex-queries) which showed it without selecting 'Go' from dropdown.


<img width="906" height="905" alt="Screenshot 2025-09-13 154940" src="https://github.com/user-attachments/assets/0f094d98-9fc5-427f-81f8-39a1f843aa28" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Complex queries section with Go examples demonstrating nested logical operators (AND/OR) for filtering.
  * Added a basic ListRows Go snippet to illustrate call structure and parameters.
  * Included a full Go example using WithListRowsQueries to combine conditions (e.g., category and price) with proper error handling.
  * Aligns Go samples with existing language examples to improve cross-language clarity for complex query construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->