### PR TITLE
docs(cli): document 19.1.0 list query flags

### DIFF
--- a/src/routes/changelog/(entries)/2026-04-28.markdoc
+++ b/src/routes/changelog/(entries)/2026-04-28.markdoc
@@ -6,7 +6,7 @@ date: 2026-04-28
 
 The Appwrite CLI **19.1.0** introduces dedicated flags for the most common filtering, sorting, and pagination needs on `list-*` commands across services. Until now, narrowing a list result from the CLI meant hand-writing an Appwrite query JSON string and passing it through `--queries`, which is awkward to escape inside a shell, hard to read in scripts, and easy to get wrong on a quick one-off. The new flags cover the everyday cases directly.
 
-You can now use the following flags on list commands such as `databases list-rows`, `databases list-tables`, `users list`, `functions list`, and `messaging list-messages`:
+You can now use the following flags on list commands such as `tables-db list-rows`, `tables-db list-tables`, `users list`, `functions list`, and `messaging list-messages`:
 
 - **`--where <expression>`** – simple comparison filters using `field=value`, `field!=value`, `field>value`, `field>=value`, `field<value`, and `field<=value`. Repeat the flag for multiple filters.
 - **`--sort-asc <attribute>`** and **`--sort-desc <attribute>`** – order results by one or more attributes.
@@ -17,11 +17,11 @@ You can now use the following flags on list commands such as `databases list-row
 For example, fetching the 10 most recently created rows where `year` is greater than 1999 is now a single readable invocation:
 
 ```sh
-appwrite databases list-rows \
+appwrite tables-db list-rows \
     --database-id "<DATABASE_ID>" \
     --table-id "<TABLE_ID>" \
