### PR TITLE
fix: update databases key to tablesDB

### DIFF
--- a/src/routes/docs/tooling/command-line/tables/+page.markdoc
+++ b/src/routes/docs/tooling/command-line/tables/+page.markdoc
@@ -32,7 +32,7 @@ After [initializing](/docs/tooling/command-line/installation#initialization) you
 {
     "projectId": "<PROJECT_ID>",
     "endpoint": "https://<REGION>.cloud.appwrite.io/v1",
-    "databases": [
+    "tablesDB": [
         {
             "$id": "<DATABASE_ID>",
             "name": "songs",


### PR DESCRIPTION

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

The legacy DB type used databases for the key. Since we have our new tables DB API, the key is now tablesDB.

Fixes https://github.com/appwrite/sdk-for-cli/issues/209

## Test Plan

None

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Configuration examples and reference documentation have been updated to reflect new naming standards for table configuration. This ensures developers have access to current and accurate examples that align with the latest schema standards, making it easier to implement correct configurations without confusion or compatibility issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->