### PR TITLE
fix(statsig): improve plugin binding error handling during client ini…

### DIFF
--- a/src/lib/statsig/client.ts
+++ b/src/lib/statsig/client.ts
@@ -87,7 +87,7 @@ function startStatsig(): void {
             // `initializeAsync` waits for this so `customIDs.stableID` applies synchronously in
             // `_configureUser`. `initializeSync` does not — without it, StableID can lag userID and
             // evaluations/bootstrap can disagree (dashboard mismatch + bad reasons).
-            if (!Storage.isReady()) {
+            if (typeof Storage?.isReady === 'function' && !Storage.isReady()) {
                 const ready = Storage.isReadyResolver?.();
                 if (ready != null) {
                     await ready;
@@ -140,16 +140,23 @@ function startStatsig(): void {
                 return null;
             }
 
-            await new Promise<void>((resolve) => {
-                setTimeout(resolve, 0);
-            });
-
-            const sessionPlugin = new StatsigSessionReplayPlugin();
-            const autoPlugin = new StatsigAutoCapturePlugin();
-            sessionPlugin.bind(instance as never);
-            autoPlugin.bind(instance as never);
-
+            // Register the client for `logEvent` as soon as core init succeeded. Previously we set
+            // `client` only after Session Replay / Auto Capture `bind()`; if either threw (CSP,
+            // privacy extensions, rrweb errors), the whole init looked failed and **all** Statsig
+            // logging stopped.
             client = instance as StatsigBrowserClient;
+
+            try {
+                await new Promise<void>((resolve) => {
+                    setTimeout(resolve, 0);
+                });
+                const sessionPlugin = new StatsigSessionReplayPlugin();
+                const autoPlugin = new StatsigAutoCapturePlugin();
+                sessionPlugin.bind(instance as never);
+                autoPlugin.bind(instance as never);
+            } catch (pluginErr: unknown) {
+                console.error('[Statsig] Session Replay / Auto Capture bind failed', pluginErr);
+            }
 
             return client;
         } catch (err: unknown) {


### PR DESCRIPTION
…tialization

- Updated startStatsig function to check if Storage.isReady is a function before calling it.
- Moved plugin binding logic into a try/catch block to handle potential errors gracefully.
- Ensured that client registration for logEvent occurs immediately after core initialization to prevent logging failures.

Made-with: Cursor

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)