### PR TITLE
Remove sites hackathon banner

### DIFF
--- a/src/lib/layouts/Main.svelte
+++ b/src/lib/layouts/Main.svelte
@@ -22,7 +22,6 @@
     import { getAppwriteDashboardUrl } from '$lib/utils/dashboard';
     import { Button, Icon, InlineTag } from '$lib/components/ui';
     import AnnouncementBanner from '$routes/(init)/init/(components)/announcement-banner.svelte';
-    import HackathonBanner from '$routes/(marketing)/(components)/(sites-hackathon)/hackathon-banner.svelte';
 
     export let omitMainId = false;
     let theme: 'light' | 'dark' | null = 'dark';
@@ -152,6 +151,7 @@
 </script>
 
 <div class="relative contents h-full">
+    <!--
     {#if !page.url.pathname.includes('/init')}
         <div class="border-smooth relative z-10 border-b bg-[#19191C]">
             <div class="is-special-padding mx-auto">
@@ -159,6 +159,7 @@
             </div>
         </div>
     {/if}
+    -->
 
     <section
         class="web-mobile-header flex! lg:hidden! {resolvedTheme}"


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Removes the sites hackathon banner from the landing page

## Test Plan

View the website index page

### Local Test

<img width="2557" height="1296" alt="image" src="https://github.com/user-attachments/assets/546b844c-344e-4176-bf20-ab495e632a91" />

## Related PRs and Issues

#2342

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Disabled the Hackathon banner in the main layout; the banner no longer appears across pages.
  - No impact on navigation or core functionality; overall UI remains unchanged aside from banner removal.
  - No changes to user data, preferences, or performance expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->