-    --where "year>1999" \
-    --sort-desc "$createdAt" \
+    --where 'year>1999' \
+    --sort-desc '$createdAt' \
     --limit 10
 ```
 

--- a/src/routes/changelog/(entries)/2026-04-28.markdoc
+++ b/src/routes/changelog/(entries)/2026-04-28.markdoc
@@ -4,30 +4,9 @@ title: "New filter, sort, and pagination flags in the Appwrite CLI"
 date: 2026-04-28
 ---
 
-The Appwrite CLI **19.1.0** introduces dedicated flags for the most common filtering, sorting, and pagination needs on `list-*` commands across services. Until now, narrowing a list result from the CLI meant hand-writing an Appwrite query JSON string and passing it through `--queries`, which is awkward to escape inside a shell, hard to read in scripts, and easy to get wrong on a quick one-off. The new flags cover the everyday cases directly.
+The Appwrite CLI **19.1.0** adds dedicated flags for filtering, sorting, and pagination on `list-*` commands, so you no longer need to hand-write Appwrite query JSON for `--queries` on common one-offs.
 
-You can now use the following flags on list commands such as `tables-db list-rows`, `tables-db list-tables`, `users list`, `functions list`, and `messaging list-messages`:
-
-- **`--where <expression>`** – simple comparison filters using `field=value`, `field!=value`, `field>value`, `field>=value`, `field<value`, and `field<=value`. Repeat the flag for multiple filters.
-- **`--sort-asc <attribute>`** and **`--sort-desc <attribute>`** – order results by one or more attributes.
-- **`--limit <number>`** and **`--offset <number>`** – control how many results to return and where to start.
-- **`--cursor-after <id>`** and **`--cursor-before <id>`** – cursor-based pagination.
-- **`--select <attribute>`** – on row and document list commands, return only the attributes you ask for.
-
-For example, fetching the 10 most recently created rows where `year` is greater than 1999 is now a single readable invocation:
-
-```sh
-appwrite tables-db list-rows \
-    --database-id "<DATABASE_ID>" \
-    --table-id "<TABLE_ID>" \
-    --where 'year>1999' \
-    --sort-desc '$createdAt' \
-    --limit 10
-```
-
-The `--queries` flag is still fully supported and remains the right tool for advanced operators, search, complex `OR` logic, or generated automation pipelines. When you mix `--queries` with the new flags, raw queries are sent first and the flag-generated queries are appended after, so existing scripts keep working as they did before.
-
-Update to the latest CLI to pick up the new flags. Read more in the [CLI commands reference](/docs/tooling/command-line/commands#filter-sort-paginate) and the [19.1.0 release notes](https://github.com/appwrite/sdk-for-cli/releases/tag/19.1.0).
+The new flags include `--where`, `--sort-asc`, `--sort-desc`, `--limit`, `--offset`, `--cursor-after`, `--cursor-before`, and `--select`. The `--queries` flag is still supported and is combined with the new flags when both are used. See the [19.1.0 release notes](https://github.com/appwrite/sdk-for-cli/releases/tag/19.1.0) for more details.
 
 {% arrow_link href="/docs/tooling/command-line/commands#filter-sort-paginate" %}
 Read the CLI commands reference

--- a/src/routes/changelog/(entries)/2026-04-28.markdoc
+++ b/src/routes/changelog/(entries)/2026-04-28.markdoc
@@ -1,0 +1,38 @@
+---
+layout: changelog
+title: "New filter, sort, and pagination flags in the Appwrite CLI"
+date: 2026-04-28
+---
+
+The Appwrite CLI **19.1.0** introduces dedicated flags for the most common filtering, sorting, and pagination needs on `list-*` commands across services. Until now, narrowing a list result from the CLI meant hand-writing an Appwrite query JSON string and passing it through `--queries`, which is awkward to escape inside a shell, hard to read in scripts, and easy to get wrong on a quick one-off. The new flags cover the everyday cases directly.
+
+You can now use the following flags on list commands such as `databases list-rows`, `databases list-tables`, `users list`, `functions list`, and `messaging list-messages`:
+
+- **`--where <expression>`** – simple comparison filters using `field=value`, `field!=value`, `field>value`, `field>=value`, `field<value`, and `field<=value`. Repeat the flag for multiple filters.
+- **`--sort-asc <attribute>`** and **`--sort-desc <attribute>`** – order results by one or more attributes.
+- **`--limit <number>`** and **`--offset <number>`** – control how many results to return and where to start.
+- **`--cursor-after <id>`** and **`--cursor-before <id>`** – cursor-based pagination.
+- **`--select <attribute>`** – on row and document list commands, return only the attributes you ask for.
+
+For example, fetching the 10 most recently created rows where `year` is greater than 1999 is now a single readable invocation:
+
+```sh
+appwrite databases list-rows \
+    --database-id "<DATABASE_ID>" \
+    --table-id "<TABLE_ID>" \
+    --where "year>1999" \
+    --sort-desc "$createdAt" \
+    --limit 10
+```
+
+The `--queries` flag is still fully supported and remains the right tool for advanced operators, search, complex `OR` logic, or generated automation pipelines. When you mix `--queries` with the new flags, raw queries are sent first and the flag-generated queries are appended after, so existing scripts keep working as they did before.
+
+Update to the latest CLI to pick up the new flags. Read more in the [CLI commands reference](/docs/tooling/command-line/commands#filter-sort-paginate) and the [19.1.0 release notes](https://github.com/appwrite/sdk-for-cli/releases/tag/19.1.0).
+
+{% arrow_link href="/docs/tooling/command-line/commands#filter-sort-paginate" %}
+Read the CLI commands reference
+{% /arrow_link %}
+
+{% arrow_link href="/docs/tooling/command-line/installation#update-your-cli" %}
+Update the CLI to the latest version
+{% /arrow_link %}

--- a/src/routes/docs/tooling/command-line/commands/+page.markdoc
+++ b/src/routes/docs/tooling/command-line/commands/+page.markdoc
@@ -198,7 +198,7 @@ appwrite databases get-row \
 
 # Filter, sort, and paginate {% #filter-sort-paginate %}
 
-List commands across services accept a set of dedicated flags for the most common filtering, sorting, and pagination needs, so you don't have to hand-write JSON [query](/docs/products/databases/queries) strings for everyday cases. These flags are supported on `list-*` commands such as `databases list-tables`, `databases list-rows`, `users list`, `functions list`, `messaging list-messages`, and similar list endpoints across services.
+List commands across services accept a set of dedicated flags for the most common filtering, sorting, and pagination needs, so you don't have to hand-write JSON [query](/docs/products/databases/queries) strings for everyday cases. These flags are supported on `list-*` commands such as `tables-db list-tables`, `tables-db list-rows`, `users list`, `functions list`, `messaging list-messages`, and similar list endpoints across services.
 
 {% table %}
 * Flag
@@ -226,14 +226,14 @@ List commands across services accept a set of dedicated flags for the most commo
 * Return results before this cursor ID. Use for backward cursor pagination.
 ---
 * `--select <attribute>`
-* Limit returned attributes on row and document list commands such as `databases list-rows`. Repeat the flag to include multiple attributes.
+* Limit returned attributes on row and document list commands such as `tables-db list-rows`. Repeat the flag to include multiple attributes.
 ---
 {% /table %}
 
 For example, to fetch the 10 most recently created rows where `year` is greater than 1999:
 
 ```sh
