### PR TITLE
fix: resolve Svelte 5 reactivity warnings

### DIFF
--- a/src/lib/components/Tooltip.svelte
+++ b/src/lib/components/Tooltip.svelte
@@ -29,12 +29,18 @@
         states: { open }
     } = createTooltip({
         positioning: {
-            placement
+            get placement() {
+                return placement;
+            }
         },
         openDelay: 0,
-        closeOnPointerDown,
+        get closeOnPointerDown() {
+            return closeOnPointerDown;
+        },
         forceVisible: true,
-        disableHoverableContent
+        get disableHoverableContent() {
+            return disableHoverableContent;
+        }
     });
 
     let flyParams = $derived(

--- a/src/lib/components/animated/text.svelte
+++ b/src/lib/components/animated/text.svelte
@@ -10,7 +10,7 @@
 
     const { text, splitBy = 'words', staggerBy = 75, class: className, ...rest }: Props = $props();
 
-    const words = splitBy === 'words' ? text.split(' ') : text.split('');
+    const words = $derived(splitBy === 'words' ? text.split(' ') : text.split(''));
 </script>
 
 <span class="sr-only">{text}</span>

--- a/src/lib/components/appwrite-network/map.svelte
+++ b/src/lib/components/appwrite-network/map.svelte
@@ -10,6 +10,7 @@
     } from './map-tooltip.svelte';
     import { createMap } from 'svg-dotted-map';
     import { browser } from '$app/environment';
+    import { untrack } from 'svelte';
 
     type Props = {
         theme: 'light' | 'dark';
@@ -19,7 +20,7 @@
 
     const { theme = 'dark', navigable = true, defaultSet = 'pop-locations' }: Props = $props();
 
-    let activeSegment = $state<string>(defaultSet);
+    let activeSegment = $state<string>(untrack(() => defaultSet));
     let activeMarkers = $derived(pins[activeSegment as PinSegment]);
 
     const { action: mousePosition, position } = useMousePosition();

--- a/src/lib/components/fancy/animated-text.svelte
+++ b/src/lib/components/fancy/animated-text.svelte
@@ -8,7 +8,7 @@
 
     let { text, class: className = '' }: Props = $props();
 
-    const words = text.split(' ');
+    const words = $derived(text.split(' '));
 </script>
 
 <span class="sr-only">{text}</span>

--- a/src/lib/components/fancy/noise.svelte
+++ b/src/lib/components/fancy/noise.svelte
@@ -18,7 +18,7 @@
         ...rest
     }: Props = $props();
 
-    const baseFrequency = grainSize! / 1;
+    const baseFrequency = $derived(grainSize! / 1);
 </script>
 
 <svg

--- a/src/lib/components/ui/button.svelte
+++ b/src/lib/components/ui/button.svelte
@@ -52,12 +52,10 @@
     }: Props = $props();
 
     const isSplit = getContext<boolean>(BUTTON_SPLIT_CONTEXT);
