### PR TITLE
Update compare-plans.svelte

### DIFF
--- a/src/routes/pricing/compare-plans.svelte
+++ b/src/routes/pricing/compare-plans.svelte
@@ -216,16 +216,16 @@
                 },
                 {
                     title: 'Reads',
-                    free: '500K',
-                    pro: '1750K',
-                    scale: '1750K',
+                    free: '500K / month',
+                    pro: '1750K / month',
+                    scale: '1750K / month',
                     enterprise: 'Custom'
                 },
                 {
                     title: 'Writes',
-                    free: '250K',
-                    pro: '750K',
-                    scale: '750K',
+                    free: '250K / month',
+                    pro: '750K / month',
+                    scale: '750K / month',
                     enterprise: 'Custom'
                 },
                 {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Clarified units for Databases “Reads” and “Writes” on the Compare Plans page by displaying limits as per-month values (e.g., “500K / month”) across Free, Pro, and Scale tiers.
  * Improves readability and reduces ambiguity around usage limits without altering any pricing, quotas, or plan logic.
  * No interactive behavior changes; purely a text/formatting update visible in the Resources table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->