### PR TITLE
Hide Hacktoberfest 2025 hackathon banner

### DIFF
--- a/src/lib/layouts/Main.svelte
+++ b/src/lib/layouts/Main.svelte
@@ -161,6 +161,7 @@
 </script>
 
 <div class="relative contents h-full">
+    <!--
     {#if !page.url.pathname.includes('/init')}
         <div class="border-smooth relative z-10 border-b bg-[#19191C]" id="top-banner">
             <div class="is-special-padding mx-auto">
@@ -168,6 +169,7 @@
             </div>
         </div>
     {/if}
+    -->
 
     <section
         class="web-mobile-header flex! lg:hidden! {resolvedTheme}"


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Hides Hacktoberfest hackathon banner from the homepage

## Test Plan

Visit the homepage

## Related PRs and Issues

#2471 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * The top banner display has been disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->