### PR TITLE
Add changelog and docs for Homebrew-native CLI binaries

### DIFF
--- a/src/routes/changelog/(entries)/2026-04-10.markdoc
+++ b/src/routes/changelog/(entries)/2026-04-10.markdoc
@@ -1,0 +1,27 @@
+---
+layout: changelog
+title: "Appwrite CLI now ships native Homebrew binaries"
+date: 2026-04-10
+---
+
+The Appwrite CLI installed via [Homebrew](https://brew.sh/) now delivers **native compiled binaries** instead of a Node.js-based package. This means faster startup, no runtime dependencies, and a smaller install footprint on macOS and Linux.
+
+Supported platforms and architectures:
+
+- macOS Apple Silicon (arm64)
+- macOS Intel (x64)
+- Linux arm64
+- Linux x64
+
+Install or upgrade with Homebrew:
+
+```sh
+brew install appwrite    # new install
+brew upgrade appwrite    # existing install
+```
+
+The CLI is still available via npm (`npm install -g appwrite-cli`) and platform-specific install scripts for environments where Homebrew is not an option.
+
+{% arrow_link href="/docs/tooling/command-line/installation" %}
+Read the updated installation docs
+{% /arrow_link %}

--- a/src/routes/docs/tooling/command-line/installation/+page.markdoc
+++ b/src/routes/docs/tooling/command-line/installation/+page.markdoc
@@ -8,13 +8,36 @@ The [Appwrite Command Line Interface (CLI)](https://github.com/appwrite/sdk-for-
 
 # Getting started {% #getting-started %}
 
-The CLI is packaged both as an [npm module](https://www.npmjs.com/package/appwrite-cli) as well as a [standalone binary](https://github.com/appwrite/sdk-for-cli/releases/latest) for your operating system, making it completely dependency free, platform independent, and language agnostic.
+The CLI is packaged as a [native binary](https://github.com/appwrite/sdk-for-cli/releases/latest) for macOS and Linux (via Homebrew), as an [npm module](https://www.npmjs.com/package/appwrite-cli), and as a standalone install script for all platforms.
 
 If you plan to use the CLI to initialize new Appwrite Functions, ensure that [Git is installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) on your machine.
 
+## Install with Homebrew (recommended) {% #install-with-homebrew %}
+
+On macOS and Linux, [Homebrew](https://brew.sh/) is the recommended way to install the Appwrite CLI. Homebrew delivers a **native compiled binary** for your platform and architecture, so there are no runtime dependencies and startup is instant.
+
+{% tabs %}
+{% tabsitem #macos title="macOS" %}
+```sh
+brew install appwrite
+```
+{% /tabsitem %}
+
+{% tabsitem #linux title="Linux" %}
+Install [Homebrew for Linux](https://docs.brew.sh/Homebrew-on-Linux), then run:
+
+```sh
+brew install appwrite
+```
+{% /tabsitem %}
+
+{% /tabs %}
+
+Supported architectures: Apple Silicon (arm64), Intel (x64), Linux arm64, and Linux x64.
+
 ## Install with npm {% #install-with-npm %}
 
-If you have npm set up, run the command below to install the CLI.
+If you have npm set up, you can install the CLI as a Node.js package. This works on any platform where Node.js runs.
 
 ```sh
 npm install -g appwrite-cli
@@ -22,19 +45,10 @@ npm install -g appwrite-cli
 
 ## Install with script {% #install-with-script %}
 
-For a completely dependency-free installation, the CLI also ships with a convenient installation script for your operating system
+The CLI also ships with installation scripts for platforms where Homebrew is not available.
 
 {% tabs %}
 {% tabsitem #macos title="macOS" %}
-
-Using [Homebrew](https://brew.sh/)
-
-```sh
-brew install appwrite
-```
-
-or terminal
-
 ```sh
 curl -sL https://appwrite.io/cli/install.sh | bash
 ```
@@ -66,22 +80,19 @@ curl -sL https://appwrite.io/cli/install.sh | bash
 # Update your CLI {% #update-your-cli %}
 
 {% tabs %}
+{% tabsitem #homebrew title="Homebrew" %}
+```sh
+brew upgrade appwrite
+```
+{% /tabsitem %}
+
 {% tabsitem #npm title="npm" %}
 ```sh
 npm install -g appwrite-cli
 ```
 {% /tabsitem %}
 
-{% tabsitem #macos title="macOS" %}
-
-Using [Homebrew](https://brew.sh/)
-
-```sh
-brew install appwrite
-```
-
-or terminal
-
+{% tabsitem #macos title="macOS (script)" %}
 ```sh
 curl -sL https://appwrite.io/cli/install.sh | bash
 ```
@@ -93,7 +104,7 @@ iwr -useb https://appwrite.io/cli/install.ps1 | iex
 ```
 {% /tabsitem %}
 
-{% tabsitem #linux title="Linux" %}
+{% tabsitem #linux title="Linux (script)" %}
 ```sh
 curl -sL https://appwrite.io/cli/install.sh | bash
 ```
@@ -203,19 +214,16 @@ If you installed Appwrite CLI using NPM, you can use the following command to un
 npm uninstall -g appwrite-cli
 ```
 
-If you installed the Appwrite CLI with brew or the installation script for your operating system, use the following command to uninstall it.
+If you installed the Appwrite CLI with Homebrew or the installation script for your operating system, use the following command to uninstall it.
 
 {% tabs %}
-{% tabsitem #macos title="macOS" %}
-
-Using [Homebrew](https://brew.sh/)
-
+{% tabsitem #homebrew title="Homebrew (macOS / Linux)" %}
 ```sh
 brew uninstall appwrite
 ```
+{% /tabsitem %}
 
-or terminal
-
+{% tabsitem #macos title="macOS (script)" %}
 ```sh
 rm -f /usr/local/bin/appwrite | bash
 ```
@@ -236,7 +244,7 @@ scoop uninstall appwrite
 ```
 {% /tabsitem %}
 
-{% tabsitem #linux title="Linux" %}
+{% tabsitem #linux title="Linux (script)" %}
 ```sh
 rm -f /usr/local/bin/appwrite | bash
 ```


### PR DESCRIPTION
## Summary
- **Changelog entry**: Announces that the Appwrite CLI now ships native compiled binaries via Homebrew for macOS and Linux (arm64 and x64), with faster startup and no runtime dependencies.
- **Install docs update**: Restructures the CLI installation page to make Homebrew the recommended install path on macOS/Linux, adds Linux Homebrew support, and clarifies the distinction between native binaries (Homebrew), npm, and script-based installs across install/update/uninstall sections.

## Context
The `sdk-generator` repo recently merged native binary distribution via Homebrew (appwrite/sdk-generator#1431). The CLI formula now delivers platform-specific compiled binaries built with Bun instead of a Node.js-based package. This PR updates the website so users can discover and understand the change.

## Test plan
- [ ] Verify the changelog entry renders correctly at `/changelog`
- [ ] Verify the install docs page renders correctly at `/docs/tooling/command-line/installation`
- [ ] Confirm all tabs (Homebrew, npm, script, Windows, Linux) display properly in install/update/uninstall sections
- [ ] Check that the `arrow_link` in the changelog points to the correct install docs URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)