### PR TITLE
Strip code fences from repo examples

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
         "@appwrite.io/console": "^0.6.4",
         "@appwrite.io/pink": "~0.26.0",
         "@appwrite.io/pink-icons": "~0.26.0",
-        "@appwrite.io/repo": "github:appwrite/appwrite#0dd2f29a7eb4ed232fdb68d0af88e157ddbddba3",
+        "@appwrite.io/repo": "github:appwrite/appwrite#31b5a1cb360b1350dd1b887e01179bce171c34bc",
         "@eslint/compat": "^1.4.1",
         "@eslint/js": "^9.39.1",
         "@fingerprintjs/fingerprintjs": "^4.6.2",
@@ -130,7 +130,7 @@
 
     "@appwrite.io/pink-icons": ["@appwrite.io/pink-icons@0.26.0", "", {}, "sha512-abLQdT0zlDkEEwvgU1ymFq0ztxuRerwx7t1oeUGFgXlm9gXrxt6nce2f5GRqg9Rb7hM3F3nyc1ds8zRRWHQOyw=="],
 
-    "@appwrite.io/repo": ["@appwrite.io/repo@github:appwrite/appwrite#0dd2f29", {}, "appwrite-appwrite-0dd2f29"],
+    "@appwrite.io/repo": ["@appwrite.io/repo@github:appwrite/appwrite#31b5a1c", {}, "appwrite-appwrite-31b5a1c"],
 
     "@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "7.27.1", "js-tokens": "4.0.0", "picocolors": "1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "@appwrite.io/console": "^0.6.4",
         "@appwrite.io/pink": "~0.26.0",
         "@appwrite.io/pink-icons": "~0.26.0",
-        "@appwrite.io/repo": "github:appwrite/appwrite#0dd2f29a7eb4ed232fdb68d0af88e157ddbddba3",
+        "@appwrite.io/repo": "github:appwrite/appwrite#31b5a1cb360b1350dd1b887e01179bce171c34bc",
         "@eslint/compat": "^1.4.1",
         "@eslint/js": "^9.39.1",
         "@fingerprintjs/fingerprintjs": "^4.6.2",

--- a/src/routes/docs/references/[version]/[platform]/[service]/specs.ts
+++ b/src/routes/docs/references/[version]/[platform]/[service]/specs.ts
@@ -148,6 +148,15 @@ function getExamples(version: string) {
     }
 }
 
+function stripMarkdownCodeFence(content: string): string {
+    const trimmed = content.trim();
+    const fenced = trimmed.match(/^```[^\n]*\n([\s\S]*?)\n```[ \t]*$/);
+    if (fenced) {
+        return fenced[1];
+    }
+    return content;
+}
+
 function filterRequestBodyProperties(
     requestBody: OpenAPIV3.ReferenceObject | OpenAPIV3.RequestBodyObject | undefined,
     allowedParameters: string[]
@@ -508,7 +517,7 @@ export async function getService(
         data.methods.push({
             id: operation['x-appwrite'].method,
             group: operation['x-appwrite'].group,
-            demo: typeof demo === 'string' ? demo : '',
+            demo: typeof demo === 'string' ? stripMarkdownCodeFence(demo) : '',
             title: operation.summary ?? '',
             description: operation.description ?? '',
             parameters: parameters ?? [],


### PR DESCRIPTION
## Summary
- strip markdown code fences from @appwrite.io/repo examples before rendering
- prevent nested fences in API reference example panel

## Testing
- not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated development dependencies

* **Bug Fixes**
  * Improved demo content display by removing unnecessary formatting syntax

<!-- end of auto-generated comment: release notes by coderabbit.ai -->