### PR TITLE
fix: change route property to use page.url.pathname

### DIFF
--- a/src/lib/components/Feedback.svelte
+++ b/src/lib/components/Feedback.svelte
@@ -29,7 +29,7 @@
             body: JSON.stringify({
                 email,
                 type: feedbackType,
-                route: page.route.id,
+                route: page.url.pathname,
                 comment,
                 metaFields: {
                     userId


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

The page.route.id doesn't resolve path variables so it can look like /docs/references/[version]/models/[model]. This makes it difficult to tell what page they were giving feedback for.

page.url.pathname will resolve the variables so it looks like /docs/references/cloud/models/user.

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Feedback submissions now correctly capture the exact page URL, ensuring responses are associated with the right page.
  * Improves accuracy of feedback routing and reduces mismatches for pages with dynamic routes.
  * No changes to the feedback UI or submission flow; existing behavior remains the same aside from improved page identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->