### PR TITLE
Update Storage docs for multi-file uploads and upload progress

### DIFF
--- a/src/routes/changelog/(entries)/2026-04-10.markdoc
+++ b/src/routes/changelog/(entries)/2026-04-10.markdoc
@@ -1,0 +1,13 @@
+---
+layout: changelog
+title: "Multi-file uploads and upload progress in Storage Console"
+date: 2026-04-10
+---
+
+The Appwrite Console now supports uploading multiple files at once to your storage buckets. You can select several files from the file picker or drag and drop them directly onto the bucket page. Files are uploaded in parallel with a concurrency limit of 5 for optimal performance.
+
+You can also now track upload progress in real time. Each file displays a progress percentage as it uploads, and the Console surfaces clear error messages if any files fail during the upload process. Files with extensions not allowed by the bucket configuration are automatically rejected before the upload begins.
+
+{% arrow_link href="/docs/products/storage/upload-download" %}
+Learn more about uploading files
+{% /arrow_link %}

--- a/src/routes/docs/products/storage/upload-download/+page.markdoc
+++ b/src/routes/docs/products/storage/upload-download/+page.markdoc
@@ -10,7 +10,11 @@ You can upload and download files both programmatically using SDKs or through th
 
 After you create a bucket or have navigated to bucket details, you can access the **Files** tab so you can upload, view, delete and update files in the bucket using the Appwrite project's dashboard. You can also perform all those operations from Appwrite's client SDK, server SDKs, and REST APIs as long as you have the proper permission.
 
-When you are in the **Files** tab, you can click **Add File** and select a file to upload. If the bucket is configured to accept the file type and size you are uploading, your file will be uploaded, and you will see the file in the list of files.
+When you are in the **Files** tab, you can click **Add File** and select one or more files to upload. You can also drag and drop files directly onto the bucket page. The Console supports uploading multiple files at once, processing up to 5 files in parallel for faster bulk uploads.
+
+During upload, a progress indicator displays the real-time upload percentage for each file. If a file fails to upload, the Console will show an error notification with details. Files that don't match the bucket's allowed file extensions are automatically rejected before the upload begins.
+
+If the bucket is configured to accept the file types and sizes you are uploading, your files will be uploaded, and you will see them in the list of files.
 
 You can also upload files programmatically using our SDKs:
 


### PR DESCRIPTION
## Summary
- Updated the Storage upload-download docs to document multi-file upload support in the Console (file picker and drag-and-drop), parallel upload processing (up to 5 concurrent), real-time upload progress indicators, and automatic file extension pre-validation
- Added a changelog entry announcing the multi-file uploads and upload progress feature in the Storage Console

## Test plan
- [ ] Verify the upload-download docs page renders correctly at `/docs/products/storage/upload-download`
- [ ] Verify the changelog entry renders correctly at `/changelog`
- [ ] Confirm the new docs accurately reflect the Console multi-file upload and progress behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)