### PR TITLE
Deno SDK Deprecation

### DIFF
--- a/src/routes/docs/products/auth/custom-token/+page.markdoc
+++ b/src/routes/docs/products/auth/custom-token/+page.markdoc
@@ -79,7 +79,7 @@ secret = token['secret']
 ```
 
 ```deno
-import { Client, Users } from "https://deno.land/x/appwrite/mod.ts";
+import { Client, Users } from "npm:node-appwrite";
 
 const client = new Client()
     .setEndpoint('https://<REGION>.cloud.appwrite.io/v1')    // Your API Endpoint

--- a/src/routes/docs/products/auth/jwt/+page.markdoc
+++ b/src/routes/docs/products/auth/jwt/+page.markdoc
@@ -123,7 +123,7 @@ client = Client.new
 ```
 
 ```deno
-import { Client } from "https://deno.land/x/appwrite/mod.ts";
+import { Client } from "npm:node-appwrite";
 
 let client = new Client()
     .setEndpoint('https://<REGION>.cloud.appwrite.io/v1')    // Your API Endpoint
@@ -260,7 +260,7 @@ rows = tablesDB.list_rows(
 # ... More code to manipulate the results
 ```
 ```deno
-import { Client } from "https://deno.land/x/appwrite/mod.ts";
+import { Client } from "npm:node-appwrite";
 
 let client = new Client()
     .setEndpoint('https://<REGION>.cloud.appwrite.io/v1')    // Your API Endpoint
@@ -439,7 +439,7 @@ rows = tablesDB.list_rows(
 # ... More code to manipulate the results
 ```
 ```deno
-import { Client } from "https://deno.land/x/appwrite/mod.ts";
+import { Client } from "npm:node-appwrite";
 
 let client = new Client()
     .setEndpoint('https://<REGION>.cloud.appwrite.io/v1') // Your API Endpoint

--- a/src/routes/docs/products/auth/labels/+page.markdoc
+++ b/src/routes/docs/products/auth/labels/+page.markdoc
@@ -88,7 +88,7 @@ response = users.update_labels(
 ```
 
 ```deno
-import * as sdk from "https://deno.land/x/appwrite/mod.ts";
+import * as sdk from "npm:node-appwrite";
 
 let client = new sdk.Client()
     .setEndpoint('https://<REGION>.cloud.appwrite.io/v1') // Your API Endpoint

--- a/src/routes/docs/products/databases/databases/+page.markdoc
+++ b/src/routes/docs/products/databases/databases/+page.markdoc
@@ -43,7 +43,7 @@ promise.then(function (response) {
 });
 ```
 ```deno
-import * as sdk from "https://deno.land/x/appwrite/mod.ts";
+import * as sdk from "npm:node-appwrite";
 
 // Init SDK
 let client = new sdk.Client();

--- a/src/routes/docs/products/databases/legacy/collections/+page.markdoc
+++ b/src/routes/docs/products/databases/legacy/collections/+page.markdoc
@@ -49,7 +49,7 @@ promise.then(function (response) {
 });
 ```
 ```deno
-import * as sdk from "https://deno.land/x/appwrite/mod.ts";
+import * as sdk from "npm:node-appwrite";
 
 // Init SDK
 let client = new sdk.Client();

--- a/src/routes/docs/products/databases/legacy/databases/+page.markdoc
+++ b/src/routes/docs/products/databases/legacy/databases/+page.markdoc
@@ -40,7 +40,7 @@ promise.then(function (response) {
 });
 ```
 ```deno
-import * as sdk from "https://deno.land/x/appwrite/mod.ts";
+import * as sdk from "npm:node-appwrite";
 
 // Init SDK
 let client = new sdk.Client();

--- a/src/routes/docs/products/databases/legacy/relationships/+page.markdoc
+++ b/src/routes/docs/products/databases/legacy/relationships/+page.markdoc
@@ -184,7 +184,7 @@ databases.create_relationship_attribute(
 
 
 ```deno
-import { Client, Databases } from "https://deno.land/x/appwrite/mod.ts";
+import { Client, Databases } from "npm:node-appwrite";
 
 const client = new Client()
     .setEndpoint("https://<REGION>.cloud.appwrite.io/v1") // Your API Endpoint

--- a/src/routes/docs/products/databases/relationships/+page.markdoc
+++ b/src/routes/docs/products/databases/relationships/+page.markdoc
@@ -184,7 +184,7 @@ tablesDB.create_relationship_column(
 
 
 ```deno
-import { Client, TablesDB } from "https://deno.land/x/appwrite/mod.ts";
+import { Client, TablesDB } from "npm:node-appwrite";
 
 const client = new Client()
     .setEndpoint("https://<REGION>.cloud.appwrite.io/v1") // Your API Endpoint

--- a/src/routes/docs/products/databases/tables/+page.markdoc
+++ b/src/routes/docs/products/databases/tables/+page.markdoc
@@ -49,7 +49,7 @@ promise.then(function (response) {
 });
 ```
 ```deno
-import * as sdk from "https://deno.land/x/appwrite/mod.ts";
+import * as sdk from "npm:node-appwrite";
 
 // Init SDK
 let client = new sdk.Client();

--- a/src/routes/docs/products/functions/develop/+page.markdoc
+++ b/src/routes/docs/products/functions/develop/+page.markdoc
@@ -172,7 +172,7 @@ def main(context)
 end
 ```
 ```deno
-import { Client } from "https://deno.land/x/appwrite@7.0.0/mod.ts";
+import { Client } from "npm:node-appwrite";
 
 // This is your Appwrite function
 // It's executed each time we get a request
@@ -1685,7 +1685,7 @@ def main(context)
 end
 ```
 ```deno
-import { Client, TablesDB, ID } from "https://deno.land/x/appwrite/mod.ts";
+import { Client, TablesDB, ID } from "npm:node-appwrite";
 
 export default function ({req, res, error}: any){
     // Set project and set API key
@@ -2043,7 +2043,7 @@ def main(context)
 end
 ```
 ```deno
-import { Client, TablesDB, ID } from "https://deno.land/x/appwrite/mod.ts";
+import { Client, TablesDB, ID } from "npm:node-appwrite";
 
 export default function ({req, res, error}: any){
     const client = new Client()

--- a/src/routes/docs/products/functions/execute/+page.markdoc
+++ b/src/routes/docs/products/functions/execute/+page.markdoc
@@ -195,7 +195,7 @@ promise.then(function (response) {
 });
 ```
 ```deno
-import * as sdk from "https://deno.land/x/appwrite/mod.ts";
+import * as sdk from "npm:node-appwrite";
 
 // Init SDK
 let client = new sdk.Client();
@@ -711,7 +711,7 @@ promise.then(function (response) {
 });
 ```
 ```deno
-import * as sdk from "https://deno.land/x/appwrite/mod.ts";
+import * as sdk from "npm:node-appwrite";
 
 // Init SDK
 let client = new sdk.Client();

--- a/src/routes/docs/products/messaging/apns/+page.markdoc
+++ b/src/routes/docs/products/messaging/apns/+page.markdoc
@@ -126,7 +126,7 @@ const provider = await messaging.updateApnsProvider(
     );
 ```
 ```deno
-import * as sdk from "https://deno.land/x/appwrite/mod.ts";
+import * as sdk from "npm:node-appwrite";
 
 // Init SDK
 let client = new sdk.Client();

--- a/src/routes/docs/products/messaging/fcm/+page.markdoc
+++ b/src/routes/docs/products/messaging/fcm/+page.markdoc
@@ -146,7 +146,7 @@ const provider = await messaging.updateFCMProvider(
     );
 ```
 ```deno
-import * as sdk from "https://deno.land/x/appwrite/mod.ts";
+import * as sdk from "npm:node-appwrite";
 
 // Init SDK
 let client = new sdk.Client();

--- a/src/routes/docs/products/messaging/mailgun/+page.markdoc
+++ b/src/routes/docs/products/messaging/mailgun/+page.markdoc
@@ -106,7 +106,7 @@ const message = await messaging.createEmail({
 });
 ```
 ```deno
-import * as sdk from "https://deno.land/x/appwrite/mod.ts";
+import * as sdk from "npm:node-appwrite";
 
 // Init SDK
 let client = new sdk.Client();
@@ -343,7 +343,7 @@ messaging.deleteProvider('<PROVIDER_ID>')
 });
 ```
 ```deno
-import * as sdk from "https://deno.land/x/appwrite/mod.ts";
+import * as sdk from "npm:node-appwrite";
 
 // Init SDK
 let client = new sdk.Client();

--- a/src/routes/docs/products/messaging/messages/+page.markdoc
+++ b/src/routes/docs/products/messaging/messages/+page.markdoc
@@ -271,7 +271,7 @@ const message = await messaging.createPush(
     );
 ```
 ```deno
-import * as sdk from "https://deno.land/x/appwrite/mod.ts";
+import * as sdk from "npm:node-appwrite";
 
 // Init SDK
 let client = new sdk.Client();
@@ -634,7 +634,7 @@ const message - await messaging.createEmail(
     );
 ```
 ```deno
-import * as sdk from "https://deno.land/x/appwrite/mod.ts";
+import * as sdk from "npm:node-appwrite";
 
 // Init SDK
 let client = new sdk.Client();
@@ -935,7 +935,7 @@ const message = await messaging.createSms(
     );
 ```
 ```deno
-import * as sdk from "https://deno.land/x/appwrite/mod.ts";
+import * as sdk from "npm:node-appwrite";
 
 // Init SDK
 let client = new sdk.Client();

--- a/src/routes/docs/products/messaging/msg91/+page.markdoc
+++ b/src/routes/docs/products/messaging/msg91/+page.markdoc
@@ -91,7 +91,7 @@ const message = await messaging.createSms(
     );
 ```
 ```deno
-import * as sdk from "https://deno.land/x/appwrite/mod.ts";
+import * as sdk from "npm:node-appwrite";
 
 // Init SDK
 let client = new sdk.Client();
@@ -366,7 +366,7 @@ const message = await messaging.updateMsg91Provider(
     );
 ```
 ```deno
-import * as sdk from "https://deno.land/x/appwrite/mod.ts";
+import * as sdk from "npm:node-appwrite";
 
 // Init SDK
 let client = new sdk.Client();

--- a/src/routes/docs/products/messaging/send-email-messages/+page.markdoc
+++ b/src/routes/docs/products/messaging/send-email-messages/+page.markdoc
@@ -61,7 +61,7 @@ const target = await users.createTarget(
 );
 ```
 ```deno
-import * as sdk from "https://deno.land/x/appwrite/mod.ts";
+import * as sdk from "npm:node-appwrite";
 
 const client = new sdk.Client()
     .setEndpoint('https://<REGION>.cloud.appwrite.io/v1')    // Your API Endpoint
@@ -298,7 +298,7 @@ const topic = await messaging.createTopic(
     );
 ```
 ```deno
-import * as sdk from "https://deno.land/x/appwrite/mod.ts";
+import * as sdk from "npm:node-appwrite";
 
 // Init SDK
 let client = new sdk.Client();
@@ -520,7 +520,7 @@ const message = await messaging.createEmail(
     );
 ```
 ```deno
-import * as sdk from "https://deno.land/x/appwrite/mod.ts";
+import * as sdk from "npm:node-appwrite";
 
 // Init SDK
 let client = new sdk.Client();
@@ -823,7 +823,7 @@ const message = await messaging.createEmail(
     );
 ```
 ```deno
-import * as sdk from "https://deno.land/x/appwrite/mod.ts";
+import * as sdk from "npm:node-appwrite";
 
 // Init SDK
 let client = new sdk.Client();

--- a/src/routes/docs/products/messaging/send-push-notifications/+page.markdoc
+++ b/src/routes/docs/products/messaging/send-push-notifications/+page.markdoc
@@ -368,7 +368,7 @@ const message = await messaging.createPush({
     });
 ```
 ```deno
-import * as sdk from "https://deno.land/x/appwrite/mod.ts";
+import * as sdk from "npm:node-appwrite";
 
 // Init SDK
 let client = new sdk.Client();

--- a/src/routes/docs/products/messaging/send-sms-messages/+page.markdoc
+++ b/src/routes/docs/products/messaging/send-sms-messages/+page.markdoc
@@ -70,7 +70,7 @@ const target = await users.createTarget(
 );
 ```
 ```deno
-import * as sdk from "https://deno.land/x/appwrite/mod.ts";
+import * as sdk from "npm:node-appwrite";
 
 const client = new sdk.Client()
     .setEndpoint('https://<REGION>.cloud.appwrite.io/v1')    // Your API Endpoint
@@ -304,7 +304,7 @@ const topic = await messaging.createTopic(
 );
 ```
 ```deno
-import * as sdk from "https://deno.land/x/appwrite/mod.ts";
+import * as sdk from "npm:node-appwrite";
 
 const client = new sdk.Client()
     .setEndpoint('https://<REGION>.cloud.appwrite.io/v1')  // Your API Endpoint
@@ -488,7 +488,7 @@ const message = await messaging.createSms(
 );
 ```
 ```deno
-import * as sdk from "https://deno.land/x/appwrite/mod.ts";
+import * as sdk from "npm:node-appwrite";
 
 const client = new sdk.Client()
     .setEndpoint('https://<REGION>.cloud.appwrite.io/v1')  // Your API Endpoint
@@ -717,7 +717,7 @@ const message = await messaging.createSms(
 );
 ```
 ```deno
-import * as sdk from "https://deno.land/x/appwrite/mod.ts";
+import * as sdk from "npm:node-appwrite";
 
 const client = new sdk.Client()
     .setEndpoint('https://<REGION>.cloud.appwrite.io/v1')  // Your API Endpoint

--- a/src/routes/docs/products/messaging/sendgrid/+page.markdoc
+++ b/src/routes/docs/products/messaging/sendgrid/+page.markdoc
@@ -98,7 +98,7 @@ const message = await messaging.createEmail({
 });
 ```
 ```deno
-import * as sdk from "https://deno.land/x/appwrite/mod.ts";
+import * as sdk from "npm:node-appwrite";
 
 // Init SDK
 let client = new sdk.Client();
@@ -321,7 +321,7 @@ const provider = await messaging.updateSendgridProvider(
     );
 ```
 ```deno
-import * as sdk from "https://deno.land/x/appwrite/mod.ts";
+import * as sdk from "npm:node-appwrite";
 
 // Init SDK
 let client = new sdk.Client();

--- a/src/routes/docs/products/messaging/smtp/+page.markdoc
+++ b/src/routes/docs/products/messaging/smtp/+page.markdoc
@@ -108,7 +108,7 @@ const message = await messaging.createEmail({
 });
 ```
 ```deno
-import * as sdk from "https://deno.land/x/appwrite/mod.ts";
+import * as sdk from "npm:node-appwrite";
 
 // Init SDK
 let client = new sdk.Client();
@@ -345,7 +345,7 @@ messaging.deleteProvider('<PROVIDER_ID>')
 });
 ```
 ```deno
-import * as sdk from "https://deno.land/x/appwrite/mod.ts";
+import * as sdk from "npm:node-appwrite";
 
 // Init SDK
 let client = new sdk.Client();

--- a/src/routes/docs/products/messaging/telesign/+page.markdoc
+++ b/src/routes/docs/products/messaging/telesign/+page.markdoc
@@ -90,7 +90,7 @@ const messaging = await messaging.createSms(
     );
 ```
 ```deno
-import * as sdk from "https://deno.land/x/appwrite/mod.ts";
+import * as sdk from "npm:node-appwrite";
 
 // Init SDK
 let client = new sdk.Client();
@@ -364,7 +364,7 @@ const provider = await messaging.updateTelesignProvider(
     );
 ```
 ```deno
-import * as sdk from "https://deno.land/x/appwrite/mod.ts";
+import * as sdk from "npm:node-appwrite";
 
 // Init SDK
 let client = new sdk.Client();

--- a/src/routes/docs/products/messaging/textmagic/+page.markdoc
+++ b/src/routes/docs/products/messaging/textmagic/+page.markdoc
@@ -90,7 +90,7 @@ const messaging = await messaging.createSms(
     );
 ```
 ```deno
-import * as sdk from "https://deno.land/x/appwrite/mod.ts";
+import * as sdk from "npm:node-appwrite";
 
 // Init SDK
 let client = new sdk.Client();
@@ -364,7 +364,7 @@ const provider = await messaging.updateTextmagicProvider(
     );
 ```
 ```deno
-import * as sdk from "https://deno.land/x/appwrite/mod.ts";
+import * as sdk from "npm:node-appwrite";
 
 // Init SDK
 let client = new sdk.Client();

--- a/src/routes/docs/products/messaging/topics/+page.markdoc
+++ b/src/routes/docs/products/messaging/topics/+page.markdoc
@@ -66,7 +66,7 @@ const topic = messaging.createTopic(
 
 ```
 ```deno
-import * as sdk from "https://deno.land/x/appwrite/mod.ts";
+import * as sdk from "npm:node-appwrite";
 
 // Init SDK
 let client = new sdk.Client();
@@ -337,7 +337,7 @@ const subscriber = await messaging.createSubscriber(
 );
 ```
 ```deno
-import * as sdk from "https://deno.land/x/appwrite/mod.ts";
+import * as sdk from "npm:node-appwrite";
 
 const client = new sdk.Client()
     .setEndpoint('https://<REGION>.cloud.appwrite.io/v1')    // Your API Endpoint

--- a/src/routes/docs/products/messaging/twilio/+page.markdoc
+++ b/src/routes/docs/products/messaging/twilio/+page.markdoc
@@ -92,7 +92,7 @@ const message = await messaging.createSms(
     );
 ```
 ```deno
-import * as sdk from "https://deno.land/x/appwrite/mod.ts";
+import * as sdk from "npm:node-appwrite";
 
 // Init SDK
 let client = new sdk.Client();
@@ -364,7 +364,7 @@ const provider = await messaging.updateTwilioProvider(
     );
 ```
 ```deno
-import * as sdk from "https://deno.land/x/appwrite/mod.ts";
+import * as sdk from "npm:node-appwrite";
 
 // Init SDK
 let client = new sdk.Client();

--- a/src/routes/docs/products/messaging/vonage/+page.markdoc
+++ b/src/routes/docs/products/messaging/vonage/+page.markdoc
@@ -92,7 +92,7 @@ const message = await messaging.createSms(
     );
 ```
 ```deno
-import * as sdk from "https://deno.land/x/appwrite/mod.ts";
+import * as sdk from "npm:node-appwrite";
 
 // Init SDK
 let client = new sdk.Client();
@@ -366,7 +366,7 @@ const provider = await messaging.updateVonageProvider(
     );
 ```
 ```deno
-import * as sdk from "https://deno.land/x/appwrite/mod.ts";
+import * as sdk from "npm:node-appwrite";
 
 // Init SDK
 let client = new sdk.Client();

--- a/src/routes/docs/products/storage/buckets/+page.markdoc
+++ b/src/routes/docs/products/storage/buckets/+page.markdoc
@@ -53,7 +53,7 @@ promise.then(function (response) {
 });
 ```
 ```deno
-import * as sdk from "https://deno.land/x/appwrite/mod.ts";
+import * as sdk from "npm:node-appwrite";
 
 // Init SDK
 let client = new sdk.Client();

--- a/src/routes/docs/products/storage/file-tokens/+page.markdoc
+++ b/src/routes/docs/products/storage/file-tokens/+page.markdoc
@@ -155,7 +155,7 @@ ResourceToken result = await tokens.CreateFileToken(
 ```
 
 ```server-deno
-import { Client, Tokens } from "https://deno.land/x/appwrite/mod.ts";
+import { Client, Tokens } from "npm:node-appwrite";
 
 const client = new Client()
     .setEndpoint('https://<REGION>.cloud.appwrite.io/v1') // Your API Endpoint
@@ -435,7 +435,7 @@ ResourceTokenList result = await tokens.List(
 ```
 
 ```server-deno
-import { Client, Tokens } from "https://deno.land/x/appwrite/mod.ts";
+import { Client, Tokens } from "npm:node-appwrite";
 
 const client = new Client()
     .setEndpoint('https://<REGION>.cloud.appwrite.io/v1') // Your API Endpoint
@@ -777,7 +777,7 @@ ResourceToken result = await tokens.Update(
 ```
 
 ```server-deno
-import { Client, Tokens } from "https://deno.land/x/appwrite/mod.ts";
+import { Client, Tokens } from "npm:node-appwrite";
 
 const client = new Client()
     .setEndpoint('https://<REGION>.cloud.appwrite.io/v1') // Your API Endpoint
@@ -1038,7 +1038,7 @@ await tokens.Delete(
 ```
 
 ```server-deno
-import { Client, Tokens } from "https://deno.land/x/appwrite/mod.ts";
+import { Client, Tokens } from "npm:node-appwrite";
 
 const client = new Client()
     .setEndpoint('https://<REGION>.cloud.appwrite.io/v1') // Your API Endpoint

--- a/src/routes/docs/quick-starts/deno/+page.markdoc
+++ b/src/routes/docs/quick-starts/deno/+page.markdoc
@@ -6,6 +6,11 @@ difficulty: beginner
 readtime: 5
 back: /docs/quick-starts
 ---
+
+{% info title="Deno SDK Deprecation" %}
+The dedicated Deno SDK has been deprecated in favor of using the Node.js SDK directly through npm specifiers, thanks to Deno's excellent Node.js compatibility. This change simplifies maintenance and ensures you always have access to the latest features.
+{% /info %}
+
 Learn how to setup your first Deno project powered by Appwrite.
 {% section #step-1 step=1 title="Create project" %}
 Head to the [Appwrite Console](https://cloud.appwrite.io/console).
@@ -51,14 +56,14 @@ echo "console.log('Hello, Deno!');" > mod.ts
 {% /section %}
 {% section #step-3 step=3 title="Install Appwrite" %}
 
-Install the Deno Appwrite SDK by importing it `deno.land/x` at the top of your file.
+Install the Appwrite SDK using npm specifiers at the top of your file.
 
 ```
 // import all as sdk
-import * as sdk from "https://deno.land/x/appwrite@15.0.0/mod.ts";
+import * as sdk from "npm:node-appwrite";
 
 // import only what you need
-import { Client, ... other imports } from "https://deno.land/x/appwrite/mod.ts";
+import { Client, ... other imports } from "npm:node-appwrite";
 ```
 
 {% /section %}
@@ -76,7 +81,7 @@ Find your project ID in the **Settings** page. Also, click on the **View API Key
 Open `mod.ts` in your IDE and initialize the Appwrite Client. Replace `<PROJECT_ID>` with your project ID and `<YOUR_API_KEY>` with your API key.
 
 ```ts
-import { Client, ID, TablesDB, Models } from "https://deno.land/x/appwrite/mod.ts";
+import { Client, ID, TablesDB, Models } from "npm:node-appwrite";
 
 const client: Client = new Client();
 

--- a/src/routes/docs/references/quick-start/+page.markdoc
+++ b/src/routes/docs/references/quick-start/+page.markdoc
@@ -145,7 +145,7 @@ client
 ;
 ```
 ```deno
-import * as sdk from "https://deno.land/x/appwrite/mod.ts";
+import * as sdk from "npm:node-appwrite";
 
 // Init SDK
 let client = new sdk.Client();

--- a/src/routes/docs/sdks/+page.markdoc
+++ b/src/routes/docs/sdks/+page.markdoc
@@ -95,12 +95,6 @@ Server libraries for integrating with Appwrite to build server side integrations
 * [appwrite/sdk-for-dotnet](https://github.com/appwrite/sdk-for-dotnet)
 * `beta`
 ---
-* {% only_dark %}{% icon_image src="/images/platforms/dark/deno.svg" alt="Deno logo" size="m" /%}{% /only_dark %}
-{% only_light %}{% icon_image src="/images/platforms/deno.svg" alt="Deno logo" size="m" /%}{% /only_light %}
-* Deno SDK `15.0.0`
-* [appwrite/sdk-for-deno](https://github.com/appwrite/sdk-for-deno)
-* 
----
 * {% only_dark %}{% icon_image src="/images/platforms/dark/go.svg" alt="Go logo" size="m" /%}{% /only_dark %}
 {% only_light %}{% icon_image src="/images/platforms/go.svg" alt="Go logo" size="m" /%}{% /only_light %}
 * Go SDK `0.7.0`
@@ -204,7 +198,7 @@ sdk.ID.custom("my-custom-id")
 
 ```
 ```deno
-import * as sdk from "https://deno.land/x/appwrite/mod.ts";
+import * as sdk from "npm:node-appwrite";
 // Generate a unique ID
 sdk.ID.unique()
 
@@ -384,12 +378,6 @@ You can discover the available enums in each SDK at the source.
 {% only_light %}{% icon_image src="/images/platforms/dotnet.svg" alt=".NET logo" size="m" /%}{% /only_light %}
 * .NET SDK `0.10.1`
 * [appwrite/sdk-for-dotnet](https://github.com/appwrite/sdk-for-dotnet/tree/dev/src/Appwrite/Enums)
-*
----
-* {% only_dark %}{% icon_image src="/images/platforms/dark/deno.svg" alt="Deno logo" size="m" /%}{% /only_dark %}
-{% only_light %}{% icon_image src="/images/platforms/deno.svg" alt="Deno logo" size="m" /%}{% /only_light %}
-* Deno SDK `12.1.0`
-* [appwrite/sdk-for-deno](https://github.com/appwrite/sdk-for-deno/tree/dev/src/enums)
 *
 ---
 * {% only_dark %}{% icon_image src="/images/platforms/dark/go.svg" alt="Go logo" size="m" /%}{% /only_dark %}

--- a/src/routes/products/functions/(components)/(snippets)/deno.txt
+++ b/src/routes/products/functions/(components)/(snippets)/deno.txt
@@ -1,4 +1,4 @@
-import { Client } from "https://deno.land/x/appwrite@7.0.0/mod.ts";
+import { Client } from "npm:node-appwrite";
 
 // This is your Appwrite function
 // It's executed each time we get a request


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated Deno code samples across Auth, Databases, Functions, Messaging, Storage, and Quick Start guides to import the SDK via npm:node-appwrite instead of deno.land URLs.
  - Added a deprecation notice in the Deno quick start to reflect the import change.
  - Refreshed SDKs overview page by removing Deno platform entries from Server SDKs and Enums tables.
  - Ensured examples remain functionally identical; only import sources changed.
  - Aligned all related snippets to the new import path for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->