### PR TITLE
Add support for public attribute filtering in API docs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "appwrite-website",
@@ -13,7 +12,7 @@
         "@appwrite.io/console": "^0.6.4",
         "@appwrite.io/pink": "~0.26.0",
         "@appwrite.io/pink-icons": "~0.26.0",
-        "@appwrite.io/repo": "github:appwrite/appwrite#aa98fbb2dc0e08def0a7cca7fe0515de643154ca",
+        "@appwrite.io/repo": "github:appwrite/appwrite#aa12ef65693ea5fbbd954c0641f76422b440eb7a",
         "@eslint/compat": "^1.4.1",
         "@eslint/js": "^9.39.1",
         "@fingerprintjs/fingerprintjs": "^4.6.2",
@@ -126,7 +125,7 @@
 
     "@appwrite.io/pink-icons": ["@appwrite.io/pink-icons@0.26.0", "", {}, "sha512-abLQdT0zlDkEEwvgU1ymFq0ztxuRerwx7t1oeUGFgXlm9gXrxt6nce2f5GRqg9Rb7hM3F3nyc1ds8zRRWHQOyw=="],
 
-    "@appwrite.io/repo": ["@appwrite.io/repo@github:appwrite/appwrite#aa98fbb", {}, "appwrite-appwrite-aa98fbb"],
+    "@appwrite.io/repo": ["@appwrite.io/repo@github:appwrite/appwrite#aa12ef6", {}, "appwrite-appwrite-aa12ef6"],
 
     "@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "7.27.1", "js-tokens": "4.0.0", "picocolors": "1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "@appwrite.io/console": "^0.6.4",
         "@appwrite.io/pink": "~0.26.0",
         "@appwrite.io/pink-icons": "~0.26.0",
-        "@appwrite.io/repo": "github:appwrite/appwrite#aa98fbb2dc0e08def0a7cca7fe0515de643154ca",
+        "@appwrite.io/repo": "github:appwrite/appwrite#aa12ef65693ea5fbbd954c0641f76422b440eb7a",
         "@eslint/compat": "^1.4.1",
         "@eslint/js": "^9.39.1",
         "@fingerprintjs/fingerprintjs": "^4.6.2",

--- a/src/routes/docs/references/[version]/[platform]/[service]/specs.ts
+++ b/src/routes/docs/references/[version]/[platform]/[service]/specs.ts
@@ -52,6 +52,7 @@ type AppwriteOperationObject = OpenAPIV3.OperationObject & {
         scope: string;
         platforms: string[];
         packaging: boolean;
+        public: boolean;
         methods?: AppwriteAdditionalMethod[];
     };
 };
@@ -65,6 +66,7 @@ type AppwriteAdditionalMethod = {
     responses: { code: number; model: string }[];
     description: string;
     demo: string;
+    public: boolean;
     deprecated?: AppwriteDeprecated;
 };
 
@@ -208,6 +210,11 @@ function* processAdditionalMethods(
     const additionalMethods = appwriteMethod['x-appwrite'].methods!;
 
     for (const additionalMethod of additionalMethods) {
+        // Skip methods where public is false
+        if (additionalMethod.public === false) {
+            continue;
+        }
+
         yield {
             method: httpMethod,
             value: {
@@ -221,7 +228,8 @@ function* processAdditionalMethods(
                 'x-appwrite': {
                     ...appwriteMethod['x-appwrite'],
                     method: additionalMethod.name,
-                    demo: additionalMethod.demo
+                    demo: additionalMethod.demo,
+                    public: additionalMethod.public
                 },
                 responses: {
                     ...appwriteMethod.responses,
@@ -257,28 +265,43 @@ function* iterateAllMethods(
 
         // Handle non-additional methods
         if (methods?.get?.tags?.includes(service) && !hasAdditionalMethods(methods.get, service)) {
-            yield { method: OpenAPIV3.HttpMethods.GET, value: methods.get, url };
+            const operation = methods.get as AppwriteOperationObject;
+            if (operation['x-appwrite']?.public !== false) {
+                yield { method: OpenAPIV3.HttpMethods.GET, value: methods.get, url };
+            }
         }
         if (
             methods?.post?.tags?.includes(service) &&
             !hasAdditionalMethods(methods.post, service)
         ) {
-            yield { method: OpenAPIV3.HttpMethods.POST, value: methods.post, url };
+            const operation = methods.post as AppwriteOperationObject;
+            if (operation['x-appwrite']?.public !== false) {
+                yield { method: OpenAPIV3.HttpMethods.POST, value: methods.post, url };
+            }
         }
         if (methods?.put?.tags?.includes(service) && !hasAdditionalMethods(methods.put, service)) {
-            yield { method: OpenAPIV3.HttpMethods.PUT, value: methods.put, url };
+            const operation = methods.put as AppwriteOperationObject;
+            if (operation['x-appwrite']?.public !== false) {
+                yield { method: OpenAPIV3.HttpMethods.PUT, value: methods.put, url };
+            }
         }
         if (
             methods?.patch?.tags?.includes(service) &&
             !hasAdditionalMethods(methods.patch, service)
         ) {
-            yield { method: OpenAPIV3.HttpMethods.PATCH, value: methods.patch, url };
+            const operation = methods.patch as AppwriteOperationObject;
+            if (operation['x-appwrite']?.public !== false) {
+                yield { method: OpenAPIV3.HttpMethods.PATCH, value: methods.patch, url };
+            }
         }
         if (
             methods?.delete?.tags?.includes(service) &&
             !hasAdditionalMethods(methods.delete, service)
         ) {
-            yield { method: OpenAPIV3.HttpMethods.DELETE, value: methods.delete, url };
+            const operation = methods.delete as AppwriteOperationObject;
+            if (operation['x-appwrite']?.public !== false) {
+                yield { method: OpenAPIV3.HttpMethods.DELETE, value: methods.delete, url };
+            }
         }
 
         // Process additional methods


### PR DESCRIPTION
## Summary
- Added `public` attribute to `AppwriteOperationObject` and `AppwriteAdditionalMethod` type definitions
- Updated `iterateAllMethods` function to filter out methods where `public` is set to `false`
- Updated `processAdditionalMethods` function to skip additional methods where `public` is `false`
- Updated dependency `@appwrite.io/repo` to include spec files with the new `public` attribute

This change allows API methods to be conditionally rendered in the documentation based on the `public` attribute in the OpenAPI spec's `x-appwrite` metadata.

## Test plan
- [ ] Verify that methods with `public: true` are displayed in the documentation
- [ ] Verify that methods with `public: false` are not displayed in the documentation
- [ ] Test with both regular methods and additional methods defined in `x-appwrite.methods`
- [ ] Ensure no TypeScript errors in the updated code

before and after:
<img width="263" height="745" alt="Screenshot 2025-12-11 at 2 02 12 PM" src="https://github.com/user-attachments/assets/fd4ab171-7bb9-487f-8695-016d30d54084" />
<img width="288" height="617" alt="Screenshot 2025-12-11 at 2 04 58 PM" src="https://github.com/user-attachments/assets/67af387c-7aae-4e98-b117-a44ac6ecd84c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API methods can now be marked as public or hidden from documentation and references.

* **Chores**
  * Updated development dependencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->