### PR TITLE
fix: resolve race condition in auth bento password animation

### DIFF
--- a/src/lib/animations/index.ts
+++ b/src/lib/animations/index.ts
@@ -25,10 +25,14 @@ export function write(
             }
         }, step);
 
-        signal?.addEventListener('abort', () => {
-            clearInterval(interval);
-            reject(new Error('Aborted'));
-        });
+        signal?.addEventListener(
+            'abort',
+            () => {
+                clearInterval(interval);
+                reject(new Error('Aborted'));
+            },
+            { once: true }
+        );
     });
 }
 
@@ -59,10 +63,14 @@ export function unwrite(
             }
         }, step);
 
-        signal?.addEventListener('abort', () => {
-            clearInterval(interval);
-            reject(new Error('Aborted'));
-        });
+        signal?.addEventListener(
+            'abort',
+            () => {
+                clearInterval(interval);
+                reject(new Error('Aborted'));
+            },
+            { once: true }
+        );
     });
 }
 

--- a/src/lib/animations/index.ts
+++ b/src/lib/animations/index.ts
@@ -8,6 +8,10 @@ export function write(
         cb('');
         return Promise.resolve();
     }
+    if (startIndex >= text.length) {
+        cb(text);
+        return Promise.resolve();
+    }
     const step = duration / text.length;
     let i = startIndex;
 
@@ -48,6 +52,11 @@ export function unwrite(
     }
     const step = duration / text.length;
     let i = startIndex ?? text.length;
