### PR TITLE
Add ID import to storage quick start examples

### DIFF
--- a/src/routes/docs/products/storage/quick-start/+page.markdoc
+++ b/src/routes/docs/products/storage/quick-start/+page.markdoc
@@ -39,154 +39,140 @@ To upload a file, add this to your app. For web apps, you can use the File objec
   }, function (error) {
       console.log(error); // Failure
   });
-````
+  ```
 
-```server-nodejs
-const sdk = require('node-appwrite');
-const { InputFile } = require('node-appwrite/file');
-const { ID } = require('node-appwrite');
+  ```server-nodejs
+  const sdk = require('node-appwrite');
+  const { InputFile } = require('node-appwrite/file');
 
-const client = new sdk.Client()
-    .setEndpoint('https://cloud.appwrite.io/v1')
-    .setProject('<PROJECT_ID>')
-    .setKey('<API_KEY>');
+  const client = new sdk.Client()
+      .setEndpoint('https://cloud.appwrite.io/v1')
+      .setProject('<PROJECT_ID>')
+      .setKey('<API_KEY>');
 
-const storage = new sdk.Storage(client);
+  const storage = new sdk.Storage(client);
 
-// If running in a browser environment, you can use File directly
-const browserFile = new File(['hello'], 'hello.txt');
-await storage.createFile({
-  bucketId: '<BUCKET_ID>',
-  fileId: ID.unique(),
-  file: browserFile
-});
-
-// If running in Node.js, use InputFile
-const nodeFile = InputFile.fromPath('/path/to/file.jpg', 'file.jpg');
-await storage.createFile({
-  bucketId: '<BUCKET_ID>',
-  fileId: ID.unique(),
-  file: nodeFile
-});
-```
-
-```client-flutter
-import 'package:appwrite/appwrite.dart';
-
-void main() { // Init SDK
-  final client = Client()
-    .setEndpoint('https://<REGION>.cloud.appwrite.io/v1')
-    .setProject('<PROJECT_ID>');
-
-  final storage = Storage(client);
-
-  final file = await storage.createFile(
+  const nodeFile = InputFile.fromPath('/path/to/file.jpg', 'file.jpg');
+  await storage.createFile({
     bucketId: '<BUCKET_ID>',
-    fileId: ID.unique(),
-    file: InputFile.fromPath(path: './path-to-files/image.jpg', filename: 'image.jpg'),
+    fileId: sdk.ID.unique(),
+    file: nodeFile
+  });
+  ```
+
+  ```client-flutter
+  import 'package:appwrite/appwrite.dart';
+
+  void main() { // Init SDK
+    final client = Client()
+      .setEndpoint('https://<REGION>.cloud.appwrite.io/v1')
+      .setProject('<PROJECT_ID>');
+
+    final storage = Storage(client);
+
+    final file = await storage.createFile(
+      bucketId: '<BUCKET_ID>',
+      fileId: ID.unique(),
+      file: InputFile.fromPath(path: './path-to-files/image.jpg', filename: 'image.jpg'),
+    );
+  }
+  ```
+  ```client-apple
+  import Appwrite
+
+  func main() async throws {
+      let client = Client()
+        .setEndpoint("https://<REGION>.cloud.appwrite.io/v1")
+        .setProject("<PROJECT_ID>")
+
+      let storage = Storage(client)
+
+      let file = try await storage.createFile(
+          bucketId: "<BUCKET_ID>",
+          fileId: ID.unique(),
+          file: InputFile.fromBuffer(yourByteBuffer,
+              filename: "image.jpg",
+              mimeType: "image/jpeg"
+          )
+      )
+  }
+  ```
+  ```client-android-kotlin
+  import io.appwrite.Client
+  import io.appwrite.services.Storage
+
+  suspend fun main() {
+      val client = Client(applicationContext)
+          .setEndpoint("https://<REGION>.cloud.appwrite.io/v1") // Your API Endpoint
+          .setProject("<PROJECT_ID>") // Your project ID
+
+      val storage = Storage(client)
+
+      val file = storage.createFile(
+          bucketId = "<BUCKET_ID>",
+          fileId = ID.unique(),
+          file = File("./path-to-files/image.jpg"),
+      )
+  }
+  ```
+
+  ```client-react-native
+  import { Client, Storage, ID } from 'react-native-appwrite';
+
+  const client = new Client()
+      .setEndpoint('https://<REGION>.cloud.appwrite.io/v1')
+      .setProject('<PROJECT_ID>');
+
+  const storage = new Storage(client);
+
+  const promise = storage.createFile(
+      '<BUCKET_ID>',
+      ID.unique(),
+      {
+          name: 'image.jpg',
+          type: 'image/jpeg',
+          size: 1234567,
+          uri: 'file:///path/to/file.jpg',
+      }
   );
-}
-```
 
-```client-apple
-import Appwrite
+  promise.then(function (response) {
+      console.log(response); // Success
+  }, function (error) {
+      console.log(error); // Failure
+  });
+  ```
 
