### PR TITLE
Refactor marketing hero component for improved Statsig integration

### DIFF
--- a/src/lib/components/homepage-variations/custom-hero.svelte
+++ b/src/lib/components/homepage-variations/custom-hero.svelte
@@ -64,13 +64,17 @@
         void whenStatsigReady().then((client) => {
             if (!client) return;
 
-            const { heroSubtitle, heroLayout: nextLayout } =
+            const { heroSubtitle: nextSubtitle, heroLayout: nextLayout } =
                 readMarketingHeroExperimentsForExposure(client, {
                     heroSubtitle: subtitle,
                     heroLayout
                 });
-            clientHeroSubtitle = heroSubtitle;
-            clientHeroLayout = nextLayout;
+            if (nextSubtitle !== subtitle) {
+                clientHeroSubtitle = nextSubtitle;
+            }
+            if (nextLayout !== heroLayout) {
+                clientHeroLayout = nextLayout;
+            }
         });
     });
 

--- a/src/lib/statsig/README.md
+++ b/src/lib/statsig/README.md
@@ -24,7 +24,7 @@
 4. **Hero Svelte** — Pass the new prop from `data`; merge into `resolveHeroQueryOverrides` if URL overrides should apply.
 5. **URL overrides (optional)** — Add a query key + reader in `hero-query-overrides.ts` and document it in the table comment there.
 
-Do **not** read experiment params only in `onMount` without also defining SSR in step 2–3 unless you intentionally want client-only assignment (e.g. prerender shell + client fill).
+Do **not** read experiment params only in `onMount` without also defining SSR in step 2–3 unless you intentionally want client-only assignment. The marketing homepage uses **`prerender = false`** so `+page.server.ts` + bootstrap match hydration and avoid layout flash.
 
 **Why two files (`*-client` / `*-server`)?** `@statsig/statsig-node-core` ships native `.node` binaries. If any module imported by a `.svelte` file pulls in `server.ts` or `marketing-hero-server.ts`, Vite tries to bundle that SDK for the browser and fails with “No loader is configured for `.node` files”.
 

--- a/src/routes/(marketing)/(components)/hero.svelte
+++ b/src/routes/(marketing)/(components)/hero.svelte
@@ -38,8 +38,8 @@
     }: Props = $props();
 
     /**
-     * Filled after the browser Statsig client runs (`initializeAsync` when `/` is prerendered).
-     * Until then, SSR/prop baselines apply. URL query overrides still win via `resolveHeroQueryOverrides`.
+     * Optional overrides after the browser Statsig client runs (exposure logging). When bootstrap
+     * matches SSR, we leave these undefined so the UI stays on server props with no flash.
      */
     let clientHeroLayout = $state<HeroLayoutVariant | undefined>(undefined);
     let clientHeroSubtitle = $state<string | undefined>(undefined);
@@ -112,8 +112,12 @@
                 heroLayout
             });
 
-            clientHeroSubtitle = nextSubtitle;
-            clientHeroLayout = nextLayout;
+            if (nextSubtitle !== subtitle) {
+                clientHeroSubtitle = nextSubtitle;
+            }
+            if (nextLayout !== heroLayout) {
+                clientHeroLayout = nextLayout;
+            }
 
             log('experiment values (after get → exposure)', {
                 [MARKETING_HERO_EXPERIMENTS.bestDescription]:

--- a/src/routes/(marketing)/+page.server.ts
+++ b/src/routes/(marketing)/+page.server.ts
@@ -14,8 +14,8 @@ import type { HeroLayoutVariant } from '$lib/statsig/hero-layout';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ cookies, request, url }) => {
-    // Prerendered `/` must not embed per-user Statsig bootstrap or stable IDs — one static HTML is
-    // served to everyone; the hero applies experiments after `initializeAsync` in the browser.
+    // `+page.ts` sets `prerender = false` for `/` so this load runs per request with real cookies.
+    // During `vite build` the marketing page may still be analyzed with `building === true`; keep a safe fallback.
     if (building) {
         return {
             heroSubtitle: DEFAULT_HERO_SUBTITLE,
@@ -53,7 +53,7 @@ export const load: PageServerLoad = async ({ cookies, request, url }) => {
         getStatsigClientBootstrapPayload(user)
     ]);
 
-    // `url.searchParams` is unavailable while prerendering (`+page.ts` has `prerender = true`).
+    // `url.searchParams` is unavailable while prerendering other routes; `/` is not prerendered.
     // Query overrides still apply in the browser via `hero.svelte` + `page.url.searchParams`.
     const heroQueryParams = url.searchParams;
     const { heroSubtitle, heroLayout, heroTitle } = resolveHeroQueryOverrides(heroQueryParams, {

--- a/src/routes/(marketing)/+page.ts
+++ b/src/routes/(marketing)/+page.ts
@@ -1,1 +1,2 @@
-export const prerender = true;
+/** Statsig hero must run in `+page.server.ts` per request (cookie + bootstrap). Prerendering `/` baked default layout/subtitle and the client overwrote them after `initializeAsync`, causing a visible flash. */
+export const prerender = false;


### PR DESCRIPTION
- Updated the `custom-hero.svelte` component to conditionally assign hero subtitle and layout based on Statsig client responses, preventing unnecessary UI flashes.
- Adjusted the `+page.ts` file to set `prerender = false`, ensuring the marketing page loads per request with real cookies and avoids layout inconsistencies.
- Enhanced documentation in `README.md` to clarify the implications of SSR and client-side rendering for the marketing homepage.

These changes aim to enhance user experience by ensuring a seamless integration of Statsig-driven features while maintaining layout stability.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)