### PR TITLE
Add disable image transformation changelog

### DIFF
--- a/src/routes/changelog/(entries)/2025-11-21.markdoc
+++ b/src/routes/changelog/(entries)/2025-11-21.markdoc
@@ -6,7 +6,7 @@ date: 2025-11-21
 
 You can now disable image transformations for any storage bucket.
 
-Image transformations allow resizing, cropping, and format conversion through the Appwrite Storage API. With this update, you have full control to turn off these operations when they're not needed, reducing the chance of unintentional processing or costs.
+Image transformations allow actions like resizing, cropping, and format conversion through the Appwrite Storage API. With this update, you have full control to turn off these operations when they're not needed, reducing the chance of unintentional processing or costs.
 
 This update is useful if you:
 
@@ -14,7 +14,7 @@ This update is useful if you:
 - Need to restrict buckets to serve only original files.
 - Want greater control over how images are accessed and displayed.
 
-You can find the toggle in your bucket settings under Image transformations.
+You can find the toggle in your bucket settings under **Image transformations**.
 
 {% arrow_link href="https://appwrite.io/discord" %}
 Join the conversation on Discord


### PR DESCRIPTION
## What does this PR do?
New changelog entry

## Test Plan
- `/changelog`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a per-bucket setting in Storage to disable image transformations (resize, crop, format conversion), allowing buckets to serve originals only, avoid unintended processing, and reduce transformation-related costs.

* **Documentation**
  * Added a changelog entry describing the per-bucket image transformation toggle, typical use cases, and where to find the setting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->