### PR TITLE
fix: Product menu remains in active state after dropdown is closed

### DIFF
--- a/src/lib/components/ProductsSubmenu.svelte
+++ b/src/lib/components/ProductsSubmenu.svelte
@@ -93,9 +93,9 @@
 
 <button
     class={cn(
-        'text-primary focus:text-accent hover:text-accent inline-flex cursor-pointer items-center justify-between outline-none',
+        'text-primary hover:text-accent focus:text-accent inline-flex cursor-pointer items-center justify-between outline-none transition-colors',
         {
-            'text-accent': $open
+            '!text-accent': $open
         }
     )}
     use:melt={$trigger}


### PR DESCRIPTION
## What does this PR do?

Fixes the bug where the "Products" navigation menu item remains in its active (red) state after the dropdown is closed and the mouse is moved away from the menu item.

**Changes made:**
- Updated the button class logic in `ProductsSubmenu.svelte` to use `!text-accent` for proper CSS specificity when dropdown is open
- Added `transition-colors` utility class for smooth color transitions between states
- Ensures the active state properly clears when `$open` state becomes false

## Test Plan

**Steps to verify the fix:**

1. Navigate to https://appwrite.io (or run the website locally)
2. Click on "Products" in the top navigation bar
3. Observe that the menu item turns red and dropdown opens
4. Click on "Products" again to close the dropdown
5. Move the mouse away from the "Products" menu item
6. **Expected result:** The "Products" menu item should return to its default (non-active) color
7. **Before fix:** The menu item would remain red/active
8. **After fix:** The menu item properly returns to default color

**Additional test cases:**
- Hover over "Products" → should turn red
- Move mouse away → should return to default color
- Click to open dropdown → should stay red while open
- Click outside to close dropdown → should return to default color

## Related PRs and Issues

Closes appwrite/website#2762 [https://github.com/appwrite/website/issues/2762]

## Screenshots
<img width="1854" height="544" alt="demo" src="https://github.com/user-attachments/assets/092d4226-e368-4c8a-bef8-b84c108760ee" />


**Before fix:**
(The Products menu remains red after closing dropdown)

**After fix:**
(The Products menu returns to default color after closing dropdown)
## Screenshots
<img width="1901" height="734" alt="image" src="https://github.com/user-attachments/assets/5380148d-0143-4eed-8d6f-7a8387284552" />



### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes, I have read and followed the Contributing Guidelines.