+    
+    if (i <= 0) {
+        cb('');
+        return Promise.resolve();
+    }
 
     return new Promise<void>((resolve, reject) => {
         const interval = setInterval(() => {

--- a/src/lib/animations/index.ts
+++ b/src/lib/animations/index.ts
@@ -1,36 +1,68 @@
-export function write(text: string, cb: (v: string) => void, duration = 500) {
+export function write(
+    text: string,
+    cb: (v: string) => void,
+    duration = 500,
+    { signal, startIndex = 0 }: { signal?: AbortSignal; startIndex?: number } = {}
+) {
     if (text.length === 0) {
         cb('');
         return Promise.resolve();
     }
     const step = duration / text.length;
-    let i = 0;
-    return new Promise<void>((resolve) => {
+    let i = startIndex;
+
+    return new Promise<void>((resolve, reject) => {
         const interval = setInterval(() => {
+            if (signal?.aborted) {
+                clearInterval(interval);
+                return reject(new Error('Aborted'));
+            }
+
             cb(text.slice(0, ++i));
             if (i === text.length) {
                 clearInterval(interval);
                 resolve();
             }
         }, step);
+
+        signal?.addEventListener('abort', () => {
+            clearInterval(interval);
+            reject(new Error('Aborted'));
+        });
     });
 }
 
-export function unwrite(text: string, cb: (v: string) => void, duration = 500) {
+export function unwrite(
+    text: string,
+    cb: (v: string) => void,
+    duration = 500,
+    { signal, startIndex }: { signal?: AbortSignal; startIndex?: number } = {}
+) {
     if (text.length === 0) {
         cb('');
         return Promise.resolve();
     }
     const step = duration / text.length;
-    let i = text.length;
-    return new Promise<void>((resolve) => {
+    let i = startIndex ?? text.length;
+
+    return new Promise<void>((resolve, reject) => {
         const interval = setInterval(() => {
+            if (signal?.aborted) {
+                clearInterval(interval);
+                return reject(new Error('Aborted'));
+            }
+
             cb(text.slice(0, --i));
             if (i === 0) {
                 clearInterval(interval);
                 resolve();
             }
         }, step);
+
+        signal?.addEventListener('abort', () => {
+            clearInterval(interval);
+            reject(new Error('Aborted'));
+        });
     });
 }
 

--- a/src/routes/(marketing)/(components)/bento/(animations)/auth.svelte
+++ b/src/routes/(marketing)/(components)/bento/(animations)/auth.svelte
@@ -14,17 +14,33 @@
     let password = $state('');
     let button: HTMLButtonElement;
 
+    let controller: AbortController | null = null;
+
     $effect(() => {
         inView(
             container,
             () => {
                 if (!isMobile()) return;
 
-                write('•••••••••••••', (v) => (password = v), 1000).then(() => {
-                    animate(button, { scale: [1, 0.95, 1] }, { duration: 0.25 });
-                });
+                controller?.abort();
+                controller = new AbortController();
+
+                write('•••••••••••••', (v) => (password = v), 1000, {
+                    signal: controller.signal,
+                    startIndex: password.length
+                })
+                    .then(() => {
+                        animate(button, { scale: [1, 0.95, 1] }, { duration: 0.25 });
+                    })
+                    .catch(() => {});
+
                 return () => {
-                    unwrite('•••••••••••••', (v) => (password = v));
+                    controller?.abort();
+                    controller = new AbortController();
+                    unwrite('•••••••••••••', (v) => (password = v), 500, {
+                        signal: controller.signal,
+                        startIndex: password.length
+                    }).catch(() => {});
                 };
             },
             { amount: 'all' }
@@ -33,11 +49,25 @@
         hover(container, () => {
             if (isMobile()) return;
 
-            write('•••••••••••••', (v) => (password = v), 1000).then(() => {
-                animate(button, { scale: [1, 0.95, 1] }, { duration: 0.25 });
-            });
+            controller?.abort();
+            controller = new AbortController();
+
+            write('•••••••••••••', (v) => (password = v), 1000, {
+                signal: controller.signal,
+                startIndex: password.length
+            })
+                .then(() => {
+                    animate(button, { scale: [1, 0.95, 1] }, { duration: 0.25 });
+                })
+                .catch(() => {});
+
             return () => {
-                unwrite('•••••••••••••', (v) => (password = v));
+                controller?.abort();
+                controller = new AbortController();
+                unwrite('•••••••••••••', (v) => (password = v), 500, {
+                    signal: controller.signal,
+                    startIndex: password.length
+                }).catch(() => {});
             };
         });
     });

--- a/src/routes/(marketing)/(components)/bento/(animations)/auth.svelte
+++ b/src/routes/(marketing)/(components)/bento/(animations)/auth.svelte
@@ -32,7 +32,9 @@
                     .then(() => {
                         animate(button, { scale: [1, 0.95, 1] }, { duration: 0.25 });
                     })
-                    .catch(() => {});
+                    .catch((err: unknown) => {
+                        if (err instanceof Error && err.message !== 'Aborted') console.error(err);
+                    });
 
                 return () => {
                     controller?.abort();
@@ -40,7 +42,9 @@
                     unwrite('•••••••••••••', (v) => (password = v), 500, {
                         signal: controller.signal,
                         startIndex: password.length
-                    }).catch(() => {});
+                    }).catch((err: unknown) => {
+                        if (err instanceof Error && err.message !== 'Aborted') console.error(err);
+                    });
                 };
             },
             { amount: 'all' }
@@ -59,7 +63,9 @@
                 .then(() => {
                     animate(button, { scale: [1, 0.95, 1] }, { duration: 0.25 });
                 })
-                .catch(() => {});
+                .catch((err: unknown) => {
+                    if (err instanceof Error && err.message !== 'Aborted') console.error(err);
+                });
 
             return () => {
                 controller?.abort();
@@ -67,7 +73,9 @@
                 unwrite('•••••••••••••', (v) => (password = v), 500, {
                     signal: controller.signal,
                     startIndex: password.length
-                }).catch(() => {});
+                }).catch((err: unknown) => {
+                    if (err instanceof Error && err.message !== 'Aborted') console.error(err);
+                });
             };
         });
 

--- a/src/routes/(marketing)/(components)/bento/(animations)/auth.svelte
+++ b/src/routes/(marketing)/(components)/bento/(animations)/auth.svelte
@@ -70,6 +70,10 @@
                 }).catch(() => {});
             };
         });
+
+        return () => {
+            controller?.abort();
+        };
     });
 </script>
 


### PR DESCRIPTION
## What does this PR do?

Fixes a race condition in the Auth bento card password animation.

When hovering in and out rapidly on desktop, the `write` and `unwrite`
animation utilities both ran simultaneously, causing the password dots
to flicker and jump erratically.

Changes:
- Added `AbortSignal` support to `write` and `unwrite` in `src/lib/animations/index.ts`
  so animations can be cleanly cancelled mid-run.
- Added optional `startIndex` parameter so animations resume from the
  current string length instead of jumping to the start/end.
- Updated `auth.svelte` to use a shared `AbortController` that cancels
  the previous animation before starting a new one on hover in/out.

## Test Plan

1. Go to the homepage on desktop
2. Hover over the Auth bento card
3. Rapidly move the cursor in and out multiple times
4. Verify the password dots animate smoothly without flickering or jumping

## Related PRs and Issues

Resolves #2758

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Typing animations are now interruptible and can resume from a specific point, making transitions between interactions (hover, mobile) smoother.

* **Bug Fixes**
  * Stops overlapping or lingering animations during rapid interactions, ignores canceled animations, and reliably cleans up animations when components unmount.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->