### PR TITLE
Update Self Hosting -> Configure service link and add Sites card

### DIFF
--- a/src/routes/docs/advanced/self-hosting/+page.markdoc
+++ b/src/routes/docs/advanced/self-hosting/+page.markdoc
@@ -133,6 +133,10 @@ Connect external storage providers like AWS S3, Backblaze, or Wasabi.
 {% cards_item href="/docs/advanced/self-hosting/configuration/functions" title="Functions Runtime" %}
 Enable serverless functions with custom runtimes and execution environments.
 {% /cards_item %}
+
+{% cards_item href="/docs/advanced/self-hosting/configuration/sites" title="Sites" %}
+Develop, deploy, and scale your web applications directly from Appwrite, alongside your backend.
+{% /cards_item %}
 {% /cards %}
 
 # Production readiness {% #production-readiness %}

--- a/src/routes/docs/advanced/self-hosting/platforms/aws/+page.markdoc
+++ b/src/routes/docs/advanced/self-hosting/platforms/aws/+page.markdoc
@@ -54,6 +54,6 @@ For production deployments, optimization, and advanced AWS configuration, see th
 
 After successful deployment:
 
-- [Configure services](/docs/advanced/self-hosting/configuration) - Set up email, storage, and other services
+- [Configure services](/docs/advanced/self-hosting#configuration) - Set up email, storage, and other services
 - [Production optimization](/docs/advanced/self-hosting/production) - Prepare for production workloads
 - [Updates and maintenance](/docs/advanced/self-hosting/production/updates) - Keep your instance up to date

--- a/src/routes/docs/advanced/self-hosting/platforms/azure/+page.markdoc
+++ b/src/routes/docs/advanced/self-hosting/platforms/azure/+page.markdoc
@@ -22,6 +22,6 @@ For production deployments, optimization, and advanced configuration, see the [p
 
 After successful deployment:
 
-- [Configure services](/docs/advanced/self-hosting/configuration) - Set up email, storage, and other services
+- [Configure services](/docs/advanced/self-hosting#configuration) - Set up email, storage, and other services
 - [Production optimization](/docs/advanced/self-hosting/production) - Prepare for production workloads
 - [Updates and maintenance](/docs/advanced/self-hosting/production/updates) - Keep your instance up to date

--- a/src/routes/docs/advanced/self-hosting/platforms/coolify/+page.markdoc
+++ b/src/routes/docs/advanced/self-hosting/platforms/coolify/+page.markdoc
@@ -77,3 +77,11 @@ The [Github Docs](https://docs.github.com/en/apps/creating-github-apps/about-cre
 
 1. **Site redirected you too many times**
    If you encounter the error `ERR_TOO_MANY_REDIRECTS` with the default Coolify configuration, turn off the **Strip Prefixes** option in the **Settings** page for the Appwrite console and Appwrite Realtime service. If you're using Cloudflare and the issue persists, update the SSL/TLS encryption setting to Full in the Cloudflare dashboard. From the dashboard, navigate to `Your Domain` -> `SSL/TLS` -> `Overview` and change the setting to Full.
+
+# Next steps {% #next-steps %}
+
+After successful deployment:
+
+- [Configure services](/docs/advanced/self-hosting#configuration) - Set up email, storage, and other services
+- [Production optimization](/docs/advanced/self-hosting/production) - Prepare for production workloads
+- [Updates and maintenance](/docs/advanced/self-hosting/production/updates) - Keep your instance up to date

--- a/src/routes/docs/advanced/self-hosting/platforms/digitalocean/+page.markdoc
+++ b/src/routes/docs/advanced/self-hosting/platforms/digitalocean/+page.markdoc
@@ -41,6 +41,6 @@ For production deployments, optimization, and advanced configuration, see the [p
 
 After successful deployment:
 
-- [Configure services](/docs/advanced/self-hosting/configuration) - Set up email, storage, and other services
+- [Configure services](/docs/advanced/self-hosting#configuration) - Set up email, storage, and other services
 - [Production optimization](/docs/advanced/self-hosting/production) - Prepare for production workloads
 - [Updates and maintenance](/docs/advanced/self-hosting/production/updates) - Keep your instance up to date

--- a/src/routes/docs/advanced/self-hosting/platforms/google-cloud/+page.markdoc
+++ b/src/routes/docs/advanced/self-hosting/platforms/google-cloud/+page.markdoc
@@ -22,6 +22,6 @@ For production deployments, optimization, and advanced configuration, see the [p
 
 After successful deployment:
 
-- [Configure services](/docs/advanced/self-hosting/configuration) - Set up email, storage, and other services
+- [Configure services](/docs/advanced/self-hosting#configuration) - Set up email, storage, and other services
 - [Production optimization](/docs/advanced/self-hosting/production) - Prepare for production workloads
 - [Updates and maintenance](/docs/advanced/self-hosting/production/updates) - Keep your instance up to date


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

1. Fixes the links from `[Configure services](/docs/advanced/self-hosting/configuration)` to `[Configure services](/docs/advanced/self-hosting#configuration)`
2. Adds `# Next steps` section to the Coolify page, just like the Google Cloud, AWS, etc. pages
3. Adds a `Sites` card to the Self Hosting page as something to enable after deployment.

## Test Plan

- Tested via `pnpm run dev` and browsing to: 
    - `http://localhost:[port]/docs/advanced/self-hosting`
    - `http://localhost:[port]/docs/advanced/self-hosting/platforms/aws`
    - `http://localhost:[port]/docs/advanced/self-hosting/platforms/azure`
    - `http://localhost:[port]/docs/advanced/self-hosting/platforms/coolify`
    - `http://localhost:[port]/docs/advanced/self-hosting/platforms/digital-ocean`
    - `http://localhost:[port]/docs/advanced/self-hosting/platforms/google-cloud`

## Related PRs and Issues

Closes Issue #2498 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes. I understand that I need to run `pnpm run build` to test the build process. On my machine, the build fails, but I'm not sure if this is a problem with my local machine, or a greater issue with the build process as as result of my changes. The `pnpm run dev` local server builds these pages properly on the fly.

```shell
<--- Last few GCs --->

[93145:0x120008000]   152724 ms: Mark-Compact 4039.3 (4103.0) -> 4037.3 (4102.5) MB, pooled: 1 MB, 549.00 / 0.00 ms  (average mu = 0.074, current mu = 0.005) allocation failure; scavenge might not succeed
[93145:0x120008000]   153288 ms: Mark-Compact 4039.4 (4103.0) -> 4037.4 (4102.5) MB, pooled: 1 MB, 561.83 / 0.00 ms  (average mu = 0.041, current mu = 0.005) allocation failure; scavenge might not succeed


<--- JS stacktrace --->

FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
----- Native stack trace -----

 1: 0x104b6066c node::OOMErrorHandler(char const*, v8::OOMDetails const&) [/opt/homebrew/Cellar/node/23.6.0/bin/node]
 2: 0x104d08740 v8::internal::V8::FatalProcessOutOfMemory(v8::internal::Isolate*, char const*, v8::OOMDetails const&) [/opt/homebrew/Cellar/node/23.6.0/bin/node]
 3: 0x104ec56f0 v8::internal::Heap::CallGCPrologueCallbacks(v8::GCType, v8::GCCallbackFlags, v8::internal::GCTracer::Scope::ScopeId) [/opt/homebrew/Cellar/node/23.6.0/bin/node]
 4: 0x104ecb188 v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace, v8::internal::GarbageCollectionReason, v8::GCCallbackFlags)::$_1::operator()() const [/opt/homebrew/Cellar/node/23.6.0/bin/node]
 5: 0x104ec5a34 void heap::base::Stack::SetMarkerAndCallbackImpl<v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace, v8::internal::GarbageCollectionReason, v8::GCCallbackFlags)::$_1>(heap::base::Stack*, void*, void const*) [/opt/homebrew/Cellar/node/23.6.0/bin/node]
 6: 0x104a78028 PushAllRegistersAndIterateStack [/opt/homebrew/Cellar/node/23.6.0/bin/node]
 7: 0x104ec291c v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace, v8::internal::GarbageCollectionReason, v8::GCCallbackFlags) [/opt/homebrew/Cellar/node/23.6.0/bin/node]
 8: 0x104ebc364 v8::internal::HeapAllocator::AllocateRawWithLightRetrySlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [/opt/homebrew/Cellar/node/23.6.0/bin/node]
 9: 0x104ebcd2c v8::internal::HeapAllocator::AllocateRawWithRetryOrFailSlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [/opt/homebrew/Cellar/node/23.6.0/bin/node]
10: 0x104ea76d4 v8::internal::FactoryBase<v8::internal::Factory>::AllocateRawArray(int, v8::internal::AllocationType) [/opt/homebrew/Cellar/node/23.6.0/bin/node]
11: 0x104ea7868 v8::internal::FactoryBase<v8::internal::Factory>::NewFixedArrayWithFiller(v8::internal::Handle<v8::internal::Map>, int, v8::internal::Handle<v8::internal::HeapObject>, v8::internal::AllocationType) [/opt/homebrew/Cellar/node/23.6.0/bin/node]
12: 0x1050bb4a0 v8::internal::OrderedHashTable<v8::internal::OrderedHashSet, 1>::Allocate(v8::internal::Isolate*, int, v8::internal::AllocationType) [/opt/homebrew/Cellar/node/23.6.0/bin/node]
13: 0x1050bb114 v8::internal::OrderedHashTable<v8::internal::OrderedHashSet, 1>::Rehash(v8::internal::Isolate*, v8::internal::Handle<v8::internal::OrderedHashSet>, int) [/opt/homebrew/Cellar/node/23.6.0/bin/node]
14: 0x105164a84 v8::internal::Runtime_SetGrow(int, unsigned long*, v8::internal::Isolate*) [/opt/homebrew/Cellar/node/23.6.0/bin/node]
15: 0x1049579f4 Builtins_CEntry_Return1_ArgvOnStack_NoBuiltinExit [/opt/homebrew/Cellar/node/23.6.0/bin/node]
16: 0x10493b674 Builtins_SetPrototypeAdd [/opt/homebrew/Cellar/node/23.6.0/bin/node]
17: 0x10d3cad0c 
18: 0x1048c0838 Builtins_InterpreterEntryTrampoline [/opt/homebrew/Cellar/node/23.6.0/bin/node]
19: 0x10d6d834c 
20: 0x1048fde20 Builtins_AsyncFunctionAwaitResolveClosure [/opt/homebrew/Cellar/node/23.6.0/bin/node]
21: 0x1049cb298 Builtins_PromiseFulfillReactionJob [/opt/homebrew/Cellar/node/23.6.0/bin/node]
22: 0x1048ed214 Builtins_RunMicrotasks [/opt/homebrew/Cellar/node/23.6.0/bin/node]
23: 0x1048be3f0 Builtins_JSRunMicrotasksEntry [/opt/homebrew/Cellar/node/23.6.0/bin/node]
24: 0x104e3a5dc v8::internal::(anonymous namespace)::Invoke(v8::internal::Isolate*, v8::internal::(anonymous namespace)::InvokeParams const&) [/opt/homebrew/Cellar/node/23.6.0/bin/node]
25: 0x104e3ad48 v8::internal::(anonymous namespace)::InvokeWithTryCatch(v8::internal::Isolate*, v8::internal::(anonymous namespace)::InvokeParams const&) [/opt/homebrew/Cellar/node/23.6.0/bin/node]
26: 0x104e652fc v8::internal::MicrotaskQueue::PerformCheckpointInternal(v8::Isolate*) [/opt/homebrew/Cellar/node/23.6.0/bin/node]
27: 0x104a795e4 node::InternalCallbackScope::Close() [/opt/homebrew/Cellar/node/23.6.0/bin/node]
28: 0x104a79444 node::InternalCallbackScope::~InternalCallbackScope() [/opt/homebrew/Cellar/node/23.6.0/bin/node]
29: 0x104a79414 node::CallbackScope::~CallbackScope() [/opt/homebrew/Cellar/node/23.6.0/bin/node]
30: 0x104b234ec (anonymous namespace)::uvimpl::Work::AfterThreadPoolWork(int) [/opt/homebrew/Cellar/node/23.6.0/bin/node]
31: 0x104b239f8 node::ThreadPoolWork::ScheduleWork()::'lambda'(uv_work_s*, int)::operator()(uv_work_s*, int) const [/opt/homebrew/Cellar/node/23.6.0/bin/node]
32: 0x104b238b0 node::ThreadPoolWork::ScheduleWork()::'lambda'(uv_work_s*, int)::__invoke(uv_work_s*, int) [/opt/homebrew/Cellar/node/23.6.0/bin/node]
33: 0x1081d6660 uv__work_done [/opt/homebrew/Cellar/libuv/1.49.2/lib/libuv.1.dylib]
34: 0x1081d9cf4 uv__async_io [/opt/homebrew/Cellar/libuv/1.49.2/lib/libuv.1.dylib]
35: 0x1081ea114 uv__io_poll [/opt/homebrew/Cellar/libuv/1.49.2/lib/libuv.1.dylib]
36: 0x1081da184 uv_run [/opt/homebrew/Cellar/libuv/1.49.2/lib/libuv.1.dylib]
37: 0x104a7a488 node::SpinEventLoopInternal(node::Environment*) [/opt/homebrew/Cellar/node/23.6.0/bin/node]
38: 0x104ba7dac node::NodeMainInstance::Run(node::ExitCode*, node::Environment*) [/opt/homebrew/Cellar/node/23.6.0/bin/node]
39: 0x104ba7b00 node::NodeMainInstance::Run() [/opt/homebrew/Cellar/node/23.6.0/bin/node]
40: 0x104b2089c node::Start(int, char**) [/opt/homebrew/Cellar/node/23.6.0/bin/node]
41: 0x18a28eb98 start [/usr/lib/dyld]
 ELIFECYCLE  Command failed.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added a new Sites configuration section to the self-hosting documentation
  * Updated navigation links across platform guides (AWS, Azure, DigitalOcean, Google Cloud) to reference in-page anchors
  * Added a Next steps section to the Coolify deployment guide with post-deployment resources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->