### PR TITLE
Document agent skills auto-install on init project

### DIFF
--- a/src/routes/docs/tooling/ai/skills/+page.markdoc
+++ b/src/routes/docs/tooling/ai/skills/+page.markdoc
@@ -25,6 +25,10 @@ Skills work across all major AI dev tools that support them. They are installed 
 
 # Install skills {% #install-skills %}
 
+{% info title="Automatic installation" %}
+When you run `appwrite init project`, the Appwrite CLI auto-detects your project configuration and installs relevant skills automatically. You can also install skills manually using the steps below.
+{% /info %}
+
 {% section #step-1 step=1 title="Run the install command" %}
 Run the following command in your project directory:
 

--- a/src/routes/docs/tooling/command-line/installation/+page.markdoc
+++ b/src/routes/docs/tooling/command-line/installation/+page.markdoc
@@ -147,7 +147,7 @@ This will create your `appwrite.config.json` file, where you will configure your
 }
 ```
 
-The CLI will also auto-detect your project configuration and automatically install relevant [Appwrite agent skills](/docs/tooling/agent-skills).
+The CLI will also auto-detect your project configuration and automatically install relevant [Appwrite agent skills](/docs/tooling/ai/skills).
 
 You can run your first CLI command after logging in. Try fetching information about your Appwrite project.
 

--- a/src/routes/docs/tooling/command-line/installation/+page.markdoc
+++ b/src/routes/docs/tooling/command-line/installation/+page.markdoc
@@ -147,6 +147,8 @@ This will create your `appwrite.config.json` file, where you will configure your
 }
 ```
 
+The CLI will also auto-detect your project configuration and automatically install relevant [Appwrite agent skills](/docs/tooling/agent-skills).
+
 You can run your first CLI command after logging in. Try fetching information about your Appwrite project.
 
 ```sh


### PR DESCRIPTION
## Summary
- Added note to CLI installation docs that `appwrite init project` auto-detects project config and installs relevant Appwrite agent skills
- Links to agent skills documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified installation docs: the CLI now auto-detects your project configuration and automatically installs relevant Appwrite agent skills during setup, so initial setup requires less manual configuration and gets you ready to use agents more quickly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->