### PR TITLE
fix: reset navbar active state after dropdown close

### DIFF
--- a/src/lib/components/ProductsSubmenu.svelte
+++ b/src/lib/components/ProductsSubmenu.svelte
@@ -93,10 +93,9 @@
 
 <button
     class={cn(
-        'text-primary focus:text-accent hover:text-accent inline-flex cursor-pointer items-center justify-between outline-none',
-        {
-            'text-accent': $open
-        }
+        'inline-flex cursor-pointer items-center justify-between outline-none transition-colors',
+        'hover:text-accent focus-visible:text-accent',
+        $open ? 'text-accent' : 'text-primary'
     )}
     use:melt={$trigger}
 >


### PR DESCRIPTION
## What does this PR do?

Resolves an issue where the **Products** navigation item stayed highlighted after its dropdown was closed.

The menu state now correctly reflects whether the dropdown is open or not.

<img width="1854" height="544" alt="Screenshot 2025-12-28 155731" src="https://github.com/user-attachments/assets/212727a6-dd76-47f1-b2d9-03e62e3cc4c8" />



---

## What was changed?

- Updated the focus styling to use `focus-visible:text-accent` instead of `focus:text-accent` for more accurate focus behavior
- Added `transition-colors` to provide smoother visual state changes
- Simplified conditional class handling by switching from object syntax to a ternary expression
- Ensured the active style is removed when the dropdown closes and focus is lost via mouse interaction

---

## Test Plan

1. Open the website
2. Click **Products** in the top navigation
3. Close the dropdown
4. Move the cursor away

**Expected:**  
The **Products** menu item returns to its default color.
<img width="1877" height="804" alt="Screenshot 2025-12-29 175932" src="https://github.com/user-attachments/assets/8cd2d70b-4855-4b2f-87aa-fded18192617" />
<img width="1838" height="441" alt="image" src="https://github.com/user-attachments/assets/6c91c876-949d-4e57-a1a6-989f7526c75f" />

---

## Additional checks

- Hover shows active color
- Dropdown open keeps active color
- Clicking outside resets the state correctly

---

## Related Issue

Closes #11029


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Style**
- Enhanced button styling in the product submenu with improved visual transitions and refined hover and focus state effects.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->