### PR TITLE
fix: Docker build and switch runtime to Node.js

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1 AS base
+FROM oven/bun:1.3.1 AS base
 
 ARG PUBLIC_APPWRITE_ENDPOINT
 ENV PUBLIC_APPWRITE_ENDPOINT ${PUBLIC_APPWRITE_ENDPOINT}
@@ -57,11 +57,16 @@ COPY bun.lock bun.lock
 
 FROM base AS build
 
-COPY . .
 RUN bun install --frozen-lockfile
+COPY . .
+RUN bun run sync
 RUN bun run build
 
-FROM base AS final
+FROM base AS prod-deps
+
+RUN bun install --frozen-lockfile --production
+
+FROM node:22-bullseye AS final
 
 # Install fontconfig
 COPY ./local-fonts /usr/share/fonts
@@ -70,8 +75,9 @@ RUN apt-get update && \
 	apt-get autoremove --purge && \
 	rm -rf /var/lib/apt/lists/*
 RUN fc-cache -f -v
+
 COPY --from=build /app/build/ build
 COPY --from=build /app/server/ server
-RUN bun install --frozen-lockfile --prod
+COPY --from=prod-deps /app/node_modules/ node_modules
 
-CMD ["bun", "server/main.js"]
+CMD ["node", "server/main.js"]

--- a/src/routes/[variation]/+page.ts
+++ b/src/routes/[variation]/+page.ts
@@ -11,7 +11,7 @@ export const load: PageLoad = ({ params }) => {
     const config = getVariationConfig(key);
 
     if (!config) {
-        throw error(404, 'Page not found');
+        throw error(404, 'Not Found');
     }
 
     return { config };


### PR DESCRIPTION
- Pin Bun base image to version 1.3.1 
- Reorder build steps to install dependencies before copying source code 
- Add sync step before build 
- Separate production dependencies into dedicated stage 
- Switch final runtime from Bun to Node.js 22 
- Copy pre-built node_modules instead of installing in final stage 
- Update error message to "Not Found"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration with latest dependencies and optimized build process
  * Minor adjustment to error message text

<!-- end of auto-generated comment: release notes by coderabbit.ai -->