### PR TITLE
Update beginner function execution tutorial as the expected data has changed 

### DIFF
--- a/src/routes/docs/advanced/platform/events/+page.markdoc
+++ b/src/routes/docs/advanced/platform/events/+page.markdoc
@@ -5,7 +5,7 @@ description: Harness the power of events in Appwrite. Explore event-driven archi
 ---
 
 Appwrite provides a variety of events that allows your application to react to changes as they happen.
-A event will fire when a change occurs in your Appwrite project, like when a new user registers or a new file is uploaded to Appwrite.
+An event will fire when a change occurs in your Appwrite project, like when a new user registers or a new file is uploaded to Appwrite.
 You can subscribe to these events with Appwrite [Functions](/docs/products/functions), [Realtime](/docs/apis/realtime), or [Webhooks](/docs/advanced/platform/webhooks).
 
 You can subscribe to events for specific resources using their ID or subscribe to changes of all resources of the same type by using a wildcard character * instead of an ID.


### PR DESCRIPTION
The curl command's body now requires the following:
```bash
-d '{"body":"this is json data"}' # new
-d '{"data":"this is json data"}' # previous
```
Which translates to the following in javascript fetch. (This took me 2 days to figure out, I am such an idiot)

```
fetch('https://64d4d22db370ae41a32e.appwrite.global', {
  method: 'POST',
  headers: {
    'X-Custom-Header': '123',
    'x-appwrite-user-jwt': '<YOUR_JWT_KEY>',
    'Content-Type': 'application/json'
  },
  body: JSON.stringify({
    'body': 'this is json data'
  })
});
```

## What does this PR do?

Update the beginner function execution tutorial so the curl command contains the correct data.

## Test Plan

I tested it against: https://syd.cloud.appwrite.io/v1 - REST

my javascript code is:
```
const payload = JSON.stringify({
        'user': l_user,
        'message': l_message
    });
    
    var bodyString = JSON.stringify({
        body: payload
    });

    var request = {
        method: 'POST',
        headers: {
            'Content-Type': 'application/json',
            'X-Appwrite-Project': PROJECT_ID,
            'X-Appwrite-JWT': jwt 
        },
        body: bodyString
    }
```

## Related PRs and Issues

I have not looked, but it seems to be well documented somewhere as I found the answer somewhere in solved git issues, and in Discord archived messages.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

I have read the CONTRIBUTING.md, but I am an really stupid (also sick and sleepy).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API request examples to reflect the correct payload structure for function execution in POST requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->