-    const splitClasses = isSplit
-        ? splitPosition
-            ? `is-split is-split-${splitPosition}`
-            : 'is-split'
-        : '';
-    const buttonClasses = cn(button({ variant }), splitClasses, classes);
+    const splitClasses = $derived(
+        isSplit ? (splitPosition ? `is-split is-split-${splitPosition}` : 'is-split') : ''
+    );
+    const buttonClasses = $derived(cn(button({ variant }), splitClasses, classes));
 </script>
 
 {#if href}

--- a/src/lib/providers/theme/theme.svelte
+++ b/src/lib/providers/theme/theme.svelte
@@ -4,6 +4,7 @@
     import { themeStore, setTheme, setResolvedTheme, setSystemTheme, setThemes } from './index';
     import ThemeScript from './theme-script.svelte';
     import { browser } from '$app/environment';
+    import { untrack } from 'svelte';
 
     interface Props {
         forcedTheme?: string;
@@ -25,27 +26,34 @@
         enableSystem = true,
         enableColorScheme = true,
         storageKey = 'theme',
-        themes = enableSystem ? ['light', 'dark', 'system'] : ['light', 'dark'],
-        defaultTheme = enableSystem ? 'system' : 'light',
+        themes: themesProp,
+        defaultTheme: defaultThemeProp,
         attribute = 'data-theme',
         value = undefined
     }: Props = $props();
 
-    // Initialize theme state
-    const initialTheme = getTheme(storageKey, defaultTheme);
-    const systemTheme = enableSystem ? getSystemTheme() : undefined;
+    const themes = untrack(
+        () => themesProp ?? (enableSystem ? ['light', 'dark', 'system'] : ['light', 'dark'])
+    );
+    const defaultTheme = untrack(() => defaultThemeProp ?? (enableSystem ? 'system' : 'light'));
 
-    themeStore.set({
-        theme: initialTheme,
-        forcedTheme,
-        resolvedTheme: initialTheme === 'system' ? systemTheme : initialTheme,
-        themes: enableSystem ? [...themes, 'system'] : themes,
-        systemTheme
+    // Initialize theme state
+    const initialTheme = untrack(() => getTheme(storageKey, defaultTheme));
+    const systemTheme = untrack(() => (enableSystem ? getSystemTheme() : undefined));
+
+    untrack(() => {
+        themeStore.set({
+            theme: initialTheme,
+            forcedTheme,
+            resolvedTheme: initialTheme === 'system' ? systemTheme : initialTheme,
+            themes: enableSystem ? [...themes, 'system'] : themes,
+            systemTheme
+        });
     });
 
     let theme = $derived($themeStore.theme);
     let resolvedTheme = $derived($themeStore.resolvedTheme);
-    const attrs = !value ? themes : Object.values(value);
+    const attrs = $derived(!value ? themes : Object.values(value));
 
     // Handle system theme changes
     const handleMediaQuery = (e?: MediaQueryList) => {

--- a/src/markdoc/layouts/Partner.svelte
+++ b/src/markdoc/layouts/Partner.svelte
@@ -30,7 +30,7 @@
         children
     }: Props = $props();
 
-    const ogImage = DEFAULT_HOST + cover;
+    const ogImage = $derived(DEFAULT_HOST + cover);
 </script>
 
 <svelte:head>

--- a/src/markdoc/nodes/Heading.svelte
+++ b/src/markdoc/nodes/Heading.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { slugify } from '$lib/utils/slugify';
-    import { getContext, hasContext, onMount, type Snippet } from 'svelte';
+    import { getContext, hasContext, onMount, untrack, type Snippet } from 'svelte';
     import type { InlineCtaProps } from '$lib/utils/blog-mid-cta';
     import type { LayoutContext } from '../layouts/Article.svelte';
     import type CallToAction from '../tags/Call_To_Action.svelte';
@@ -15,7 +15,7 @@
 
     const { level, id: elementId = undefined, step = undefined, children }: HeadingProps = $props();
 
-    const tag = `h${level + 1}`;
+    const tag = $derived(`h${level + 1}`);
     const ctx = hasContext('headings') ? getContext<LayoutContext>('headings') : undefined;
 
     interface BlogMidCtaContext {
@@ -33,16 +33,18 @@
     const MidCtaComponent = midCta?.component;
     let renderMidCta = $state(false);
 
-    if (midCta && MidCtaComponent && level === midCta.level) {
-        const alreadyInserted = get(midCta.inserted);
-        if (!alreadyInserted) {
-            midCta.count += 1;
-            if (midCta.count === midCta.targetIndex) {
-                renderMidCta = true;
-                midCta.inserted.set(true);
+    untrack(() => {
+        if (midCta && MidCtaComponent && level === midCta.level) {
+            const alreadyInserted = get(midCta.inserted);
+            if (!alreadyInserted) {
+                midCta.count += 1;
+                if (midCta.count === midCta.targetIndex) {
+                    renderMidCta = true;
+                    midCta.inserted.set(true);
+                }
             }
         }
-    }
+    });
 
     let element: HTMLElement | undefined = $state();
 

--- a/src/markdoc/nodes/Image.svelte
+++ b/src/markdoc/nodes/Image.svelte
@@ -15,7 +15,7 @@
     let { src, alt, title }: ImageProps = $props();
 
     const inTable = isInTable();
-    const isAudio = /\.(wav|mp3|m4a|ogg)$/i.test(src);
+    const isAudio = $derived(/\.(wav|mp3|m4a|ogg)$/i.test(src));
 
     const {
         elements: { portalled, trigger, content, overlay },

--- a/src/markdoc/nodes/Link.svelte
+++ b/src/markdoc/nodes/Link.svelte
@@ -7,31 +7,35 @@
         children: Snippet;
     }
 
-    let { href, title, children }: LinkProps = $props();
+    let { href: rawHref, title, children }: LinkProps = $props();
 
     const whitelisted = ['appwrite.io', 'cloud.appwrite.io'];
 
-    const isExternal = ['http://', 'https://'].some((prefix) => {
-        if (href.startsWith(prefix)) {
-            try {
-                const hostname = new URL(href).hostname.replace(/^www\./, '');
+    const isExternal = $derived(
+        ['http://', 'https://'].some((prefix) => {
+            if (rawHref.startsWith(prefix)) {
+                try {
+                    const hostname = new URL(rawHref).hostname.replace(/^www\./, '');
 
-                return !whitelisted.includes(hostname);
-            } catch {
-                return true;
+                    return !whitelisted.includes(hostname);
+                } catch {
+                    return true;
+                }
             }
-        }
-        return false;
-    });
+            return false;
+        })
+    );
 
-    const target = isExternal ? '_blank' : undefined;
+    const target = $derived(isExternal ? '_blank' : undefined);
 
-    const doFollow = href.includes('?dofollow=true') || href.includes('&dofollow=true');
-    if (doFollow) {
-        href = href.replace(/[?&]dofollow=true/g, '').replace(/[?&]$/, '');
-    }
+    const doFollow = $derived(
+        rawHref.includes('?dofollow=true') || rawHref.includes('&dofollow=true')
+    );
+    const href = $derived(
+        doFollow ? rawHref.replace(/[?&]dofollow=true/g, '').replace(/[?&]$/, '') : rawHref
+    );
 
-    const rel = isExternal ? `noopener${doFollow ? '' : ' nofollow'}` : undefined;
+    const rel = $derived(isExternal ? `noopener${doFollow ? '' : ' nofollow'}` : undefined);
 </script>
 
 <a {href} {title} {target} {rel}>{@render children()}</a>

--- a/src/markdoc/tags/Arrow_Link.svelte
+++ b/src/markdoc/tags/Arrow_Link.svelte
@@ -9,9 +9,9 @@
 
     const { href, children }: ArrowLinkProps = $props();
 
-    const isExternal = /https?:\/\//.test(href);
-    const target = isExternal ? '_blank' : '_self';
-    const rel = isExternal ? 'noopener nofollow' : undefined;
+    const isExternal = $derived(/https?:\/\//.test(href));
+    const target = $derived(isExternal ? '_blank' : '_self');
+    const rel = $derived(isExternal ? 'noopener nofollow' : undefined);
 </script>
 
 <a

--- a/src/markdoc/tags/Call_To_Action.svelte
+++ b/src/markdoc/tags/Call_To_Action.svelte
@@ -27,7 +27,7 @@
         event = undefined
     }: Props = $props();
 
-    let benefits: Array<string> = [point1, point2, point3, point4];
+    const benefits: Array<string> = $derived([point1, point2, point3, point4]);
 </script>
 
 <div

--- a/src/markdoc/tags/Count_Title.svelte
+++ b/src/markdoc/tags/Count_Title.svelte
@@ -5,7 +5,7 @@
 
     const { title = '' }: Props = $props();
 
-    const el = title ? 'h3' : 'span';
+    const el = $derived(title ? 'h3' : 'span');
 </script>
 
 <svelte:element this={el} class="text-sub-body text-primary font-medium">

--- a/src/markdoc/tags/Storage_Image.svelte
+++ b/src/markdoc/tags/Storage_Image.svelte
@@ -40,23 +40,25 @@
         just_img = false
     }: Props = $props();
 
-    const src = storage
-        .getFilePreview(
-            bucket_id,
-            file_id,
-            width,
-            height,
-            gravity as any,
-            quality,
-            border_width,
-            border_color,
-            border_radius,
-            opacity,
-            rotation,
-            background_color,
-            output as any
-        )
-        .toString();
+    const src = $derived(
+        storage
+            .getFilePreview(
+                bucket_id,
+                file_id,
+                width,
+                height,
+                gravity as any,
+                quality,
+                border_width,
+                border_color,
+                border_radius,
+                opacity,
+                rotation,
+                background_color,
+                output as any
+            )
+            .toString()
+    );
 </script>
 
 {#if just_img}

--- a/src/routes/(init)/init/(components)/countdown-card.svelte
+++ b/src/routes/(init)/init/(components)/countdown-card.svelte
@@ -4,6 +4,7 @@
     import Badge from './badge.svelte';
     import Counter from './counter.svelte';
     import type { DayProps } from './day.svelte';
+    import { untrack } from 'svelte';
 
     type $$Props = Pick<DayProps, 'illustration' | 'release' | 'index' | 'title'>;
 
@@ -16,7 +17,7 @@
 
     const { illustration = '', release, index, title }: Props = $props();
 
-    const { days, hours, minutes, seconds, hasReleased } = createCountdown(release);
+    const { days, hours, minutes, seconds, hasReleased } = untrack(() => createCountdown(release));
 </script>
 
 <a href="#day-{index}">

--- a/src/routes/(init)/init/(components)/media-card.svelte
+++ b/src/routes/(init)/init/(components)/media-card.svelte
@@ -9,7 +9,7 @@
 
     const { title, poster, type, url }: Props = $props();
 
-    const icon = type === 'discord' ? DiscordIcon : PlayIcon;
+    const icon = $derived(type === 'discord' ? DiscordIcon : PlayIcon);
 </script>
 
 <div class="group mt-2 w-fit min-w-[190px]">

--- a/src/routes/(init)/init/(components)/pre-release-card.svelte
+++ b/src/routes/(init)/init/(components)/pre-release-card.svelte
@@ -4,6 +4,7 @@
     import { createCountdown } from '$lib/utils/create-countdown';
     import Counter from './counter.svelte';
     import { format } from 'date-fns';
+    import { untrack } from 'svelte';
 
     interface Props {
         release: Date;
@@ -12,7 +13,7 @@
 
     let { release, index }: Props = $props();
 
-    const { days, hours, minutes, seconds } = createCountdown(release);
+    const { days, hours, minutes, seconds } = untrack(() => createCountdown(release));
 </script>
 
 <div class="relative h-fit pb-8">

--- a/src/routes/(init)/init/tickets/(components)/ticket-card.svelte
+++ b/src/routes/(init)/init/tickets/(components)/ticket-card.svelte
@@ -32,7 +32,7 @@
         ...props
     }: Props = $props();
 
-    const firstName = name?.split(' ')[0].trim();
+    const firstName = $derived(name?.split(' ')[0].trim());
 
     const handleFlip = () => {
         if (disableEffects) return;

--- a/src/routes/(init)/init/tickets/(components)/ticket-url.svelte
+++ b/src/routes/(init)/init/tickets/(components)/ticket-url.svelte
@@ -5,7 +5,7 @@
 
     let { username }: Props = $props();
 
-    const copyUrl = `https://appwrite.io/init/tickets/${username}`;
+    const copyUrl = $derived(`https://appwrite.io/init/tickets/${username}`);
 </script>
 
 <div

--- a/src/routes/(init)/init/tickets/[username]/+page.svelte
+++ b/src/routes/(init)/init/tickets/[username]/+page.svelte
@@ -11,19 +11,20 @@
     import InitGiveaway from '$routes/(init)/init/(assets)/init-giveaway.png';
     import { Media } from '$lib/UI';
     import { FooterNav, MainFooter } from '$lib/components';
+    import { untrack } from 'svelte';
 
     const { data } = $props();
 
-    let firstName = data.ticket?.name?.split(/\s/)[0] ?? '';
-    let id = data.ticket?.id.toString().padStart(6, '0');
-    const ticketUrl = `${page.url.origin}/init/tickets/${data.ticket.gh_user}`;
-    const ogImage = `${ticketUrl}/og`;
+    const firstName = $derived(data.ticket?.name?.split(/\s/)[0] ?? '');
+    const id = $derived(data.ticket?.id.toString().padStart(6, '0'));
+    const ticketUrl = $derived(`${page.url.origin}/init/tickets/${data.ticket.gh_user}`);
+    const ogImage = $derived(`${ticketUrl}/og`);
 
     const { copied, copy } = createCopy(page.url.href);
 
     let claiming = $state<boolean>(false);
 
-    const shareTextOptions = [
+    const shareTextOptions = untrack(() => [
         `Join us during the week of ${initDates} to celebrate everything new with @appwrite. Claim your ticket here 👇 ${ticketUrl}`,
         `Come celebrate everything new with @appwrite from ${initDates}! Don't miss out on the latest features and updates. Get your ticket ASAP! 📅 ${ticketUrl}`,
         `Don't miss out on init @appwrite from ${initDates}. Get your ticket now and join us for a week of innovation. 🚀 ${ticketUrl}`,
@@ -44,7 +45,7 @@
         `Join us for a week of everything new with @appwrite, ${initDates}. Get your ticket here: ${ticketUrl}`,
         `Don't miss out on everything new with @appwrite from ${initDates}. Get your ticket here: 💡 ${ticketUrl}`,
         `Let's check out everything new with @appwrite from ${initDates}. Secure your ticket and join us for a week full of awesomeness! 🎉 ${ticketUrl}`
-    ];
+    ]);
 
     let twitterText = $state(
         encodeURIComponent(shareTextOptions[Math.floor(Math.random() * shareTextOptions.length)])

--- a/src/routes/(init)/init/tickets/customize/+page.svelte
+++ b/src/routes/(init)/init/tickets/customize/+page.svelte
@@ -18,6 +18,7 @@
     import { Button, Icon } from '$lib/components/ui';
     import { initDates } from '../../+page.svelte';
     import CustomizationDrawer from './(components)/customization-drawer.svelte';
+    import { untrack } from 'svelte';
 
     let { data } = $props();
 
@@ -31,11 +32,13 @@
         { minQuietPeriodMs: 2500 }
     );
 
-    let originalTicketData = $state({
-        name: data.ticket?.name ?? '',
-        title: data.ticket?.title ?? '',
-        sticker: data.ticket?.sticker
-    });
+    let originalTicketData = $state(
+        untrack(() => ({
+            name: data.ticket?.name ?? '',
+            title: data.ticket?.title ?? '',
+            sticker: data.ticket?.sticker
+        }))
+    );
 
     let updatedTicketData = $derived({
         name: originalTicketData.name.split(' ')[0],

--- a/src/routes/(marketing)/(components)/(ai-animations)/skills.svelte
+++ b/src/routes/(marketing)/(components)/(ai-animations)/skills.svelte
@@ -7,7 +7,7 @@
     import Checkmark from '$lib/components/fancy/checkmark.svelte';
 
     let container: HTMLElement;
-    let activePill: HTMLElement;
+    let activePill: HTMLElement = $state()!;
     let active = $state(false);
     let complete = $state(false);
     let typedText = $state('');

--- a/src/routes/(marketing)/(components)/scale.svelte
+++ b/src/routes/(marketing)/(components)/scale.svelte
@@ -2,7 +2,7 @@
     import { cn } from '$lib/utils/cn';
     import NumberFlow from '@number-flow/svelte';
     import { inView } from 'motion';
-    import { onDestroy, type Snippet } from 'svelte';
+    import { onDestroy, untrack, type Snippet } from 'svelte';
     import { browser } from '$app/environment';
 
     const animationDuration = 3;
@@ -47,8 +47,8 @@
         ]
     }: Props = $props();
 
-    let localStats = $state(stats.map((stat) => ({ ...stat, number: 0 })));
-    const originalNumbers = stats.map((stat) => stat.number);
+    let localStats = $state(untrack(() => stats.map((stat) => ({ ...stat, number: 0 }))));
+    const originalNumbers = untrack(() => stats.map((stat) => stat.number));
 
     const updateNumbers = () => {
         localStats.forEach((stat, index) => {

--- a/src/routes/blog/+layout.svelte
+++ b/src/routes/blog/+layout.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
-    import { setContext } from 'svelte';
+    import { setContext, untrack } from 'svelte';
     import type { AuthorData, CategoryData, PostsData } from './content.js';
 
     let { data, children } = $props();
-    setContext<PostsData[]>('posts', data.posts);
-    setContext<AuthorData[]>('authors', data.authors);
-    setContext<CategoryData[]>('categories', data.categories);
-    setContext<string | null>('rawContent', data.rawContent);
+    untrack(() => {
+        setContext<PostsData[]>('posts', data.posts);
+        setContext<AuthorData[]>('authors', data.authors);
+        setContext<CategoryData[]>('categories', data.categories);
+        setContext<string | null>('rawContent', data.rawContent);
+    });
 </script>
 
 {@render children()}

--- a/src/routes/blog/[[page]]/+page.svelte
+++ b/src/routes/blog/[[page]]/+page.svelte
@@ -13,8 +13,10 @@
 
     let { data } = $props();
 
-    const featured = data.featured;
-    const categories = data.filteredCategories.sort((a, b) => a.name.localeCompare(b.name));
+    const featured = $derived(data.featured);
+    const categories = $derived(
+        data.filteredCategories.sort((a, b) => a.name.localeCompare(b.name))
+    );
 
     let isFirstPage = $derived(data.currentPage === 1);
 

--- a/src/routes/blog/[[page]]/+page.svelte
+++ b/src/routes/blog/[[page]]/+page.svelte
@@ -15,7 +15,7 @@
 
     const featured = $derived(data.featured);
     const categories = $derived(
-        data.filteredCategories.sort((a, b) => a.name.localeCompare(b.name))
+        data.filteredCategories.toSorted((a, b) => a.name.localeCompare(b.name))
     );
 
     let isFirstPage = $derived(data.currentPage === 1);

--- a/src/routes/changelog/entry/[entry]/+page.svelte
+++ b/src/routes/changelog/entry/[entry]/+page.svelte
@@ -11,13 +11,13 @@
 
     let { data } = $props();
 
-    const seo = {
+    const seo = $derived({
         title: data.title,
         description: data.description ?? DEFAULT_DESCRIPTION,
         ogImage: data.cover
             ? DEFAULT_HOST + data.cover
             : `${DEFAULT_HOST}/images/open-graph/website.png`
-    };
+    });
 
     const sharingOptions = socialSharingOptions.filter((option) => option.label !== 'YCombinator');
 

--- a/src/routes/docs/tutorials/android/+layout.svelte
+++ b/src/routes/docs/tutorials/android/+layout.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
     import { globToTutorial } from '$lib/utils/tutorials.js';
-    import { setContext } from 'svelte';
+    import { setContext, untrack } from 'svelte';
 
     let { data, children } = $props();
-    const tutorials = globToTutorial(data);
+    const tutorials = untrack(() => globToTutorial(data));
     setContext('tutorials', tutorials);
 </script>
 

--- a/src/routes/docs/tutorials/apple/+layout.svelte
+++ b/src/routes/docs/tutorials/apple/+layout.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
     import { globToTutorial } from '$lib/utils/tutorials.js';
-    import { setContext } from 'svelte';
+    import { setContext, untrack } from 'svelte';
 
     let { data, children } = $props();
-    const tutorials = globToTutorial(data);
+    const tutorials = untrack(() => globToTutorial(data));
     setContext('tutorials', tutorials);
 </script>
 

--- a/src/routes/docs/tutorials/astro-ssr-auth/+layout.svelte
+++ b/src/routes/docs/tutorials/astro-ssr-auth/+layout.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
     import { globToTutorial } from '$lib/utils/tutorials.js';
-    import { setContext } from 'svelte';
+    import { setContext, untrack } from 'svelte';
 
     let { data, children } = $props();
-    const tutorials = globToTutorial(data);
+    const tutorials = untrack(() => globToTutorial(data));
     setContext('tutorials', tutorials);
 </script>
 

--- a/src/routes/docs/tutorials/flutter/+layout.svelte
+++ b/src/routes/docs/tutorials/flutter/+layout.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
     import { globToTutorial } from '$lib/utils/tutorials.js';
-    import { setContext } from 'svelte';
+    import { setContext, untrack } from 'svelte';
 
     let { data, children } = $props();
-    const tutorials = globToTutorial(data);
+    const tutorials = untrack(() => globToTutorial(data));
     setContext('tutorials', tutorials);
 </script>
 

--- a/src/routes/docs/tutorials/nextjs-ssr-auth/+layout.svelte
+++ b/src/routes/docs/tutorials/nextjs-ssr-auth/+layout.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
     import { globToTutorial } from '$lib/utils/tutorials.js';
-    import { setContext } from 'svelte';
+    import { setContext, untrack } from 'svelte';
 
     let { data, children } = $props();
-    const tutorials = globToTutorial(data);
+    const tutorials = untrack(() => globToTutorial(data));
     setContext('tutorials', tutorials);
 </script>
 

--- a/src/routes/docs/tutorials/nextjs/+layout.svelte
+++ b/src/routes/docs/tutorials/nextjs/+layout.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
     import { globToTutorial } from '$lib/utils/tutorials.js';
-    import { setContext } from 'svelte';
+    import { setContext, untrack } from 'svelte';
 
     let { data, children } = $props();
-    const tutorials = globToTutorial(data);
+    const tutorials = untrack(() => globToTutorial(data));
     setContext('tutorials', tutorials);
 </script>
 

--- a/src/routes/docs/tutorials/nuxt-ssr-auth/+layout.svelte
+++ b/src/routes/docs/tutorials/nuxt-ssr-auth/+layout.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
     import { globToTutorial } from '$lib/utils/tutorials.js';
-    import { setContext } from 'svelte';
+    import { setContext, untrack } from 'svelte';
 
     let { data, children } = $props();
-    const tutorials = globToTutorial(data);
+    const tutorials = untrack(() => globToTutorial(data));
     setContext('tutorials', tutorials);
 </script>
 

--- a/src/routes/docs/tutorials/nuxt/+layout.svelte
+++ b/src/routes/docs/tutorials/nuxt/+layout.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
     import { globToTutorial } from '$lib/utils/tutorials.js';
-    import { setContext } from 'svelte';
+    import { setContext, untrack } from 'svelte';
 
     let { data, children } = $props();
-    const tutorials = globToTutorial(data);
+    const tutorials = untrack(() => globToTutorial(data));
     setContext('tutorials', tutorials);
 </script>
 

--- a/src/routes/docs/tutorials/react-native/+layout.svelte
+++ b/src/routes/docs/tutorials/react-native/+layout.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
     import { globToTutorial } from '$lib/utils/tutorials.js';
-    import { setContext } from 'svelte';
+    import { setContext, untrack } from 'svelte';
 
     let { data, children } = $props();
-    const tutorials = globToTutorial(data);
+    const tutorials = untrack(() => globToTutorial(data));
     setContext('tutorials', tutorials);
 </script>
 

--- a/src/routes/docs/tutorials/react/+layout.svelte
+++ b/src/routes/docs/tutorials/react/+layout.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
     import { globToTutorial } from '$lib/utils/tutorials.js';
-    import { setContext } from 'svelte';
+    import { setContext, untrack } from 'svelte';
 
     let { data, children } = $props();
-    const tutorials = globToTutorial(data);
+    const tutorials = untrack(() => globToTutorial(data));
     setContext('tutorials', tutorials);
 </script>
 

--- a/src/routes/docs/tutorials/refine/+layout.svelte
+++ b/src/routes/docs/tutorials/refine/+layout.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
     import { globToTutorial } from '$lib/utils/tutorials.js';
-    import { setContext } from 'svelte';
+    import { setContext, untrack } from 'svelte';
 
     let { data, children } = $props();
-    const tutorials = globToTutorial(data);
+    const tutorials = untrack(() => globToTutorial(data));
     setContext('tutorials', tutorials);
 </script>
 

--- a/src/routes/docs/tutorials/subscriptions-with-stripe/+layout.svelte
+++ b/src/routes/docs/tutorials/subscriptions-with-stripe/+layout.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
     import { globToTutorial } from '$lib/utils/tutorials.js';
-    import { setContext } from 'svelte';
+    import { setContext, untrack } from 'svelte';
 
     let { data, children } = $props();
-    const tutorials = globToTutorial(data);
+    const tutorials = untrack(() => globToTutorial(data));
     setContext('tutorials', tutorials);
 </script>
 

--- a/src/routes/docs/tutorials/sveltekit-csr-auth/+layout.svelte
+++ b/src/routes/docs/tutorials/sveltekit-csr-auth/+layout.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
     import { globToTutorial } from '$lib/utils/tutorials.js';
-    import { setContext } from 'svelte';
+    import { setContext, untrack } from 'svelte';
 
     let { data, children } = $props();
-    const tutorials = globToTutorial(data);
+    const tutorials = untrack(() => globToTutorial(data));
     setContext('tutorials', tutorials);
 </script>
 

--- a/src/routes/docs/tutorials/sveltekit-ssr-auth/+layout.svelte
+++ b/src/routes/docs/tutorials/sveltekit-ssr-auth/+layout.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
     import { globToTutorial } from '$lib/utils/tutorials.js';
-    import { setContext } from 'svelte';
+    import { setContext, untrack } from 'svelte';
 
     let { data, children } = $props();
-    const tutorials = globToTutorial(data);
+    const tutorials = untrack(() => globToTutorial(data));
     setContext('tutorials', tutorials);
 </script>
 

--- a/src/routes/docs/tutorials/sveltekit/+layout.svelte
+++ b/src/routes/docs/tutorials/sveltekit/+layout.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
     import { globToTutorial } from '$lib/utils/tutorials.js';
-    import { setContext } from 'svelte';
+    import { setContext, untrack } from 'svelte';
 
     let { data, children } = $props();
-    const tutorials = globToTutorial(data);
+    const tutorials = untrack(() => globToTutorial(data));
     setContext('tutorials', tutorials);
 </script>
 

--- a/src/routes/docs/tutorials/vue/+layout.svelte
+++ b/src/routes/docs/tutorials/vue/+layout.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
     import { globToTutorial } from '$lib/utils/tutorials.js';
-    import { setContext } from 'svelte';
+    import { setContext, untrack } from 'svelte';
 
     let { data, children } = $props();
-    const tutorials = globToTutorial(data);
+    const tutorials = untrack(() => globToTutorial(data));
     setContext('tutorials', tutorials);
 </script>
 

--- a/src/routes/integrations/+page.svelte
+++ b/src/routes/integrations/+page.svelte
@@ -36,7 +36,7 @@
     let hasQuery = $derived(query.length > 0);
 
     // platform filters
-    const platforms = ['All', ...data.platforms];
+    const platforms = $derived(['All', ...data.platforms]);
 
     let activePlatform = $state('All');
 

--- a/src/routes/threads/+page.svelte
+++ b/src/routes/threads/+page.svelte
@@ -12,6 +12,7 @@
     import PreFooter from './PreFooter.svelte';
     import TagsDropdown from './TagsDropdown.svelte';
     import { getThreads } from './helpers';
+    import { untrack } from 'svelte';
 
     const title = 'Threads' + TITLE_SUFFIX;
     const description =
@@ -20,7 +21,7 @@
 
     let { data } = $props();
 
-    let threads = $state(data.threads);
+    let threads = $state(untrack(() => data.threads));
 
     let searching = false; // Do some sick animation
     let query = $state('');

--- a/src/routes/threads/[id]/+page.svelte
+++ b/src/routes/threads/[id]/+page.svelte
@@ -12,9 +12,11 @@
 
     let { data } = $props();
 
-    const title = data.title + ' - Threads' + TITLE_SUFFIX;
+    const title = $derived(data.title + ' - Threads' + TITLE_SUFFIX);
     const description = DEFAULT_DESCRIPTION;
-    const discordLink = `https://discord.com/channels/564160730845151244/${data.discord_id}`;
+    const discordLink = $derived(
+        `https://discord.com/channels/564160730845151244/${data.discord_id}`
+    );
 
     function shorten(str: string, len: number) {
         return str.length > len ? str.slice(0, len) + '...' : str;


### PR DESCRIPTION
## Summary
- Eliminates all `state_referenced_locally` and `non_reactive_update` warnings surfaced by `svelte-check` and the build (`svelte-check` now reports **0 errors, 0 warnings** on this branch).
- Touches 46 Svelte files across tutorial layouts, markdoc nodes/tags, init ticket flows, blog, threads, integrations, theme provider, and shared UI primitives.

## Approach
- **`$derived`** wraps top-level reads of props / `data` so access happens in a reactive context (e.g. `ticket-card`, `button`, `noise`, `Storage_Image`, `Heading`, `Link`, `Call_To_Action`, `Partner`, blog page, changelog entry, threads, integrations, animated text, etc.).
- **`untrack`** wraps one-time initializers where only the initial snapshot is meaningful (`setContext` payloads in the 17 tutorial + blog layouts, `$state(...)` seeded from props in `scale` / `customize` / `map` / `threads`, and the mid-CTA init block in `Heading`).
- **Tooltip** switched `melt-ui` config options to getters so reactivity is preserved without firing the warning.
- **skills.svelte** — `activePill` now declared with `$state()` (fixes `non_reactive_update`).
- **theme provider** — removed prop-default cross-references and moved derived init values into `untrack` blocks.

The two remaining build-time messages (`vite-plugin-svelte rolldown-vite experimental` and `optimizeDeps.esbuildOptions deprecated`) originate from plugin internals and will resolve when `vite-plugin-svelte` lands full rolldown support — not addressable here.

## Test plan
- [ ] `bun run check` → `0 errors and 0 warnings`
- [ ] `bun run format` passes
- [ ] `bun run build` completes without new warnings
- [ ] Spot-check affected pages locally: any docs tutorial layout, `/blog`, `/blog/[page]`, `/changelog/entry/*`, `/init/tickets/[username]`, `/init/tickets/customize`, `/integrations`, `/threads`, `/threads/[id]`
- [ ] Verify tooltips still open/close correctly (melt-ui getter change)
- [ ] Verify theme provider still respects system theme and persists selection