### PR TITLE
fix: remove scale plan from docs

### DIFF
--- a/src/routes/docs/advanced/platform/+layout.svelte
+++ b/src/routes/docs/advanced/platform/+layout.svelte
@@ -85,10 +85,6 @@
                     href: '/docs/advanced/platform/pro'
                 },
                 {
-                    label: 'Scale',
-                    href: '/docs/advanced/platform/scale'
-                },
-                {
                     label: 'Enterprise',
                     href: '/docs/advanced/platform/enterprise'
                 },


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the "Scale" plan navigation link from the documentation sidebar's Plans section.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->