### PR TITLE
docs: CLI workflow updates for webhooks, deployment logs, and run command

### DIFF
--- a/src/routes/changelog/(entries)/2026-04-16.markdoc
+++ b/src/routes/changelog/(entries)/2026-04-16.markdoc
@@ -1,0 +1,17 @@
+---
+layout: changelog
+title: "CLI workflow updates: webhook management, deployment logs, and run improvements"
+date: 2026-04-16
+---
+
+The Appwrite CLI has received several workflow improvements for push, pull, run, and deployment commands.
+
+**Webhook management** is now available through the CLI. Use `appwrite pull webhooks` and `appwrite push webhooks` to sync webhook configurations between your local project and the Appwrite Console. Webhooks are also included in `push all` and `pull all` flows, so your entire project configuration stays in sync.
+
+**Realtime deployment log streaming** now displays build logs directly in your terminal when pushing functions or sites. The CLI connects via WebSocket for live output and automatically falls back to polling if the connection drops. Use `--no-logs` to disable streaming for async deployments.
+
+**Local function emulation** with `appwrite run functions` now validates source code before starting and uses improved startup detection to ensure the runtime is ready before reporting success.
+
+{% arrow_link href="/docs/tooling/command-line/webhooks" %}
+Learn about CLI webhook management
+{% /arrow_link %}

