### PR TITLE
build: add `workflow_dispatch` in production workflow; exclude `deploy` stage

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -3,6 +3,7 @@ name: Production deployment
 on:
     release:
         types: [published]
+    workflow_dispatch:
 
 env:
     TAG: ${{ github.event.release.tag_name }}
@@ -51,6 +52,7 @@ jobs:
     deploy:
         needs: build
         runs-on: ubuntu-latest
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         steps:
             - name: Execute SSH commands
               uses: appleboy/ssh-action@master


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR introduces workflow_dispatch functionality for the main branch, excluding the deploy stage. The deploy stage will continue to function as before, while the new changes enable deployments to Kubernetes through the deploy_kubernetes stage. 

More info can be found https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context

(Provide a description of what this PR does.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.) Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Production deployment workflow to allow manual triggering via workflow_dispatch.
  * Added condition to skip deploy job on manual runs, ensuring deployments only occur on standard triggers.
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->