### PR TITLE
add changelog entry for file token url fix

### DIFF
--- a/src/routes/changelog/(entries)/2025-12-01.markdoc
+++ b/src/routes/changelog/(entries)/2025-12-01.markdoc
@@ -13,9 +13,9 @@ We've fixed two issues with non-expiring file tokens:
 
 With this fix:
 
-- Non-expiring file tokens now generate consistent URLs across all requests
-- URLs remain valid indefinitely as intended
-- Improved reliability for long-term file sharing and caching strategies
+- Non-expiring file tokens now generate consistent URLs across all requests.
+- URLs remain valid indefinitely as intended.
+- Improved reliability for long-term file sharing and caching strategies.
 
 This update is now live on Appwrite Cloud.
 


### PR DESCRIPTION
## What does this PR do?
Adds a new changelog entry documenting a fix for file token URL consistency and expiration issues in Appwrite Cloud

## Test Plan

- `/changelog/entry/2025-12-01`

## Related PRs and Issues
DRL-1827


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed non-expiring file tokens that were incorrectly expiring after 15 minutes.
  * Resolved inconsistent URL generation for file tokens across requests.
  * File sharing URLs now generate consistently and remain valid indefinitely, improving reliability for long-term sharing and caching.
  * Update is live on Appwrite Cloud.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->