### PR TITLE
fix: hackathon dates to fit server time

### DIFF
--- a/src/routes/(marketing)/(components)/(hackathon)/hackathon-banner.svelte
+++ b/src/routes/(marketing)/(components)/(hackathon)/hackathon-banner.svelte
@@ -3,10 +3,10 @@
     import Badge from './badge.svelte';
     import { format } from 'date-fns';
 
-    const startDate = new Date('2025-10-02');
-    const endDate = new Date('2025-11-01');
+    // const startDate = new Date('2025-10-02');
+    // const endDate = new Date('2025-11-01');
 
-    const hackathonDates = `${format(startDate, 'MMM d')} - ${format(endDate, 'MMM d')}`;
+    const hackathonDates = `OCT 1 - OCT 31`;
 </script>
 
 <a href="https://apwr.dev/hf2025-hackathon" target="_blank" rel="noopener noreferrer">

--- a/src/routes/(marketing)/(components)/(hackathon)/hackathon-banner.svelte
+++ b/src/routes/(marketing)/(components)/(hackathon)/hackathon-banner.svelte
@@ -3,8 +3,8 @@
     import Badge from './badge.svelte';
     import { format } from 'date-fns';
 
-    const startDate = new Date('2025-10-01');
-    const endDate = new Date('2025-10-31');
+    const startDate = new Date('2025-10-02');
+    const endDate = new Date('2025-11-01');
 
     const hackathonDates = `${format(startDate, 'MMM d')} - ${format(endDate, 'MMM d')}`;
 </script>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

<img width="522" height="90" alt="image" src="https://github.com/user-attachments/assets/4a5e503c-a250-4f36-bcbb-d9de581d65c8" />

Adding Oct 1st - Oct 31st shows up as these dates in the above banner. the PR adds a day to the start and a day to the end date so itll show up correctly.

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the hackathon banner to show a static date range: "OCT 1 - OCT 31".
  * Ensures the marketing banner consistently reflects the event window across relevant pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->