### PR TITLE
Update collections to tables in CLI sidebar

### DIFF
--- a/src/routes/docs/tooling/command-line/+layout.svelte
+++ b/src/routes/docs/tooling/command-line/+layout.svelte
@@ -29,8 +29,8 @@
             label: 'Deployments',
             items: [
                 {
-                    label: 'Collections',
-                    href: '/docs/tooling/command-line/collections'
+                    label: 'Tables',
+                    href: '/docs/tooling/command-line/tables'
                 },
                 {
                     label: 'Functions',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated command-line documentation navigation: replaced the “Collections” item with “Tables” in the Deployments section, linking to /docs/tooling/command-line/tables.
  * Improves clarity and discoverability of the relevant docs; no changes to CLI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->