### PR TITLE
build: destroy staging infra docker swarm and remove GitHub actions deploy stage

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -49,38 +49,6 @@ jobs:
                       "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}"
                       "SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}"
 
-    deploy:
-        needs: build
-        runs-on: ubuntu-latest
-        steps:
-            - name: Execute SSH commands
-              uses: appleboy/ssh-action@master
-              with:
-                  host: ${{ secrets.STG_SSH_HOST }}
-                  username: ${{ secrets.STG_SSH_USERNAME }}
-                  key: ${{ secrets.STG_SSH_KEY }}
-                  script: |
-                      url="https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/appwrite/${{ env.REPOSITORY }}.git"
-                      if ! git clone "${url}" "${{ env.REPOSITORY }}" 2>/dev/null && [ -d "${{ env.REPOSITORY }}" ] ; then
-                          echo "Clone failed because the folder ${{ env.REPOSITORY }} exists"
-                      fi
-
-                      cd ${{ env.REPOSITORY }}
-                      git reset --hard HEAD
-                      git remote set-url origin $url
-                      git fetch origin
-                      git checkout ${{ env.TAG }}
-
-                      rm -f .env
-                      echo "_APP_VERSION=${{ env.TAG }}" >> .env
-                      echo "_APP_DOMAIN=${{ secrets.STG_APP_DOMAIN }}" >> .env
-                      echo "_APP_SYSTEM_SECURITY_EMAIL_ADDRESS=${{ secrets.APP_SYSTEM_SECURITY_EMAIL_ADDRESS }}" >> .env
-                      echo "_APP_BETTER_STACK_INCIDENT_URL=${{ secrets.BETTER_STACK_INCIDENT_URL }}" >> .env
-
-                      echo ${{ secrets.GH_REGISTRY_TOKEN }} | docker login ghcr.io --username ${{ env.REGISTRY_USERNAME }} --password-stdin
-                      docker-compose -f ${{ env.STACK_FILE }} config
-                      env $(cat .env | xargs) docker stack deploy --prune --resolve-image always --with-registry-auth -c ${{ env.STACK_FILE }} ${{ env.REPOSITORY }}
-
     deploy_kubernetes:
         strategy:
             matrix:

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -1,16 +1,1 @@
-module "droplets" {
-    source = "../../modules/digitalocean"
 
-    private_key = "${var.PRIVATE_KEY}"
-    project_name = "hmp"
-    region = "fra1"
-    environment = "stg"
-    base_image = "docker-20-04"
-    subnet_range = "10.116.0.0/20"
-    worker_size = "s-1vcpu-2gb"
-    worker_count = 4
-    manager_size = "s-1vcpu-2gb"
-    manager_count = 2
-
-    digitalocean_project_name = "Staging - Homepage"
-}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

- Bring down staging infra not required anymore
- Remove deploy stage from staging GitHub Actions

(Provide a description of what this PR does.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Removed the legacy SSH-based staging deployment, consolidating staging releases to the existing Kubernetes workflow.
  - Retired DigitalOcean droplet provisioning from the staging environment, standardizing infrastructure on Kubernetes.
  - Simplifies pipeline maintenance and reduces infrastructure drift across environments.
  - No changes to application behavior; end-user experience remains the same.
  - Production workflows are unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->