--- a/src/routes/docs/products/functions/develop-locally/+page.markdoc
+++ b/src/routes/docs/products/functions/develop-locally/+page.markdoc
@@ -64,7 +64,7 @@ Build finished.
 ✓ Success: Visit http://localhost:3000/ to execute your function.
 ```
 
-This command helps you efficiently develop your Appwrite functions on your local machine. When developing your Appwrite function locally, it will receive [headers](/docs/products/functions/develop#headers) like a function deployed to Appwrite.
+This command helps you efficiently develop your Appwrite functions on your local machine. The CLI validates that your function source code exists before starting the emulation and waits for the runtime to report a successful startup before showing the success message. When developing your Appwrite function locally, it will receive [headers](/docs/products/functions/develop#headers) like a function deployed to Appwrite.
 
 {% arrow_link href="/docs/products/functions/develop" %}
 Learn more about developing a function

--- a/src/routes/docs/tooling/command-line/+layout.svelte
+++ b/src/routes/docs/tooling/command-line/+layout.svelte
@@ -55,6 +55,10 @@
                 {
                     label: 'Buckets',
                     href: '/docs/tooling/command-line/buckets'
+                },
+                {
+                    label: 'Webhooks',
+                    href: '/docs/tooling/command-line/webhooks'
                 }
             ]
         }

--- a/src/routes/docs/tooling/command-line/commands/+page.markdoc
+++ b/src/routes/docs/tooling/command-line/commands/+page.markdoc
@@ -71,16 +71,16 @@ Below is a list of the available commands in the Appwrite CLI. You can get more 
 * Description
 ---
 * `init [options]`
-* The init command provides a convenient wrapper for creating and initializing projects, functions, tables, buckets, teams, and messaging-topics in Appwrite.
+* The init command provides a convenient wrapper for creating and initializing projects, functions, tables, buckets, teams, and messaging-topics in Appwrite. After initialization, the CLI provides personalized next steps based on your project state.
 ---
 * `pull`
-* The pull command helps you pull your Appwrite project, functions, tables, buckets, teams, and messaging-topics.
+* The pull command helps you pull your Appwrite project, functions, tables, buckets, teams, messaging-topics, and [webhooks](/docs/tooling/command-line/webhooks).
 ---
 * `push`
-* The push command provides a convenient wrapper for pushing your functions, tables, buckets, teams, and topics.
+* The push command provides a convenient wrapper for pushing your functions, tables, buckets, teams, topics, and [webhooks](/docs/tooling/command-line/webhooks). When pushing functions or sites, the CLI streams realtime deployment logs so you can monitor your build progress.
 ---
 * `run`
-* The run command allows you to run projects locally to allow easy development and quick debugging.
+* The run command allows you to run projects locally to allow easy development and quick debugging. Uses Docker-based emulation with source code validation and improved startup detection.
 ---
 {% /table %}
 
@@ -149,6 +149,22 @@ Below is a list of the available commands in the Appwrite CLI. You can get more 
 * Display help for command
 ---
 {% /table %}
+
+# Deployment logs {% #deployment-logs %}
+
+When pushing functions or sites, the CLI streams realtime build logs directly to your terminal using a WebSocket connection. This lets you monitor the build and deployment process as it happens without needing to check the Appwrite Console.
+
+```sh
+appwrite push functions
+```
+
+If you prefer not to see the logs, use the `--no-logs` flag to disable streaming and run the deployment asynchronously.
+
+```sh
+appwrite push functions --no-logs
+```
+
+If the realtime connection drops during a deployment, the CLI automatically falls back to polling for updates until the deployment completes.
 
 # Verbose {% #verbose %}
 In case of errors with any command, you can get more information about what went wrong using the `--verbose` flag

--- a/src/routes/docs/tooling/command-line/webhooks/+page.markdoc
+++ b/src/routes/docs/tooling/command-line/webhooks/+page.markdoc
@@ -1,0 +1,131 @@
+---
+layout: article
+title: Webhooks
+description: Manage your Appwrite webhooks using the Command-Line Tool (CLI) with push and pull commands.
+---
+
+{% partial file="cli-disclaimer.md" /%}
+
+The Appwrite CLI can manage webhooks for your project. Webhooks allow you to receive HTTP callbacks when events occur in your Appwrite project, such as when a user is created or a document is updated.
+
+# Pull webhooks {% #pull-webhooks %}
+
+Pull your existing Appwrite webhooks from the Appwrite Console using the `pull` command in the folder containing your `appwrite.config.json` file.
+
+```sh
+appwrite pull webhooks
+```
+
+When pulling, if a webhook exists locally but has been deleted remotely, the CLI will warn you and ask for confirmation before removing it from your local configuration.
+
+# appwrite.config.json {% #appwritejson %}
+
+After [initializing](/docs/tooling/command-line/installation#initialization) your Appwrite project and pulling your existing webhooks, your `appwrite.config.json` file should look similar to the following:
+
+```json
+{
+    "projectId": "<PROJECT_ID>",
+    "endpoint": "https://<REGION>.cloud.appwrite.io/v1",
+    "webhooks": [
+        {
+            "$id": "abc123",
+            "name": "Order notifications",
+            "url": "https://example.com/webhooks/orders",
+            "events": [
+                "databases.*.collections.*.documents.*.create",
+                "databases.*.collections.*.documents.*.update"
+            ],
+            "enabled": true,
+            "tls": true
+        },
+        {
+            "$id": "def456",
+            "name": "User signup alerts",
+            "url": "https://example.com/webhooks/users",
+            "events": [
+                "users.*.create"
+            ],
+            "enabled": true,
+            "tls": true
+        }
+    ]
+}
+```
+
+Each webhook supports the following fields:
+
+{% table %}
+* Field
+* Description
+---
+* `$id`
+* Unique identifier for the webhook.
+---
+* `name`
+* Human-readable name for the webhook.
+---
+* `url`
+* The URL endpoint that receives the webhook HTTP callbacks.
+---
+* `events`
+* Array of [Appwrite events](/docs/advanced/platform/events) that trigger the webhook.
+---
+* `enabled`
+* Whether the webhook is active. Set to `false` to temporarily disable it.
+---
+* `tls`
+* Whether TLS certificate verification is enabled for the webhook endpoint.
+---
+{% /table %}
+
+# Push webhooks {% #push-webhooks %}
+
+{% partial file="cli-push-command.md" /%}
+
+```sh
+appwrite push webhooks
+```
+
+When pushing, the CLI will create new webhooks or update existing ones based on the `$id` field. You will be prompted to select which webhooks to push unless you use the `--all` flag.
+
+```sh
+appwrite push webhooks --all
+```
+
+# Push and pull all {% #push-pull-all %}
+
+Webhooks are included in the `push all` and `pull all` flows alongside functions, tables, teams, buckets, and topics.
+
+```sh
+appwrite push all
+appwrite pull all
+```
+
+# Commands {% #commands %}
+
+The webhooks commands allow you to manage your project webhooks. Appwrite webhook CLI commands generally follow the following syntax:
+
+```sh
+appwrite projects [COMMAND] [OPTIONS]
+```
+
+{% table %}
+* Command
+* Description
+---
+* `list-webhooks [options]`
+* Get a list of all the webhooks for your project. Use query parameters to filter results.
+---
+* `create-webhook [options]`
+* Create a new webhook for your project. Provide a name, URL, and list of events.
+---
+* `get-webhook [options]`
+* Get a webhook by its unique ID.
+---
+* `update-webhook [options]`
+* Update a webhook by its unique ID. You can modify the name, URL, events, enabled status, and TLS settings.
+---
+* `delete-webhook [options]`
+* Delete a webhook by its unique ID.
+---
+{% /table %}


### PR DESCRIPTION
## Summary
- **New webhooks CLI doc page** (`/docs/tooling/command-line/webhooks`): Documents `appwrite pull webhooks` and `appwrite push webhooks` commands, config format, supported fields, and webhook CRUD commands
- **Deployment log streaming section** in commands reference: Documents realtime WebSocket-based build log streaming during `push functions`/`push sites`, the `--no-logs` flag, and automatic fallback to polling
- **Updated CLI commands reference**: Push/pull descriptions now include webhooks; init command mentions personalized next steps; run command describes source validation and startup detection
- **Updated develop-locally docs**: Notes source code validation and startup detection improvements for `appwrite run functions`
- **Changelog entry** (2026-04-16): Summarizes webhook management, deployment log streaming, and run command improvements
- **Sidebar navigation**: Added Webhooks to the CLI Deployments section

## Test plan
- [ ] Verify the new webhooks page renders correctly at `/docs/tooling/command-line/webhooks`
- [ ] Verify the webhooks link appears in the CLI sidebar navigation under Deployments
- [ ] Verify the changelog entry renders at `/changelog`
- [ ] Verify the deployment logs section appears on the commands page
- [ ] Verify all internal links resolve correctly (webhook references from commands page, arrow_link in changelog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)