### PR TITLE
fix: lint error exclude `deploy` directory

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,6 +6,7 @@ node_modules
 .env
 .env.*
 !.env.example
+deploy
 
 # Ignore files for PNPM, NPM and YARN
 pnpm-lock.yaml

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -16,6 +16,7 @@ export default ts.config(
     ...svelte.configs.recommended,
     prettier,
     ...svelte.configs.prettier,
+    { ignores: ['/deploy/**'] },
     {
         languageOptions: {
             globals: { ...globals.browser, ...globals.node }
@@ -37,7 +38,7 @@ export default ts.config(
     },
     {
         files: ['**/*.svelte', '**/*.svelte.ts', '**/*.svelte.js'],
-        ignores: ['eslint.config.js', 'svelte.config.js'],
+        ignores: ['eslint.config.js', 'svelte.config.js', '/deploy/**'],
         languageOptions: {
             parserOptions: {
                 // Only uncomment this if you want it to take 3 minutes https://github.com/sveltejs/eslint-plugin-svelte/issues/1084


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)
This pull request updates the configuration to exclude the `deploy` directory from linting. Linting was tested using `pnpm run lint`
## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.). Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Project tooling updated to ignore the deploy directory for formatting and linting.
  * Reduces spurious warnings and changes in pre-commit and CI checks.
  * Streamlines developer workflow and produces cleaner pull requests.
  * No functional changes to the application; users will see no impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->