-appwrite databases list-rows \
+appwrite tables-db list-rows \
     --database-id "<DATABASE_ID>" \
     --table-id "<TABLE_ID>" \
     --where 'year>1999' \
@@ -244,7 +244,7 @@ appwrite databases list-rows \
 The `--queries` flag is still supported and remains the way to pass raw [Appwrite query](/docs/products/databases/queries) JSON strings for advanced cases, automation pipelines, or operators that the new flags don't cover. When you mix `--queries` with the new flags, the raw queries are sent first and the flag-generated queries are appended after.
 
 ```sh
-appwrite databases list-rows \
+appwrite tables-db list-rows \
     --database-id "<DATABASE_ID>" \
     --table-id "<TABLE_ID>" \
     --queries '[{"method":"search","attribute":"title","values":["Avatar"]}]' \

--- a/src/routes/docs/tooling/command-line/commands/+page.markdoc
+++ b/src/routes/docs/tooling/command-line/commands/+page.markdoc
@@ -205,7 +205,7 @@ List commands across services accept a set of dedicated flags for the most commo
 * Description
 ---
 * `--where <expression>`
-* Filter using a simple comparison expression. Supports `field=value`, `field!=value`, `field>value`, `field>=value`, `field<value`, and `field<=value`. Repeat the flag to apply multiple filters.
+* Filter using a simple comparison expression. Supports `field=value`, `field!=value`, `field>value`, `field>=value`, `field<value`, and `field<=value`. Repeat the flag to apply multiple filters. Quote the expression (for example `'year>1999'`) so that `>` and `<` are not interpreted as shell redirection.
 ---
 * `--sort-asc <attribute>`
 * Sort results by an attribute in ascending order. Repeat for multiple sort fields.
@@ -226,7 +226,7 @@ List commands across services accept a set of dedicated flags for the most commo
 * Return results before this cursor ID. Use for backward cursor pagination.
 ---
 * `--select <attribute>`
-* Limit returned attributes on row and document list commands such as `databases list-rows` and `databases list-documents`. Repeat the flag to include multiple attributes.
+* Limit returned attributes on row and document list commands such as `databases list-rows`. Repeat the flag to include multiple attributes.
 ---
 {% /table %}
 
@@ -236,8 +236,8 @@ For example, to fetch the 10 most recently created rows where `year` is greater 
 appwrite databases list-rows \
     --database-id "<DATABASE_ID>" \
     --table-id "<TABLE_ID>" \
-    --where "year>1999" \
-    --sort-desc "$createdAt" \
+    --where 'year>1999' \
+    --sort-desc '$createdAt' \
     --limit 10
 ```
 
