### PR TITLE
Move Queries and Order from Journeys to Concepts in database docs menu

### DIFF
--- a/src/routes/docs/products/databases/+layout.svelte
+++ b/src/routes/docs/products/databases/+layout.svelte
@@ -52,6 +52,14 @@
                     href: '/docs/products/databases/relationships'
                 },
                 {
+                    label: 'Queries',
+                    href: '/docs/products/databases/queries'
+                },
+                {
+                    label: 'Order',
+                    href: '/docs/products/databases/order'
+                },
+                {
                     label: 'Operators',
                     href: '/docs/products/databases/operators',
                     new: isNewUntil('31 Dec 2025')
@@ -70,14 +78,6 @@
         {
             label: 'Journeys',
             items: [
-                {
-                    label: 'Queries',
-                    href: '/docs/products/databases/queries'
-                },
-                {
-                    label: 'Order',
-                    href: '/docs/products/databases/order'
-                },
                 {
                     label: 'Pagination',
                     href: '/docs/products/databases/pagination'


### PR DESCRIPTION
## What does this PR do?
Reorganizes the database documentation menu by moving the 'Queries' and 'Order' pages from the Journeys section to the Concepts section.

## Test Plan

See sidebar on: `/docs/products/databases`

<img width="592" height="468" alt="Screenshot 2026-01-13 at 18 03 42" src="https://github.com/user-attachments/assets/7f7a8157-778c-4943-9bef-302eea7439f5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized database documentation navigation by moving "Queries" and "Order" sections from Journeys to Concepts for improved information architecture and discoverability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->