### PR TITLE
Fix installation command for Appwrite SDK

### DIFF
--- a/src/routes/docs/quick-starts/nextjs/+page.markdoc
+++ b/src/routes/docs/quick-starts/nextjs/+page.markdoc
@@ -53,7 +53,7 @@ These settings will create a minimal Next.js setup that's perfect for getting st
 Install the JavaScript Appwrite SDK.
 
 ```sh
-appwrite
+npm install appwrite
 ```
 {% /section %}
 {% section #step-4 step=4 title="Define Appwrite service" %}


### PR DESCRIPTION

This pull request updates the documentation for the Next.js quick start guide to clarify the installation command for the Appwrite JavaScript SDK.

Documentation improvement:

* Changed the installation command from `appwrite` to `npm install appwrite` in `src/routes/docs/quick-starts/nextjs/+page.markdoc` to provide the correct instructions for installing the Appwrite SDK.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Next.js Quick Start to show the correct install command for the Appwrite SDK (now uses the explicit npm installation command), making the step clearer and copy-paste friendly.
  * Adjusted section formatting and newline handling for improved readability and consistency across the guide.
  * No functional changes to the product; this is a content and formatting improvement to enhance the onboarding documentation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->