-func main() async throws {
-    let client = Client()
-      .setEndpoint("https://<REGION>.cloud.appwrite.io/v1")
-      .setProject("<PROJECT_ID>")
+  ```http
+  POST /v1/storage/buckets/{bucketId}/files HTTP/1.1
+  Content-Type: multipart/form-data; boundary="cec8e8123c05ba25"
+  Content-Length: *Length of your entity body in bytes*
+  X-Appwrite-Project: <PROJECT_ID>
 
-    let storage = Storage(client)
+  --cec8e8123c05ba25
+  Content-Disposition: form-data; name="operations"
 
-    let file = try await storage.createFile(
-        bucketId: "<BUCKET_ID>",
-        fileId: ID.unique(),
-        file: InputFile.fromBuffer(yourByteBuffer,
-            filename: "image.jpg",
-            mimeType: "image/jpeg"
-        )
-    )
-}
-```
+  { "query": "mutation CreateFile($bucketId: String!, $fileId: String!, $file: InputFile!) { storageCreateFile(bucketId: $bucketId, fileId: $fileId, file: $file) { id } }", "variables": { "bucketId": "<BUCKET_ID>", "fileId": "<FILE_ID>", "file": null } }
+  --cec8e8123c05ba25
+  Content-Disposition: form-data; name="map"
 
-```client-android-kotlin
-import io.appwrite.Client
-import io.appwrite.services.Storage
-import io.appwrite.ID
+  { "0": ["variables.file"] }
+  --cec8e8123c05ba25
+  Content-Disposition: form-data; name="0"; filename="file.txt"
+  Content-Type: text/plain
 
-suspend fun main() {
-    val client = Client(applicationContext)
-        .setEndpoint("https://<REGION>.cloud.appwrite.io/v1") // Your API Endpoint
-        .setProject("<PROJECT_ID>") // Your project ID
+  File content.
 
-    val storage = Storage(client)
-
-    val file = storage.createFile(
-        bucketId = "<BUCKET_ID>",
-        fileId = ID.unique(),
-        file = File("./path-to-files/image.jpg"),
-    )
-}
-```
-
-```client-react-native
-import { Client, Storage, ID } from 'react-native-appwrite';
-
-const client = new Client()
-    .setEndpoint('https://<REGION>.cloud.appwrite.io/v1')
-    .setProject('<PROJECT_ID>');
-
-const storage = new Storage(client);
-
-const promise = storage.createFile(
-    '<BUCKET_ID>',
-    ID.unique(),
-    {
-        name: 'image.jpg',
-        type: 'image/jpeg',
-        size: 1234567,
-        uri: 'file:///path/to/file.jpg',
-    }
-);
-
-promise.then(function (response) {
-    console.log(response); // Success
-}, function (error) {
-    console.log(error); // Failure
-});
-```
-
-```http
-POST /v1/storage/buckets/{bucketId}/files HTTP/1.1
-Content-Type: multipart/form-data; boundary="cec8e8123c05ba25"
-Content-Length: *Length of your entity body in bytes*
-X-Appwrite-Project: <PROJECT_ID>
-
---cec8e8123c05ba25
-Content-Disposition: form-data; name="operations"
-
-{ "query": "mutation CreateFile($bucketId: String!, $fileId: String!, $file: InputFile!) { storageCreateFile(bucketId: $bucketId, fileId: $fileId, file: $file) { id } }", "variables": { "bucketId": "<BUCKET_ID>", "fileId": "<FILE_ID>", "file": null } }
---cec8e8123c05ba25
-Content-Disposition: form-data; name="map"
-
-{ "0": ["variables.file"] }
---cec8e8123c05ba25
-Content-Disposition: form-data; name="0"; filename="file.txt"
-Content-Type: text/plain
-
-File content.
-
---cec8e8123c05ba25--
-```
+  --cec8e8123c05ba25--
+  ```
 
 {% /multicode %}
 
-# Download file {% #download-file %}
 
+# Download file {% #download-file %}
 To download a file, use the `getFileDownload` method.
 
 {% multicode %}
-
 ```client-web
 import { Client, Storage } from "appwrite";
 
@@ -206,7 +192,6 @@ const result = storage.getFileDownload({
 
 console.log(result); // Resource URL
 ```
-
 ```client-flutter
 import 'package:appwrite/appwrite.dart';
 
@@ -245,7 +230,6 @@ FutureBuilder(
   },
 );
 ```
-
 ```client-apple
 import Appwrite
 
@@ -262,7 +246,6 @@ func main() async throws {
     print(String(describing: byteBuffer))
 }
 ```
-
 ```client-android-kotlin
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
@@ -307,5 +290,4 @@ const result = storage.getFileDownload({
 
 console.log(result); // Resource URL
 ```
-
 {% /multicode %}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated Storage Quick Start examples to consistently use ID-based file generation across client and server samples.
  - Clarified client and Node.js snippets to match their respective SDK usage.
  - Removed a browser-specific create-file snippet to streamline the multi-language examples and reduce duplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->