### PR TITLE
Refactor Copy as Markdown and Dockerfile update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,6 +78,7 @@ RUN fc-cache -f -v
 
 COPY --from=build /app/build/ build
 COPY --from=build /app/server/ server
+COPY --from=build /app/src/routes/ src/routes
 COPY --from=prod-deps /app/node_modules/ node_modules
 
 CMD ["node", "server/main.js"]


### PR DESCRIPTION
- Copy routes directory from build stage into image 
- Refactor Copy as Markdown to fetch markdown on demand 
- Replace page store import with app state and simplify state usage 
- Implement copy state (copied, copying) and new UI flow 
- Restore menu with Copy as Markdown and View as Markdown options


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dropdown menu interface for markdown operations, providing Copy as Markdown and View as Markdown options
  * Added visual "Copied" indicator that displays for 2 seconds after successful copy actions

* **Improvements**
  * Enhanced markdown copy functionality with on-demand retrieval for better performance
  * Copy button now disabled during operation for improved user experience

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->