### PR TITLE
Add orderRandom query to the queries docs

### DIFF
--- a/src/routes/docs/products/databases/queries/+page.markdoc
+++ b/src/routes/docs/products/databases/queries/+page.markdoc
@@ -1507,6 +1507,40 @@ query.OrderAsc("attribute")
 ```
 {% /multicode %}
 
+### Order random {% #order-random %}
+
+Orders results in random order.
+
+{% multicode %}
+```client-web
+Query.orderRandom()
+```
+```client-flutter
+Query.orderRandom()
+```
+```server-python
+Query.order_random()
+```
+```server-ruby
+Query.order_random()
+```
+```server-nodejs
+Query.orderRandom()
+```
+```server-php
+Query::orderRandom()
+```
+```client-apple
+Query.orderRandom()
+```
+```server-go
+query.OrderRandom()
+```
+```http
+{"method":"orderRandom"}
+```
+{% /multicode %}
+
 ## Pagination {% #pagination %}
 
 ### Limit {% #limit %}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Adds `orderRandom` query to the queries docs

## Test Plan

Visit `/docs/products/databases/queries#order-random`

### Local Test

<img width="2386" height="1342" alt="image" src="https://github.com/user-attachments/assets/49cf5de0-db77-44b5-9abe-25ae327f9ad1" />

## Related PRs and Issues

No

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an “Order random” subsection to the database queries Ordering docs, explaining how to return results in random order.
  * Provided code examples for client-web, client-flutter, client-apple, server SDKs (Node.js, Python, Ruby, PHP, Go), and HTTP.
  * Mirrors existing orderAsc/orderDesc sections for consistency.
  * Improves discoverability and parity of examples across platforms.
  * No API or functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->