### PR TITLE
OAuth2: Recommend token flow or custom domain

### DIFF
--- a/src/routes/docs/products/auth/oauth2/+page.markdoc
+++ b/src/routes/docs/products/auth/oauth2/+page.markdoc
@@ -28,7 +28,7 @@ Before using OAuth 2 login, you need to enable and configure an OAuth 2 login pr
 
 To initialize the OAuth 2 login process, use the [Create OAuth 2 Session](/docs/references/cloud/client-web/account#createOAuth2Session) route.
 
-{% info title="Third‑Party Cookies" %}
+{% info title="Third‑Party cookies" %}
 Most browsers now block third‑party cookies by default, so `createOAuth2Session` may not set a session. Use the [token‑based flow](/docs/products/auth/server-side-rendering#oauth2) instead or set up a custom domain in Appwrite that matches your app’s origin so cookies are first‑party. Learn more here: [Fixing OAuth2 issues in Appwrite Cloud](/blog/post/fixing-oauth2-issues-in-appwrite-cloud).
 {% /info %}
 


### PR DESCRIPTION
## What does this PR do?
Adds info box about third-party cookie issues with creteteOauth2Session

Follow up:
- We'll need to properly document the createOauth2Token and update tutorials