### PR TITLE
fix: rendering of multi method sdk specs

### DIFF
--- a/src/lib/utils/specs.ts
+++ b/src/lib/utils/specs.ts
@@ -32,6 +32,11 @@ type SDKMethodModel = {
     name: string;
 };
 
+type AppwriteDeprecated = {
+    since: string;
+    replaceWith: string;
+};
+
 type AppwriteOperationObject = OpenAPIV3.OperationObject & {
     'x-appwrite': {
         method: string;
@@ -60,6 +65,7 @@ type AppwriteAdditionalMethod = {
     responses: { code: number; model: string }[];
     description: string;
     demo: string;
+    deprecated?: AppwriteDeprecated;
 };
 
 export type AppwriteSchemaObject = OpenAPIV3.SchemaObject & {
@@ -216,11 +222,16 @@ function* iterateAllMethods(
         ) {
             const appwritePost = methods.post as AppwriteOperationObject;
             for (const additionalMethod of appwritePost['x-appwrite'].methods!) {
+                if (additionalMethod.deprecated) continue;
+
                 yield {
                     method: OpenAPIV3.HttpMethods.POST,
                     value: {
                         ...methods.post,
-                        summary: additionalMethod.desc,
+                        summary:
+                            additionalMethod.desc.length > 0
+                                ? additionalMethod.desc
+                                : methods.post.summary,
                         description: additionalMethod.description,
                         requestBody: filterRequestBodyProperties(
                             methods.post.requestBody,

--- a/src/lib/utils/specs.ts
+++ b/src/lib/utils/specs.ts
@@ -175,6 +175,71 @@ function filterRequestBodyProperties(
     return filteredRequestBody;
 }
 
+/**
+ * Checks if a method has additional methods in x-appwrite.methods
+ */
+function hasAdditionalMethods(
+    method: OpenAPIV3.OperationObject | undefined,
+    service: string
+): method is AppwriteOperationObject {
+    return !!(
+        method?.tags?.includes(service) &&
+        typeof (method as AppwriteOperationObject)['x-appwrite'] === 'object' &&
+        Array.isArray((method as AppwriteOperationObject)['x-appwrite']?.methods)
+    );
+}
+
+/**
+ * Processes additional methods for a given HTTP method and yields the results
+ */
+function* processAdditionalMethods(
+    method: OpenAPIV3.OperationObject,
+    httpMethod: OpenAPIV3.HttpMethods,
+    url: string
+): Generator<{
+    method: OpenAPIV3.HttpMethods;
+    value: OpenAPIV3.OperationObject | AppwriteOperationObject;
+    url: string;
+}> {
+    const appwriteMethod = method as AppwriteOperationObject;
+    const additionalMethods = appwriteMethod['x-appwrite'].methods!;
+
+    for (const additionalMethod of additionalMethods) {
+        if (additionalMethod.deprecated) continue;
+
+        yield {
+            method: httpMethod,
+            value: {
+                ...method,
+                summary: additionalMethod.desc.length > 0 ? additionalMethod.desc : method.summary,
+                description: additionalMethod.description,
+                requestBody: filterRequestBodyProperties(
+                    method.requestBody,
+                    additionalMethod.parameters
+                ),
+                'x-appwrite': {
+                    ...appwriteMethod['x-appwrite'],
+                    method: additionalMethod.name,
+                    demo: additionalMethod.demo
+                },
+                responses: {
+                    ...appwriteMethod.responses,
+                    [additionalMethod.responses[0].code]: {
+                        content: {
+                            'application/json': {
+                                schema: {
+                                    $ref: additionalMethod.responses[0].model
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            url
+        };
+    }
+}
+
 function* iterateAllMethods(
     api: OpenAPIV3.Document,
     service: string
@@ -185,79 +250,45 @@ function* iterateAllMethods(
 }> {
     for (const url in api.paths) {
         const methods = api.paths[url];
-        if (methods?.get?.tags?.includes(service)) {
+
+        // Handle non-additional methods
+        if (methods?.get?.tags?.includes(service) && !hasAdditionalMethods(methods.get, service)) {
             yield { method: OpenAPIV3.HttpMethods.GET, value: methods.get, url };
         }
-        if (methods?.post?.tags?.includes(service)) {
-            // Skip if additional methods are present in [x-appwrite].methods
-            if (
-                methods?.post &&
-                (!('x-appwrite' in methods.post) ||
-                    !methods.post['x-appwrite'] ||
-                    typeof methods.post['x-appwrite'] !== 'object' ||
-                    !('methods' in methods.post['x-appwrite']))
-            ) {
-                yield { method: OpenAPIV3.HttpMethods.POST, value: methods.post, url };
-            }
-        }
-        if (methods?.put?.tags?.includes(service)) {
-            yield { method: OpenAPIV3.HttpMethods.PUT, value: methods.put, url };
-        }
-        if (methods?.patch?.tags?.includes(service)) {
-            yield { method: OpenAPIV3.HttpMethods.PATCH, value: methods.patch, url };
-        }
-        if (methods?.delete?.tags?.includes(service)) {
-            yield {
-                method: OpenAPIV3.HttpMethods.DELETE,
-                value: methods.delete,
-                url
-            };
-        }
-
-        // Check additional methods in [x-appwrite].methods
         if (
             methods?.post?.tags?.includes(service) &&
-            typeof (methods.post as AppwriteOperationObject)['x-appwrite'] === 'object' &&
-            Array.isArray((methods.post as AppwriteOperationObject)['x-appwrite']?.methods)
+            !hasAdditionalMethods(methods.post, service)
         ) {
-            const appwritePost = methods.post as AppwriteOperationObject;
-            for (const additionalMethod of appwritePost['x-appwrite'].methods!) {
-                if (additionalMethod.deprecated) continue;
+            yield { method: OpenAPIV3.HttpMethods.POST, value: methods.post, url };
+        }
+        if (methods?.put?.tags?.includes(service) && !hasAdditionalMethods(methods.put, service)) {
+            yield { method: OpenAPIV3.HttpMethods.PUT, value: methods.put, url };
+        }
+        if (
+            methods?.patch?.tags?.includes(service) &&
+            !hasAdditionalMethods(methods.patch, service)
+        ) {
+            yield { method: OpenAPIV3.HttpMethods.PATCH, value: methods.patch, url };
+        }
+        if (
+            methods?.delete?.tags?.includes(service) &&
+            !hasAdditionalMethods(methods.delete, service)
+        ) {
+            yield { method: OpenAPIV3.HttpMethods.DELETE, value: methods.delete, url };
+        }
 
-                yield {
-                    method: OpenAPIV3.HttpMethods.POST,
-                    value: {
-                        ...methods.post,
-                        summary:
-                            additionalMethod.desc.length > 0
-                                ? additionalMethod.desc
-                                : methods.post.summary,
-                        description: additionalMethod.description,
-                        requestBody: filterRequestBodyProperties(
-                            methods.post.requestBody,
-                            additionalMethod.parameters
-                        ),
-                        'x-appwrite': {
-                            ...appwritePost['x-appwrite'],
-                            method: additionalMethod.name,
-                            demo: additionalMethod.demo
-                        },
-                        responses: {
-                            ...appwritePost.responses,
-                            [additionalMethod.responses[0].code]: {
-                                content: {
-                                    'application/json': {
-                                        schema: {
-                                            $ref: additionalMethod.responses[0].model
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    url
-                };
-            }
+        // Process additional methods
+        if (hasAdditionalMethods(methods?.get, service)) {
+            yield* processAdditionalMethods(methods.get!, OpenAPIV3.HttpMethods.GET, url);
+        }
+        if (hasAdditionalMethods(methods?.post, service)) {
+            yield* processAdditionalMethods(methods.post!, OpenAPIV3.HttpMethods.POST, url);
+        }
+        if (hasAdditionalMethods(methods?.put, service)) {
+            yield* processAdditionalMethods(methods.put!, OpenAPIV3.HttpMethods.PUT, url);
+        }
+        if (hasAdditionalMethods(methods?.patch, service)) {
+            yield* processAdditionalMethods(methods.patch!, OpenAPIV3.HttpMethods.PATCH, url);
         }
     }
 }

--- a/src/lib/utils/specs.ts
+++ b/src/lib/utils/specs.ts
@@ -224,15 +224,18 @@ function* processAdditionalMethods(
                 },
                 responses: {
                     ...appwriteMethod.responses,
-                    [additionalMethod.responses[0].code]: {
-                        content: {
-                            'application/json': {
-                                schema: {
-                                    $ref: additionalMethod.responses[0].model
-                                }
-                            }
-                        }
-                    }
+                    [additionalMethod.responses[0].code]:
+                        additionalMethod.responses[0].code === 204
+                            ? { description: 'No Content' }
+                            : {
+                                  content: {
+                                      'application/json': {
+                                          schema: {
+                                              $ref: additionalMethod.responses[0].model
+                                          }
+                                      }
+                                  }
+                              }
                 }
             },
             url
@@ -289,6 +292,9 @@ function* iterateAllMethods(
         }
         if (hasAdditionalMethods(methods?.patch, service)) {
             yield* processAdditionalMethods(methods.patch!, OpenAPIV3.HttpMethods.PATCH, url);
+        }
+        if (hasAdditionalMethods(methods?.delete, service)) {
+            yield* processAdditionalMethods(methods.delete!, OpenAPIV3.HttpMethods.DELETE, url);
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

skips deprecated methods loading in case of multi methods + fixes rendering of method name (if `desc` is empty show summary)

## Test Plan
<img width="464" height="789" alt="Screenshot 2025-09-16 at 4 44 15 PM" src="https://github.com/user-attachments/assets/2c2db77e-ee65-4eab-8b68-e90064ebba3b" />

## Related PRs and Issues

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deprecation metadata so deprecated variants are hidden from outputs.
  * Improved handling of alternate/added method variants for GET/POST/PUT/PATCH, with clearer summaries and merged demo/metadata.
  * Responses for added variants now include the primary response model.

* **Bug Fixes**
  * Request bodies for added variants now reflect declared parameters accurately.
  * DELETE variants no longer produce confusing alternate entries when other variants exist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->