### PR TITLE
Find Appwrite scale plan documentation

### DIFF
--- a/src/partials/resource-limits.md
+++ b/src/partials/resource-limits.md
@@ -47,7 +47,7 @@ Reaching your organization's resource limits will have the following effects unt
 
 ## Switching to Free plan and reaching limits {% #switching-to-free-plan-reaching-resource-limits %}
 
-When an orgnization switches from Pro or Scale plan to Free plan, the organization's projects will be able to take advantage of the existing limits until the end of the current billing period.
+When an orgnization switches from a paid plan to the Free plan, the organization's projects will be able to take advantage of the existing limits until the end of the current billing period.
 After the billing period ends, the Free plan limits and consequences will apply.
 
 If an organisation has multiple members after the billing period ends, all admins besides the original creator of the organization will be removed.

--- a/src/routes/docs/advanced/platform/+page.markdoc
+++ b/src/routes/docs/advanced/platform/+page.markdoc
@@ -72,9 +72,7 @@ Learn about Appwrite Free plan. Free plan for hobby projects and learners.
 Learn about Appwrite Pro, for growing organizations that need to scale.
 {% /cards_item %}
 
-{% cards_item href="/docs/advanced/platform/scale" title="Scale" %}
-Coming soon.
-{% /cards_item %}
+
 
 {% cards_item href="/docs/advanced/platform/enterprise" title="Enterprise" %}
 Learn about Appwrite Enterprise, for large organizations with advanced needs.

--- a/src/routes/docs/advanced/platform/database-reads-and-writes/+page.markdoc
+++ b/src/routes/docs/advanced/platform/database-reads-and-writes/+page.markdoc
@@ -35,7 +35,7 @@ For example, if you fetch a table of 50 rows with a single API call, this counts
 - **Included**: 500,000 read operations and 250,000 write operations per month.
 - **Overage**: Not available (operations are throttled when limits are reached).
 
-### Pro and Scale Plans
+### Pro Plan
 - **Included**: 1,750,000 read operations and 750,000 write operations per month.
 - **Overage**: $0.060 per 100,000 additional read operations and $0.10 per 100,000 additional write operations.
 

--- a/src/routes/docs/advanced/platform/fair-use-policy/+page.markdoc
+++ b/src/routes/docs/advanced/platform/fair-use-policy/+page.markdoc
@@ -40,7 +40,7 @@ We continuously monitor resource usage to ensure compliance with this policy. Us
 Users who consistently exceed usage limits have the following options:
 
 - **Upgrade to a higher plan:** Users may select a plan that better fits their needs.
-- **Resource upgrades:** Pro and Scale plan users may upgrade the usage limits for specific resources. Pricing details are available [here](/pricing).
+- **Resource upgrades:** Paid plan users may upgrade the usage limits for specific resources. Pricing details are available [here](/pricing).
 
 # Policy updates {% #policy-updates %}
 

--- a/src/routes/docs/advanced/platform/image-transformations/+page.markdoc
+++ b/src/routes/docs/advanced/platform/image-transformations/+page.markdoc
@@ -26,6 +26,6 @@ For example, suppose there are around 100 images in storage. If only 50 of these
 ## Pricing
 
 - Currently, this feature is **unavailable on the free plan**.
-- Pro and Scale plans include 100 origin images per month. Additional usage is available at $5 per 1000 origin images.
+- See the [pricing page](/pricing) for included origin image allocations and overage rates on paid plans.
 
 For detailed information about the different pricing options and features, please visit the [pricing page](/pricing).

--- a/src/routes/docs/advanced/platform/roles/+page.markdoc
+++ b/src/routes/docs/advanced/platform/roles/+page.markdoc
@@ -26,4 +26,4 @@ Analysts are limited to read-only access across all resources. This role is suit
 Billing users are restricted to billing-related actions, with access to `billing.read` and `billing.write` scopes only. They can view and manage billing details but cannot interact with other parts of the system.
 
 ## Custom roles {% #custom-roles %}
-Custom roles will soon be available on the Appwrite Console. Custom roles will be a Scale and Enterprise plans feature.
+Custom roles will soon be available on the Appwrite Console for Enterprise customers.

--- a/src/routes/docs/advanced/platform/scale/+page.markdoc
+++ b/src/routes/docs/advanced/platform/scale/+page.markdoc
@@ -1,9 +1,0 @@
----
-layout: article
-title: Scale
-description: Appwrite's Scale plan fully supports scaling your application.
----
-
-Appwrite's Scale plan is designed for growing development teams and agencies with many organizational members and large projects.
-The plan offers unlimited seats across your organization and dedicated resources per project.
-Scale plan organizations will receive additional compliance measures, organization roles, and dedicated support.

--- a/src/routes/docs/advanced/platform/uptime-sla/+page.markdoc
+++ b/src/routes/docs/advanced/platform/uptime-sla/+page.markdoc
@@ -14,7 +14,6 @@ We commit to maintaining the following monthly uptime percentages based on your 
 | --- | --- |
 | **Free** | N/A |
 | **Pro** | 99.5% |
-| **Scale** | 99.9% |
 | **Enterprise** | 99.95% |
 
 # Allowed downtime {% #allowed-downtime %}
@@ -25,7 +24,6 @@ Based on the above uptime commitments, permissible downtime durations are:
 | --- | --- | --- |
 | **Free** | N/A | N/A |
 | **Pro** | ~1.83 days | ~3.6 hours |
