### PR TITLE
fix: added nav back for offer pages

### DIFF
--- a/src/lib/layouts/Main.svelte
+++ b/src/lib/layouts/Main.svelte
@@ -232,7 +232,7 @@
                         width="130"
                     />
                 </a>
-                {#if !hideNavigation && !isOfferPage}
+                {#if !hideNavigation}
                     <MainNav initialized={$initialized} links={navLinks} />
                 {/if}
             </div>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

<img width="1886" height="953" alt="image" src="https://github.com/user-attachments/assets/57032135-2fb8-4569-bf4c-8813803f4e66" />
<img width="1888" height="970" alt="image" src="https://github.com/user-attachments/assets/f8c6e419-70c3-4c3c-80d6-81c7b71d213f" />



## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Main navigation now appears on offer pages when not hidden, ensuring consistent visibility across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->