@@ -275,8 +275,8 @@ You can narrow the result set with the [filter, sort, and pagination flags](#fil
 
 ```sh
 appwrite users list \
-    --where "emailVerification=true" \
-    --sort-desc "$createdAt" \
+    --where 'emailVerification=true' \
+    --sort-desc '$createdAt' \
     --limit 25
 ```
 

--- a/src/routes/docs/tooling/command-line/commands/+page.markdoc
+++ b/src/routes/docs/tooling/command-line/commands/+page.markdoc
@@ -196,6 +196,61 @@ appwrite databases get-row \
   --console --open
 ```
 
+# Filter, sort, and paginate {% #filter-sort-paginate %}
+
+List commands across services accept a set of dedicated flags for the most common filtering, sorting, and pagination needs, so you don't have to hand-write JSON [query](/docs/products/databases/queries) strings for everyday cases. These flags are supported on `list-*` commands such as `databases list-tables`, `databases list-rows`, `users list`, `functions list`, `messaging list-messages`, and similar list endpoints across services.
+
+{% table %}
+* Flag
+* Description
+---
+* `--where <expression>`
+* Filter using a simple comparison expression. Supports `field=value`, `field!=value`, `field>value`, `field>=value`, `field<value`, and `field<=value`. Repeat the flag to apply multiple filters.
+---
+* `--sort-asc <attribute>`
+* Sort results by an attribute in ascending order. Repeat for multiple sort fields.
+---
+* `--sort-desc <attribute>`
+* Sort results by an attribute in descending order. Repeat for multiple sort fields.
+---
+* `--limit <number>`
+* Maximum number of results to return.
+---
+* `--offset <number>`
+* Number of results to skip from the beginning.
+---
+* `--cursor-after <id>`
+* Return results after this cursor ID. Use for forward [cursor pagination](/docs/products/databases/pagination).
+---
+* `--cursor-before <id>`
+* Return results before this cursor ID. Use for backward cursor pagination.
+---
+* `--select <attribute>`
+* Limit returned attributes on row and document list commands such as `databases list-rows` and `databases list-documents`. Repeat the flag to include multiple attributes.
+---
+{% /table %}
+
+For example, to fetch the 10 most recently created rows where `year` is greater than 1999:
+
+```sh
+appwrite databases list-rows \
+    --database-id "<DATABASE_ID>" \
+    --table-id "<TABLE_ID>" \
+    --where "year>1999" \
+    --sort-desc "$createdAt" \
+    --limit 10
+```
+
+The `--queries` flag is still supported and remains the way to pass raw [Appwrite query](/docs/products/databases/queries) JSON strings for advanced cases, automation pipelines, or operators that the new flags don't cover. When you mix `--queries` with the new flags, the raw queries are sent first and the flag-generated queries are appended after.
+
+```sh
+appwrite databases list-rows \
+    --database-id "<DATABASE_ID>" \
+    --table-id "<TABLE_ID>" \
+    --queries '[{"method":"search","attribute":"title","values":["Avatar"]}]' \
+    --limit 10
+```
+
 # Examples {% #examples %}
 
 ## Create user {% #create-user %}
@@ -214,6 +269,15 @@ To get a list of all your project users, you can use the list command.
 
 ```sh
 appwrite users list
+```
+
+You can narrow the result set with the [filter, sort, and pagination flags](#filter-sort-paginate). For example, to fetch the 25 most recently created users whose email is verified:
+
+```sh
+appwrite users list \
+    --where "emailVerification=true" \
+    --sort-desc "$createdAt" \
+    --limit 25
 ```
 
 ## List tables {% #list-tables %}


### PR DESCRIPTION
## Summary

- Document the new flag-based filtering, sorting, and pagination options introduced in [Appwrite CLI 19.1.0](https://github.com/appwrite/sdk-for-cli/releases/tag/19.1.0) on the [CLI commands reference](/docs/tooling/command-line/commands).
- Add a new \"Filter, sort, and paginate\" section covering `--where`, `--sort-asc`, `--sort-desc`, `--limit`, `--offset`, `--cursor-after`, `--cursor-before`, and `--select`, with a worked example and a clear note that `--queries` is still supported for advanced cases.
- Update the existing \"List users\" example to demonstrate the new flags.
- Add a changelog entry at `2026-04-28.markdoc` announcing the change.

The new flags replace the previous workflow where users had to escape Appwrite query JSON inside `--queries`, which is awkward in a shell. They are additive and fully backwards compatible — when both are passed, raw `--queries` values are sent first and flag-generated queries are appended after.

## Test plan

- [ ] Visit `/docs/tooling/command-line/commands` and confirm the new \"Filter, sort, and paginate\" section renders, the table is correctly formatted, and the in-page anchor `#filter-sort-paginate` works.
- [ ] Confirm the inline link from the updated \"List users\" example jumps to the new section.
- [ ] Visit the changelog and confirm the new `2026-04-28` entry renders, with both arrow links resolving to the CLI commands reference and the CLI installation \"Update your CLI\" anchor.
- [ ] Verify the page passes the existing markdoc lint / build pipeline in CI.