### PR TITLE
Replace Request a demo CTAs with Get started linking to Cloud

### DIFF
--- a/src/lib/utils/blog-cta.ts
+++ b/src/lib/utils/blog-cta.ts
@@ -44,9 +44,9 @@ const STARTUPS_CTA: BlogCtaConfig = {
 const AUTH_CTA: BlogCtaConfig = {
     heading: 'Customer identity without the hassle',
     description: 'Add secure authentication in minutes, not weeks.',
-    label: 'Request a demo',
-    href: 'https://appwrite.io/contact-us/enterprise',
-    event: 'blog-cta-auth-demo-btn-click',
+    label: 'Get started',
+    href: getAppwriteDashboardUrl(),
+    event: 'blog-cta-auth-get-started-btn-click',
     points: [
         'Built-in security and compliance',
         'Multiple login methods',

--- a/src/routes/blog/post/how-appwrite-makes-auth-easy-for-ecommerce/+page.markdoc
+++ b/src/routes/blog/post/how-appwrite-makes-auth-easy-for-ecommerce/+page.markdoc
@@ -58,7 +58,7 @@ You can mix and match depending on your store's needs.
 
 Enhance security by enabling two-factor authentication using TOTP apps like Google Authenticator. No extra backend work required. Learn more about [MFA](/docs/products/auth/mfa)
 
-{% call_to_action title="Customer identity without the hassle" description="Add secure authentication for your users in just a couple of minutes." point1="Built-in security and compliance" point2="Multiple login methods" point3="Custom authentication flows" point4="Multi-factor authentication" cta="Request a demo" url="https://appwrite.io/contact-us/enterprise" /%}
+{% call_to_action title="Customer identity without the hassle" description="Add secure authentication for your users in just a couple of minutes." point1="Built-in security and compliance" point2="Multiple login methods" point3="Custom authentication flows" point4="Multi-factor authentication" cta="Get started" url="https://cloud.appwrite.io/" /%}
 
 ## 3. **Self-Service account management**
 

--- a/src/routes/blog/post/rethinking-saas-authentication/+page.markdoc
+++ b/src/routes/blog/post/rethinking-saas-authentication/+page.markdoc
@@ -31,7 +31,7 @@ Technologies like **Single Sign-On (SSO)** help bridge this gap—offering both 
 
 Take a look at our [developer’s guide to user authentication](/blog/post/guide-to-user-authentication) for more in-depth insights.
 
-{% call_to_action title="Customer identity without the hassle" description="Add secure authentication for your users in just a couple of minutes." point1="Built-in security and compliance" point2="Multi-factor authentication" point3="Custom roles and permissions" point4="Session control and management" cta="Request a demo" url="https://appwrite.io/contact-us/enterprise" /%}
+{% call_to_action title="Customer identity without the hassle" description="Add secure authentication for your users in just a couple of minutes." point1="Built-in security and compliance" point2="Multi-factor authentication" point3="Custom roles and permissions" point4="Session control and management" cta="Get started" url="https://cloud.appwrite.io/" /%}
 
 ## Managing multi-tenant complexity
 

--- a/src/routes/blog/post/understand-oauth2/+page.markdoc
+++ b/src/routes/blog/post/understand-oauth2/+page.markdoc
@@ -68,7 +68,7 @@ OAuth2 offers different "flows" to accommodate various scenarios. Here's a break
 
 - Web apps with secure backend servers.
 
-{% call_to_action title="Customer identity without the hassle" description="Add secure authentication for your users in just a couple of minutes." point1="Multiple OAuth providers" point2="Built-in security" point3="Custom roles and permissions" point4="Integrates with your favourite SDK" cta="Request a demo" url="https://appwrite.io/contact-us/enterprise" /%}
+{% call_to_action title="Customer identity without the hassle" description="Add secure authentication for your users in just a couple of minutes." point1="Multiple OAuth providers" point2="Built-in security" point3="Custom roles and permissions" point4="Integrates with your favourite SDK" cta="Get started" url="https://cloud.appwrite.io/" /%}
 
 
 ## 2. Authorization code flow with PKCE (Proof Key for Code Exchange)

--- a/src/routes/blog/post/what-is-ciam/+page.markdoc
+++ b/src/routes/blog/post/what-is-ciam/+page.markdoc
@@ -27,7 +27,7 @@ A comprehensive CIAM solution includes:
 - **Scalability:** Designed to handle millions of users simultaneously without compromising performance.
 - **Security measures:** Features like passwordless [authentication](/products/auth), biometric verification, and threat detection protect both customer data and business operations.
 
-{% call_to_action title="Customer identity without the hassle" description="Add secure authentication for your users in just a couple of minutes." point1="Email/Password, SMS, OAuth, and more" point2="Server side rendering" point3="Session control and management" point4="Built-in security and compliance" cta="Request a demo" url="https://appwrite.io/contact-us/enterprise" /%}
+{% call_to_action title="Customer identity without the hassle" description="Add secure authentication for your users in just a couple of minutes." point1="Email/Password, SMS, OAuth, and more" point2="Server side rendering" point3="Session control and management" point4="Built-in security and compliance" cta="Get started" url="https://cloud.appwrite.io/" /%}
 
 # Why CIAM matters
 


### PR DESCRIPTION
Update AUTH_CTA in blog-cta resolver and inline call_to_action blocks on auth-related posts to use Appwrite Cloud instead of enterprise contact.

Made-with: Cursor

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)