### PR TITLE
Fix import path casing for tablesdb package

### DIFF
--- a/src/routes/docs/quick-starts/go/+page.markdoc
+++ b/src/routes/docs/quick-starts/go/+page.markdoc
@@ -79,7 +79,7 @@ package main
 import (
 	"github.com/appwrite/sdk-for-go/appwrite"
 	"github.com/appwrite/sdk-for-go/client"
-	"github.com/appwrite/sdk-for-go/tablesDB"
+	"github.com/appwrite/sdk-for-go/tablesdb"
 	"github.com/appwrite/sdk-for-go/models"
 	"github.com/appwrite/sdk-for-go/query"
 )
@@ -88,7 +88,7 @@ var (
 	appwriteClient    client.Client
 	todoDatabase      *models.Database
 	todoTable    *models.Table
-	appwriteDatabases *tablesDB.TablesDB
+	appwriteDatabases *tablesdb.TablesDB
 )
 
 func main() {
@@ -275,7 +275,7 @@ import (
 
 	"github.com/appwrite/sdk-for-go/appwrite"
 	"github.com/appwrite/sdk-for-go/client"
-	"github.com/appwrite/sdk-for-go/tablesDB"
+	"github.com/appwrite/sdk-for-go/tablesdb"
 	"github.com/appwrite/sdk-for-go/id"
 	"github.com/appwrite/sdk-for-go/models"
 	"github.com/appwrite/sdk-for-go/query"
@@ -285,7 +285,7 @@ var (
 	appwriteClient    client.Client
 	todoDatabase      *models.Database
 	todoTable    *models.Table
-	tablesDB *tablesDB.TablesDB
+	tablesDB *tablesdb.TablesDB
 )
 
 func main() {


### PR DESCRIPTION
Tried using the Appwrite SDK for Golang but encountered an issue while importing TablesDB. The official Golang docs (https://pkg.go.dev/github.com/appwrite/sdk-for-go/tablesdb) actually allow for tablesdb while the Appwrite docs ask for TablesDB.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Changes the naming import from tablesDB to tablesdb


## Test Plan

I am working on a project right now and using tablesDB throws:
<img width="897" height="171" alt="image" src="https://github.com/user-attachments/assets/8b76ae39-4620-4391-a124-817e5795b0e5" />

Using tablesdb works
<img width="703" height="416" alt="image" src="https://github.com/user-attachments/assets/d8407f3d-dc0a-4707-97ea-a88ebbe5d547" />



## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Updated Go quick-start guide with corrected package import paths and type references in code examples. These updates ensure sample code properly compiles and aligns with the current SDK structure, enabling developers to successfully follow the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->