-| **Scale** | ~8.76 hours | ~43.2 minutes |
 | **Enterprise** | ~4.38 hours | ~21.6 minutes |
 
 # Service credit terms {% #service-credit-terms %}
@@ -35,7 +33,6 @@ If we fail to meet our uptime commitment, affected users may be eligible for ser
 | Plan | Uptime < Commitment but ≥ 99% | Uptime < 99% but ≥ 95% | Uptime < 95% |
 | --- | --- | --- | --- |
 | **Pro** | 10% of monthly fee | 25% of monthly fee | 50% of monthly fee |
-| **Scale** | 10% of monthly fee | 25% of monthly fee | 50% of monthly fee |
 | **Enterprise** | 10% of monthly fee | 25% of monthly fee | 50% of monthly fee |
 
 # Credit request procedure {% #credit-request-procedure %}

--- a/src/routes/docs/advanced/security/pci/+page.markdoc
+++ b/src/routes/docs/advanced/security/pci/+page.markdoc
@@ -4,7 +4,7 @@ title: PCI
 description: Learn about Appwrite's measure to achieve PCI compliance when handling payments and transactions, ensuring secure and safe handling of payment information and personal data.
 ---
 The Payment Card Industry Data Security Standard (PCI) is a standard that concerns the handling of credit card information, transactions, and payments.
-Appwrite uses [Stripe](https://stripe.com/en-se) to securely handle payments for Appwrite Pro and Scale plans. 
+Appwrite uses [Stripe](https://stripe.com/en-se) to securely handle payments for Appwrite paid plans. 
 Stripe is a [PCI Service Provider Level 1](https://www.visa.com/splisting/searchGrsp.do?companyNameCriteria=stripe) provider
 with a strong [commitment to security and privacy](https://stripe.com/docs/security) that matches Appwrite's core values.
 

--- a/src/routes/docs/products/databases/backups/+page.markdoc
+++ b/src/routes/docs/products/databases/backups/+page.markdoc
@@ -8,14 +8,14 @@ Appwrite Backups enable seamless, **encrypted** database backups on Cloud.
 All backups are **hot** backups, ensuring zero downtime and fast recovery.
 Learn how to efficiently back up your databases to ensure data security and smooth recovery.
 
-{% info title="Backups are available on Appwrite Cloud for all Pro, Scale, and Enterprise customers." %}
+{% info title="Backups are available on Appwrite Cloud for all Pro and Enterprise customers." %}
 {% /info %}
 
 Appwrite Backups allow you to automate database backups using backup policies, supporting pre-defined, custom retention & other options. You can also create manual backups whenever necessary.
 
 # Backup policies {% #backup-policies %}
 
-Backup policies allow you to automate your backup process. The Scale and Enterprise plans allow for more customization and offer options like how often backups should occur, how long they should be retained, and when they should run.
+Backup policies allow you to automate your backup process. The Enterprise plan allows for more customization and offers options like how often backups should occur, how long they should be retained, and when they should run.
 
 ## Creating a backup policy {% #creating-backup-policy %}
 
@@ -40,21 +40,21 @@ To automate your database backups, you need to create backup policies that run a
     ![Pro plan policy](/images/docs/databases/pro-policy.png)
     {% /only_light %}
 
-    * On **Scale** and **Enterprise** plans, you get access to more & custom policies\
+    * On the **Enterprise** plan, you get access to more & custom policies\
     &nbsp;
         * Select a pre-defined policy
             {% only_dark %}
-            ![Scale plan policies](/images/docs/databases/dark/scale-policies.png)
+            ![Enterprise plan policies](/images/docs/databases/dark/scale-policies.png)
             {% /only_dark %}
             {% only_light %}
-            ![Scale plan policies](/images/docs/databases/scale-policies.png)
+            ![Enterprise plan policies](/images/docs/databases/scale-policies.png)
             {% /only_light %}
         * Or create a custom policy and adjust the settings as you like
             {% only_dark %}
-            ![Custom policies for Scale plan](/images/docs/databases/dark/scale-custom-policies.png)
+            ![Custom policies for Enterprise plan](/images/docs/databases/dark/scale-custom-policies.png)
             {% /only_dark %}
             {% only_light %}
-            ![Custom policies for Scale plan](/images/docs/databases/scale-custom-policies.png)
+            ![Custom policies for Enterprise plan](/images/docs/databases/scale-custom-policies.png)
             {% /only_light %}
 
 4. Click on **Create**

--- a/src/routes/docs/products/databases/transactions/+page.markdoc
+++ b/src/routes/docs/products/databases/transactions/+page.markdoc
@@ -26,7 +26,6 @@ The maximum number of operations you can stage per transaction depends on your p
 |------|-------------------------------|
 | Free | 100 |
 | Pro | 1,000 |
-| Scale | 2,500 |
 
 # Create a transaction {% #create-a-transaction %}
 


### PR DESCRIPTION
Remove all mentions of the Appwrite Scale plan from the documentation to reflect current offerings.

This PR removes all references to the Appwrite Scale plan, including its dedicated documentation page, and updates related content to refer to generic paid plans, Pro, or Enterprise plans where appropriate. This ensures the documentation accurately reflects the current product offerings.

---
<a href="https://cursor.com/background-agent?bcId=bc-c089b5ad-00aa-4c53-b2ca-937d42e4c869"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c089b5ad-00aa-4c53-b2ca-937d42e4c869"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

