### PR TITLE
fix: avoid duplicate methods in API reference sidebar groups

### DIFF
--- a/src/routes/docs/references/[version]/[platform]/[service]/+page.svelte
+++ b/src/routes/docs/references/[version]/[platform]/[service]/+page.svelte
@@ -175,9 +175,23 @@
         });
     }
 
+    /**
+     * Groups methods by `group` and de-duplicates titles per group.
+     */
     function groupMethodsByGroup(methods: SDKMethod[]) {
+        const seen = new Set<string>();
+
         return methods.reduce<Record<string, SDKMethod[]>>((acc, method) => {
             const groupKey = method.group || '';
+            const dedupeKey = `${groupKey}::${method.title}`;
+
+            // skip duplicate titles within the same group
+            if (seen.has(dedupeKey)) {
+                return acc;
+            }
+
+            seen.add(dedupeKey);
+
             if (!acc[groupKey]) {
                 acc[groupKey] = [];
             }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?
before:
<img width="331" height="463" alt="image" src="https://github.com/user-attachments/assets/1e66d4f7-d25d-44d4-9a32-a1552060f6ed" />
after:
<img width="284" height="281" alt="image" src="https://github.com/user-attachments/assets/69325412-21e9-460b-aa15-ade8c7d6e960" />


## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced documentation reference pages to eliminate duplicate method listings and provide cleaner organization of SDK reference material.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->