### PR TITLE
docs: fix broken images to claude mcp

### DIFF
--- a/src/routes/integrations/mcp-claude/+page.markdoc
+++ b/src/routes/integrations/mcp-claude/+page.markdoc
@@ -18,8 +18,8 @@ platform:
 images: 
     - /images/integrations/mcp-claude/cover.png
     - /images/integrations/mcp-claude/appwrite-api-key.png
-    - /images/docs/mcp/claude/claude-mcp-tools.png
-    - /images/docs/mcp/claude/claude-list-users.png
+    - /images/docs/mcp/claude-desktop/claude-mcp-tools.png
+    - /images/docs/mcp/claude-desktop/claude-list-users.png
 ---
 
 Claude Desktop is a standalone application by Anthropic that allows users to interact with the Claude large language model directly from their Mac or Windows desktops. Designed for convenience and speed, it offers a distraction-free chat experience, supports multiple conversations, and runs natively for faster performance and system integration. Whether you're brainstorming, coding, summarizing documents, or automating workflows, Claude Desktop makes it easy to harness AI assistance without relying on a browser.

--- a/src/routes/integrations/mcp-claude/+page.markdoc
+++ b/src/routes/integrations/mcp-claude/+page.markdoc
@@ -79,7 +79,7 @@ You may have noticed the `--users` argument, which enables Claude Desktop to int
 
 Once you have updated and saved the `claude_desktop_config.json` file, restart Claude Desktop and click on the MCP tools button (at the bottom right section of the prompt input) to view the available MCP tools.
 
-![Claude MCP Tools](/images/docs/mcp/claude/claude-mcp-tools.png)
+![Claude MCP Tools](/images/docs/mcp/claude-desktop/claude-mcp-tools.png)
 
 {% info title="Claude Code" %}
 If you are using the Claude Code CLI, you can use the following command in your terminal to configure the MCP server in the exact same manner:
@@ -93,7 +93,7 @@ claude mcp add-json appwrite '{"command":"uvx","args":["mcp-server-appwrite","--
 
 Finally, you can test the integration by asking Claude Desktop to list all the users in your Appwrite project.
 
-![Claude Desktop](/images/docs/mcp/claude/claude-list-users.png)
+![Claude Desktop](/images/docs/mcp/claude-desktop/claude-list-users.png)
 
 # Read more about MCP with Claude Desktop
 


### PR DESCRIPTION
Fix 2 broken images on the claude for desktop page

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fix broken images on claude for desktop page

BEFORE:

<img width="616" height="885" alt="image" src="https://github.com/user-attachments/assets/6885cdd9-9176-47bc-adde-32d95b62185e" />


AFTER UPDATE:

<img width="616" height="1000" alt="image" src="https://github.com/user-attachments/assets/9ad14859-45e5-48f8-995d-ff1d875de3c7" />


## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced four screenshots in the Claude MCP integration guide with updated desktop visuals (header and inline images).
  * Corrected image references so screenshots render reliably across the site.
  * No functional changes; content-only refresh to improve accuracy and clarity for readers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->