### PR TITLE
Avoid duplicated metadescriptions

### DIFF
--- a/src/routes/partners/+page.svelte
+++ b/src/routes/partners/+page.svelte
@@ -11,7 +11,7 @@
     import Why from './(components)/why.svelte';
 
     const title = 'Partners' + TITLE_SUFFIX;
-    const description = DEFAULT_DESCRIPTION;
+    const description = 'Grow your agency with the Appwrite Partners Program. Get flexible tiers, expert training, volume discounts, early access to new features, and more.';
     const ogImage = DEFAULT_HOST + '/images/open-graph/website.png';
 </script>
 

--- a/src/routes/the-appwrite-network/+page.svelte
+++ b/src/routes/the-appwrite-network/+page.svelte
@@ -13,7 +13,7 @@
     } from '$lib/utils/metadata';
 
     const title = 'The Appwrite Network';
-    const description = DEFAULT_DESCRIPTION;
+    const description = 'Discover The Appwrite Network. Explore our global PoP locations, edges, regions, and more to ensure <50ms ping and low latency for your apps worldwide.';
     const ogImage = `${DEFAULT_HOST}/images/open-graph/website.png`;
 
     const heading = 'The Appwrite Network';


### PR DESCRIPTION
## What does this PR do?

Uses custom descriptions for those pages instead of using the default metadescription.
Using the same is bad for SEO and not a good practice.