### PR TITLE
fix(docs): correct markdown links and typo's in REST API page

### DIFF
--- a/src/routes/docs/+page.svelte
+++ b/src/routes/docs/+page.svelte
@@ -458,7 +458,7 @@
                         >
                             <h4 class="text-sub-body text-primary font-medium">REST API</h4>
                             <p class="text-sub-body mt-1">
-                                Integrate with HTTP requests without the needing an SDK.
+                                Integrate with HTTP requests without needing an SDK.
                             </p>
                         </a>
                     </li>

--- a/src/routes/docs/apis/rest/+page.markdoc
+++ b/src/routes/docs/apis/rest/+page.markdoc
@@ -4,7 +4,7 @@ title: REST
 description: Discover the Appwrite REST API for building robust and scalable applications. Access detailed documentation on REST endpoints, authentication, and data management.
 ---
 
-Appwrite supports multiple protocols for accessing the server, including [REST](/docs/apis/rest), [GraphQL](/docs/apis/graphql), and [Realtime](/docs/apis/realtime). The REST API allows you to access your Appwrite server through HTTP requests without the needing an SDK. Each endpoint in the API represents a specific operation on a specific resource.
+Appwrite supports multiple protocols for accessing the server, including [REST](/docs/apis/rest), [GraphQL](/docs/apis/graphql), and [Realtime](/docs/apis/realtime). The REST API allows you to access your Appwrite server through HTTP requests without needing an SDK. Each endpoint in the API represents a specific operation on a specific resource.
 
 # Headers {% #headers %}
 
@@ -21,7 +21,7 @@ Appwrite's REST APIs expect certain headers to be included with each request:
 ---
 - Content-Type: application/json
 - required
-- Content type of the HTTP request. Would usually be `application/json`.
+- Content type of the HTTP request. Typically set to `application/json`.
 ---
 - X-Appwrite-Key: [API-KEY]
 - optional
@@ -103,9 +103,9 @@ X-Appwrite-JWT: [TOKEN]
 
 # Files {% #files %}
 
-Appwrite implements resumable, chunked uploads for files larger than 5MB. Chunked uploads send files in chunks of 5MB to reduce memory footprint and increase resilience when handling large files. Appwrite SDKs will automatically handle chunked uploads, but it is possible to implement this with the REST API directly.
+Appwrite implements resumable, chunked uploads for files larger than 5MB. Chunked uploads send files in chunks of 5MB to reduce memory footprint and increase resilience when handling large files. [Appwrite SDKs](/docs/sdks) will automatically handle chunked uploads, but it is possible to implement this with the REST API directly.
 
-Upload endpoints in Appwrite, such as [Create File] (/docs/references/cloud/client-web/storage#createFile) and [Create Deployment] (/docs/references/cloud/server-nodejs/functions#createDeployment), are different from other endpoints. These endpoints take multipart form data instead of JSON data. To implement chunked uploads, you will need to implement the following headers. If you wish, this logic is already available in any of the [Appwrite SDKs](/docs/sdks).
+Upload endpoints in Appwrite, such as [Create File](https://appwrite.io/docs/references/cloud/client-web/storage#createFile) and [Create Deployment](https://appwrite.io/docs/references/cloud/server-nodejs/functions#createDeployment), are different from other endpoints. These endpoints take multipart form data instead of JSON data. To implement chunked uploads, you will need to implement the following headers. If you wish, this logic is already available in any of the [Appwrite SDKs](/docs/sdks).
 
 {% table %}
 - Header


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR fixes:

- Informal wording in headers section (Would usually be → Typically set to).
<img width="815" height="96" alt="image" src="https://github.com/user-attachments/assets/3c99e69b-47f8-4c8a-bf54-6bb28d90a281" />

- Grammar issue in introduction (without the needing → without needing).
<img width="819" height="151" alt="image" src="https://github.com/user-attachments/assets/08390204-b83a-4367-936a-eef5d725785b" />

- Incorrect markdown link syntax in Files upload endpoints ([Create File] (/...) → [Create File](/...)).
<img width="825" height="349" alt="image" src="https://github.com/user-attachments/assets/8d70dee0-e42e-44c8-9898-16d8f4809a4f" />

## Test Plan

Verified that all updated links render correctly and text changes improve readability.


## Related PRs and Issues

#2478 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes