### PR TITLE
fix og image sizes for blog posts

### DIFF
--- a/src/markdoc/layouts/Post.svelte
+++ b/src/markdoc/layouts/Post.svelte
@@ -90,8 +90,8 @@
     <meta name="twitter:description" content={description} />
     <!-- Image -->
     <meta property="og:image" content={DEFAULT_HOST + cover} />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
+    <meta property="og:image:width" content="1463" />
+    <meta property="og:image:height" content="822" />
     <meta name="twitter:image" content={DEFAULT_HOST + cover} />
     <meta name="twitter:card" content="summary_large_image" />
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Open Graph image metadata dimensions for social media previews. Image dimensions adjusted to 1463×822 pixels to optimize how posts appear when shared across social platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->