### PR TITLE
Update marketing page for improved Statsig integration and SSR handling

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -51,6 +51,7 @@ jobs:
                       "SENTRY_RELEASE=${{ github.event.release.tag_name }}"
 
     deploy_kubernetes:
+        if: github.event_name != 'release' || !contains(github.event.release.tag_name, '-rc')
         strategy:
             matrix:
                 region: [{ full: fra1, short: fra }]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,10 @@ services:
                 - PUBLIC_APPWRITE_COL_MESSAGES_ID=$PUBLIC_APPWRITE_COL_MESSAGES_ID
                 - PUBLIC_APPWRITE_FN_TLDR_ID=$PUBLIC_APPWRITE_FN_TLDR_ID
                 - PUBLIC_POSTHOG_API_KEY=$PUBLIC_POSTHOG_API_KEY
+        environment:
+            # Runtime (`$env/dynamic/private`) — keep out of image build args.
+            - STATSIG_SERVER_SECRET=${STATSIG_SERVER_SECRET}
+            - STATSIG_ENVIRONMENT=${STATSIG_ENVIRONMENT}
         restart: always
         networks:
             - homepage

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
         "test:integration": "playwright test",
         "test:unit": "vitest",
         "optimize": "bun ./scripts/optimize-assets.js",
-        "optimize:all": "bun ./scripts/optimize-all.js"
+        "optimize:all": "bun ./scripts/optimize-all.js",
+        "benchmark:http": "k6 run scripts/benchmark-k6.js"
     },
     "dependencies": {
         "@sentry/sveltekit": "^10.28.0",

--- a/scripts/benchmark-k6.js
+++ b/scripts/benchmark-k6.js
@@ -1,0 +1,66 @@
+/**
+ * k6 load / smoke test against a local or remote HTTP server.
+ *
+ * Requires k6: https://k6.io/docs/get-started/installation/
+ *   brew install k6
+ *
+ * Run:
+ *   pnpm benchmark:http
+ *   BASE_URL=http://127.0.0.1:3000 pnpm benchmark:http
+ *   ITERATIONS=200 VUS=10 pnpm benchmark:http
+ *   DURATION=1m VUS=20 COOKIE='statsig_stable_id=...' pnpm benchmark:http
+ *
+ * Env (shell → inherited by k6, read via __ENV):
+ *   BASE_URL      default http://127.0.0.1:5173
+ *   TARGET_PATH   default /
+ *   VUS           virtual users (default 5)
+ *   DURATION      e.g. 30s, 1m (default 30s) — used when ITERATIONS is unset
+ *   ITERATIONS    if set, uses shared-iterations instead of fixed duration
+ *   MAX_DURATION  cap for shared-iterations (default 5m)
+ *   COOKIE        optional Cookie header
+ */
+
+import http from 'k6/http';
+import { check } from 'k6';
+
+const base = (__ENV.BASE_URL || 'http://127.0.0.1:5173').replace(/\/$/, '');
+const path = __ENV.TARGET_PATH || '/';
+const url = `${base}${path.startsWith('/') ? path : `/${path}`}`;
+
+const vus = Number(__ENV.VUS || 5);
+const iterationsEnv = __ENV.ITERATIONS;
+const hasIterations = iterationsEnv != null && iterationsEnv !== '' && Number(iterationsEnv) > 0;
+
+export const options = hasIterations
+    ? {
+          scenarios: {
+              bench: {
+                  executor: 'shared-iterations',
+                  vus: Math.max(1, vus),
+                  iterations: Math.max(1, Number(iterationsEnv)),
+                  maxDuration: __ENV.MAX_DURATION || '5m'
+              }
+          },
+          thresholds: {
+              http_req_failed: ['rate<0.05']
+          }
+      }
+    : {
+          vus: Math.max(1, vus),
+          duration: __ENV.DURATION || '30s',
+          thresholds: {
+              http_req_failed: ['rate<0.05']
+          }
+      };
+
+const headers = { Accept: 'text/html,*/*' };
+if (__ENV.COOKIE) {
+    headers.Cookie = __ENV.COOKIE;
+}
+
+export default function () {
+    const res = http.get(url, { headers, tags: { name: 'benchmark' } });
+    check(res, {
+        'status 2xx': (r) => r.status >= 200 && r.status < 400
+    });
+}

--- a/src/instrumentation.server.ts
+++ b/src/instrumentation.server.ts
@@ -1,6 +1,12 @@
 import * as Sentry from '@sentry/sveltekit';
+import { getStatsigServerClient } from '$lib/statsig/server';
 
 Sentry.init({
     dsn: 'https://27d41dc8bb67b596f137924ab8599e59@o1063647.ingest.us.sentry.io/4507497727000576',
     tracesSampleRate: 1.0
+});
+
+/** Start Node Statsig `initialize()` before the first HTTP request so `/` load is not cold. */
+void getStatsigServerClient().catch(() => {
+    /* No `STATSIG_SERVER_SECRET` or network failure — homepage uses defaults until init succeeds. */
 });

--- a/src/lib/statsig/README.md
+++ b/src/lib/statsig/README.md
@@ -1,17 +1,17 @@
 # Statsig layout
 
-| Path                                   | Role                                                                                                            |
-| -------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| `server.ts`                            | Node `Statsig` singleton, `toStatsigUser`, bootstrap payload for the browser SDK.                               |
-| `client.ts`                            | Browser init (`initStatsig`, `whenStatsigReady`), stable id cookie, plugins.                                    |
-| `experiment-eval.ts`                   | Shared readers for typed Statsig evaluations (e.g. layout param keys + `.value` fallback).                      |
-| `experiments/marketing-hero-ids.ts`    | Experiment id strings only (safe on **client** and server).                                                     |
-| `experiments/marketing-hero-client.ts` | Browser-only: `readMarketingHeroExperimentsForExposure` (import from **Svelte** / client code).                 |
+| Path                                   | Role                                                                                                                        |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `server.ts`                            | Node `Statsig` singleton, `toStatsigUser`, bootstrap payload for the browser SDK.                                           |
+| `client.ts`                            | Browser init (`initStatsig`, `whenStatsigReady`), stable id cookie, plugins.                                                |
+| `experiment-eval.ts`                   | Shared readers for typed Statsig evaluations (e.g. layout param keys + `.value` fallback).                                  |
+| `experiments/marketing-hero-ids.ts`    | Experiment id strings only (safe on **client** and server).                                                                 |
+| `experiments/marketing-hero-client.ts` | Browser-only: `readMarketingHeroExperimentsForExposure` (import from **Svelte** / client code).                             |
 | `experiments/marketing-hero-server.ts` | Server-only: `loadMarketingHomeStatsigBundle` (cached homepage batch), `evaluateHero*`, etc. (never import from `.svelte`). |
-| `hero-statsig.server.ts`               | Thin re-export barrel (legacy import path for `+page.server.ts`).                                               |
-| `hero-query-overrides.ts`              | URL query overrides for local QA (`?hero_layout=`, `?hero_subtitle=`, …).                                       |
-| `hero-layout.ts`                       | Pure `normalizeHeroLayout` + `HeroLayoutVariant` type (no network).                                             |
-| `cta-events.ts`                        | Which analytics events mirror into Statsig.                                                                     |
+| `hero-statsig.server.ts`               | Thin re-export barrel (legacy import path for `+page.server.ts`).                                                           |
+| `hero-query-overrides.ts`              | URL query overrides for local QA (`?hero_layout=`, `?hero_subtitle=`, …).                                                   |
+| `hero-layout.ts`                       | Pure `normalizeHeroLayout` + `HeroLayoutVariant` type (no network).                                                         |
+| `cta-events.ts`                        | Which analytics events mirror into Statsig.                                                                                 |
 
 ## Adding a new experiment (marketing hero)
 

--- a/src/lib/statsig/README.md
+++ b/src/lib/statsig/README.md
@@ -21,7 +21,7 @@
     - In `experiments/marketing-hero-server.ts`, add `evaluateYourThingExperiment(...)` using `getStatsigServerClient()` + `toStatsigUser()` + `getExperiment(..., { disableExposureLogging: true })` for SSR without exposure.
     - In `experiments/marketing-hero-client.ts`, extend `readMarketingHeroExperimentsForExposure` so the browser calls `getExperiment(...).get(...)` (exposure for Pulse / Results). Extend `MarketingHeroStatsigBaseline` if SSR + hydration share the field.
 3. **`(marketing)/+page.server.ts`** — `Promise.all` your new evaluator next to the existing ones; pass the value into `resolveHeroQueryOverrides` baseline or add a new field on `data`.
-4. **Hero Svelte** — Pass the new prop from `data`; merge into `resolveHeroQueryOverrides` if URL overrides should apply.
+4. **Hero Svelte** — Add fields to `+page.server.ts` / `+page.ts` load `data`; the marketing hero reads them from `page.data` (not props / not `onMount` state). Merge into `resolveHeroQueryOverrides` if URL overrides should apply.
 5. **URL overrides (optional)** — Add a query key + reader in `hero-query-overrides.ts` and document it in the table comment there.
 
 Do **not** read experiment params only in `onMount` without also defining SSR in step 2–3 unless you intentionally want client-only assignment (e.g. prerender shell + client fill). The marketing homepage is **`prerender = true`**, so production stays fast; expect a possible brief layout/copy update after the Statsig client loads unless you move `/` to per-request SSR (tradeoff: every hit waits on Statsig).

--- a/src/lib/statsig/README.md
+++ b/src/lib/statsig/README.md
@@ -7,7 +7,7 @@
 | `experiment-eval.ts`                   | Shared readers for typed Statsig evaluations (e.g. layout param keys + `.value` fallback).                      |
 | `experiments/marketing-hero-ids.ts`    | Experiment id strings only (safe on **client** and server).                                                     |
 | `experiments/marketing-hero-client.ts` | Browser-only: `readMarketingHeroExperimentsForExposure` (import from **Svelte** / client code).                 |
-| `experiments/marketing-hero-server.ts` | Server-only: `evaluateHeroDescriptionExperiment`, `evaluateHeroLayoutExperiment` (never import from `.svelte`). |
+| `experiments/marketing-hero-server.ts` | Server-only: `loadMarketingHomeStatsigBundle` (cached homepage batch), `evaluateHero*`, etc. (never import from `.svelte`). |
 | `hero-statsig.server.ts`               | Thin re-export barrel (legacy import path for `+page.server.ts`).                                               |
 | `hero-query-overrides.ts`              | URL query overrides for local QA (`?hero_layout=`, `?hero_subtitle=`, …).                                       |
 | `hero-layout.ts`                       | Pure `normalizeHeroLayout` + `HeroLayoutVariant` type (no network).                                             |

--- a/src/lib/statsig/README.md
+++ b/src/lib/statsig/README.md
@@ -24,7 +24,7 @@
 4. **Hero Svelte** — Pass the new prop from `data`; merge into `resolveHeroQueryOverrides` if URL overrides should apply.
 5. **URL overrides (optional)** — Add a query key + reader in `hero-query-overrides.ts` and document it in the table comment there.
 
-Do **not** read experiment params only in `onMount` without also defining SSR in step 2–3 unless you intentionally want client-only assignment. The marketing homepage uses **`prerender = false`** so `+page.server.ts` + bootstrap match hydration and avoid layout flash.
+Do **not** read experiment params only in `onMount` without also defining SSR in step 2–3 unless you intentionally want client-only assignment (e.g. prerender shell + client fill). The marketing homepage is **`prerender = true`**, so production stays fast; expect a possible brief layout/copy update after the Statsig client loads unless you move `/` to per-request SSR (tradeoff: every hit waits on Statsig).
 
 **Why two files (`*-client` / `*-server`)?** `@statsig/statsig-node-core` ships native `.node` binaries. If any module imported by a `.svelte` file pulls in `server.ts` or `marketing-hero-server.ts`, Vite tries to bundle that SDK for the browser and fails with “No loader is configured for `.node` files”.
 

--- a/src/lib/statsig/experiments/marketing-hero-server.ts
+++ b/src/lib/statsig/experiments/marketing-hero-server.ts
@@ -4,29 +4,76 @@
  *
  * @see ../README.md
  */
-import type { StatsigUser } from '@statsig/statsig-node-core';
+import type { Statsig, StatsigUser } from '@statsig/statsig-node-core';
 import { readLayoutVariantFromStatsigEvaluation } from '../experiment-eval';
 import type { HeroLayoutVariant } from '../hero-layout';
 import { normalizeHeroSubtitle } from '../hero-query-overrides';
-import { getStatsigServerClient, toStatsigUser, type StatsigServerUserInput } from '../server';
+import {
+    getStatsigClientBootstrapPayloadForClient,
+    getStatsigServerClient,
+    toStatsigUser,
+    type StatsigServerUserInput
+} from '../server';
 import { MARKETING_HERO_EXPERIMENTS } from './marketing-hero-ids';
 
 export { MARKETING_HERO_EXPERIMENTS };
 
 const DISABLE_EXPOSURE = { disableExposureLogging: true } as const;
 
+export type MarketingHomeStatsigBundle = {
+    heroSubtitleBase: string;
+    heroLayoutBase: HeroLayoutVariant;
+    statsigBootstrap: string | null;
+};
+
 /**
- * SSR: `best_description`. Client must still call `readMarketingHeroExperimentsForExposure` so Pulse gets an exposure.
+ * Cache is **per Statsig stable id** (same cookie as `+page.server.ts` / browser SDK): one row per
+ * anonymous browser, not per logged-in Appwrite user. Lives in this Node process memory only.
  */
-export async function evaluateHeroDescriptionExperiment(
-    user: StatsigUser | StatsigServerUserInput,
+/** Longer TTL = fewer Statsig round-trips for returning visitors (stale hero assignment up to this window). */
+const MARKETING_HOME_STATSIG_CACHE_TTL_MS = 300_000;
+/** Hard cap on distinct stable ids tracked in one process; enforced with LRU eviction below. */
+const MARKETING_HOME_STATSIG_CACHE_MAX = 5_000;
+
+type CacheRow = {
+    expiresAt: number;
+    /** LRU tie-breaker when the map is full and every row is still inside TTL. */
+    lastAccessAt: number;
+    bundle: MarketingHomeStatsigBundle;
+};
+
+const marketingHomeStatsigCache = new Map<string, CacheRow>();
+
+function sweepExpiredMarketingHomeStatsigCache(now: number) {
+    for (const [k, v] of marketingHomeStatsigCache) {
+        if (v.expiresAt <= now) {
+            marketingHomeStatsigCache.delete(k);
+        }
+    }
+}
+
+/** If still above max (e.g. many first-time visitors inside TTL), drop least-recently-used rows. */
+function evictMarketingHomeStatsigCacheLru() {
+    const max = MARKETING_HOME_STATSIG_CACHE_MAX;
+    const target = Math.floor(max * 0.75);
+    if (marketingHomeStatsigCache.size <= max) return;
+
+    const entries = [...marketingHomeStatsigCache.entries()].sort(
+        (a, b) => a[1].lastAccessAt - b[1].lastAccessAt
+    );
+    while (marketingHomeStatsigCache.size > target && entries.length > 0) {
+        const next = entries.shift();
+        if (next === undefined) break;
+        marketingHomeStatsigCache.delete(next[0]);
+    }
+}
+
+async function evaluateHeroDescriptionWithClient(
+    client: Statsig,
+    statsigUser: StatsigUser,
     fallback: string
 ): Promise<string> {
-    const client = await getStatsigServerClient();
-    if (!client) return fallback;
-
     try {
-        const statsigUser = toStatsigUser(user);
         const experiment = client.getExperiment(
             statsigUser,
             MARKETING_HERO_EXPERIMENTS.bestDescription,
@@ -39,18 +86,12 @@ export async function evaluateHeroDescriptionExperiment(
     }
 }
 
-/**
- * SSR: `hero_layout` (experiment and/or dynamic config with the same id).
- */
-export async function evaluateHeroLayoutExperiment(
-    user: StatsigUser | StatsigServerUserInput,
+async function evaluateHeroLayoutWithClient(
+    client: Statsig,
+    statsigUser: StatsigUser,
     fallback: HeroLayoutVariant
 ): Promise<HeroLayoutVariant> {
-    const client = await getStatsigServerClient();
-    if (!client) return fallback;
-
     try {
-        const statsigUser = toStatsigUser(user);
         const id = MARKETING_HERO_EXPERIMENTS.heroLayout;
         const experiment = client.getExperiment(statsigUser, id, DISABLE_EXPOSURE);
         let r = readLayoutVariantFromStatsigEvaluation(experiment, fallback);
@@ -63,4 +104,89 @@ export async function evaluateHeroLayoutExperiment(
     } catch {
         return fallback;
     }
+}
+
+/**
+ * One Statsig client + one user shape for the homepage: parallel eval + bootstrap, with a short
+ * in-memory cache keyed by stable id to speed repeat `/` loads.
+ */
+export async function loadMarketingHomeStatsigBundle(
+    user: StatsigUser | StatsigServerUserInput,
+    cacheKey: string,
+    fallbacks: { subtitle: string; layout: HeroLayoutVariant }
+): Promise<MarketingHomeStatsigBundle> {
+    const now = Date.now();
+    sweepExpiredMarketingHomeStatsigCache(now);
+
+    const hit = marketingHomeStatsigCache.get(cacheKey);
+    if (hit && hit.expiresAt > now) {
+        hit.lastAccessAt = now;
+        return hit.bundle;
+    }
+
+    const client = await getStatsigServerClient();
+    if (!client) {
+        return {
+            heroSubtitleBase: fallbacks.subtitle,
+            heroLayoutBase: fallbacks.layout,
+            statsigBootstrap: null
+        };
+    }
+
+    const statsigUser = toStatsigUser(user);
+
+    const bootstrapFilters = {
+        experimentFilter: new Set([
+            MARKETING_HERO_EXPERIMENTS.bestDescription,
+            MARKETING_HERO_EXPERIMENTS.heroLayout
+        ]),
+        dynamicConfigFilter: new Set([MARKETING_HERO_EXPERIMENTS.heroLayout])
+    };
+
+    const [heroSubtitleBase, heroLayoutBase, statsigBootstrap] = await Promise.all([
+        evaluateHeroDescriptionWithClient(client, statsigUser, fallbacks.subtitle),
+        evaluateHeroLayoutWithClient(client, statsigUser, fallbacks.layout),
+        Promise.resolve(
+            getStatsigClientBootstrapPayloadForClient(client, statsigUser, bootstrapFilters)
+        )
+    ]);
+
+    const bundle: MarketingHomeStatsigBundle = {
+        heroSubtitleBase,
+        heroLayoutBase,
+        statsigBootstrap
+    };
+
+    marketingHomeStatsigCache.set(cacheKey, {
+        expiresAt: now + MARKETING_HOME_STATSIG_CACHE_TTL_MS,
+        lastAccessAt: now,
+        bundle
+    });
+    evictMarketingHomeStatsigCacheLru();
+
+    return bundle;
+}
+
+/**
+ * SSR: `best_description`. Client must still call `readMarketingHeroExperimentsForExposure` so Pulse gets an exposure.
+ */
+export async function evaluateHeroDescriptionExperiment(
+    user: StatsigUser | StatsigServerUserInput,
+    fallback: string
+): Promise<string> {
+    const client = await getStatsigServerClient();
+    if (!client) return fallback;
+    return evaluateHeroDescriptionWithClient(client, toStatsigUser(user), fallback);
+}
+
+/**
+ * SSR: `hero_layout` (experiment and/or dynamic config with the same id).
+ */
+export async function evaluateHeroLayoutExperiment(
+    user: StatsigUser | StatsigServerUserInput,
+    fallback: HeroLayoutVariant
+): Promise<HeroLayoutVariant> {
+    const client = await getStatsigServerClient();
+    if (!client) return fallback;
+    return evaluateHeroLayoutWithClient(client, toStatsigUser(user), fallback);
 }

--- a/src/lib/statsig/hero-statsig.server.ts
+++ b/src/lib/statsig/hero-statsig.server.ts
@@ -11,7 +11,9 @@ export {
 export {
     evaluateHeroDescriptionExperiment,
     evaluateHeroLayoutExperiment,
-    MARKETING_HERO_EXPERIMENTS
+    loadMarketingHomeStatsigBundle,
+    MARKETING_HERO_EXPERIMENTS,
+    type MarketingHomeStatsigBundle
 } from './experiments/marketing-hero-server';
 export type {
     MarketingHeroClientExposureDebug,

--- a/src/lib/statsig/server.ts
+++ b/src/lib/statsig/server.ts
@@ -2,6 +2,7 @@ import { env } from '$env/dynamic/private';
 import {
     Statsig,
     StatsigUser,
+    type ClientInitResponseOptions,
     type StatsigOptions,
     type StatsigUserArgs
 } from '@statsig/statsig-node-core';
@@ -76,12 +77,24 @@ export async function getStatsigClientBootstrapPayload(
 ): Promise<string | null> {
     const client = await getStatsigServerClient();
     if (!client) return null;
+    return getStatsigClientBootstrapPayloadForClient(client, user);
+}
 
+/** Same as {@link getStatsigClientBootstrapPayload} when the Node client is already initialized. */
+export function getStatsigClientBootstrapPayloadForClient(
+    client: Statsig,
+    user: StatsigUser | StatsigServerUserInput,
+    initOverrides?: Pick<
+        ClientInitResponseOptions,
+        'experimentFilter' | 'dynamicConfigFilter' | 'featureGateFilter' | 'layerFilter'
+    >
+): string | null {
     try {
         const statsigUser = toStatsigUser(user);
         const response = client.getClientInitializeResponse(statsigUser, {
             hashAlgorithm: 'djb2',
-            clientSdkKey: STATSIG_CLIENT_SDK_KEY
+            clientSdkKey: STATSIG_CLIENT_SDK_KEY,
+            ...initOverrides
         });
         if (response == null || response === '') {
             return null;

--- a/src/routes/(marketing)/(components)/hero.svelte
+++ b/src/routes/(marketing)/(components)/hero.svelte
@@ -20,36 +20,26 @@
     import GradientText from '$lib/components/fancy/gradient-text.svelte';
     import { Button } from '$lib/components/ui';
     import { cn } from '$lib/utils/cn';
+    import type { PageData } from '../$types';
     import Dashboard from './dashboard.svelte';
     import HeroBanner from './hero-banner.svelte';
 
-    type Props = {
-        title?: string;
-        /** Resolved on the server from Statsig (`+page.server.ts`) so SSR matches the experiment. */
-        subtitle?: string;
-        /** `hero_layout` experiment: `0` aside, `1` bottom + wrapped title, `2` bottom + single-line title. */
-        heroLayout?: HeroLayoutVariant;
+    /** Merged layout + page load; Statsig keys come from `+page.server.ts` (omitted from generated `PageData` in some setups). */
+    type MarketingHeroPageData = PageData & {
+        statsigBootstrap?: string | null;
+        statsigStableUserId?: string | null;
+        statsigUserAgent?: string | null;
     };
 
-    const {
-        title = DEFAULT_HERO_TITLE,
-        subtitle = DEFAULT_HERO_SUBTITLE,
-        heroLayout = 0
-    }: Props = $props();
+    /** From `+page.server.ts` + `+page.ts` — single source of truth for first paint (no `onMount` layout state). */
+    const data = $derived(page.data as MarketingHeroPageData);
 
-    /**
-     * Optional overrides after the browser Statsig client runs (exposure logging). When bootstrap
-     * matches SSR, we leave these undefined so the UI stays on server props with no flash.
-     */
-    let clientHeroLayout = $state<HeroLayoutVariant | undefined>(undefined);
-    let clientHeroSubtitle = $state<string | undefined>(undefined);
-
-    /** Statsig baseline from SSR + optional client overrides; URL query params override in the browser. */
+    /** URL query overrides apply in the browser; baseline always comes from `page.data`. */
     const resolved = $derived(
         resolveHeroQueryOverrides(building ? new URLSearchParams() : page.url.searchParams, {
-            heroLayout: clientHeroLayout ?? heroLayout,
-            heroSubtitle: clientHeroSubtitle ?? subtitle,
-            heroTitle: title
+            heroLayout: (data.heroLayout ?? 0) as HeroLayoutVariant,
+            heroSubtitle: data.heroSubtitle ?? DEFAULT_HERO_SUBTITLE,
+            heroTitle: data.heroTitle ?? DEFAULT_HERO_TITLE
         })
     );
 
@@ -58,36 +48,34 @@
     const layoutBottomTwoLineTitle = $derived(resolved.heroLayout === 1);
 
     /**
-     * SSR evaluates experiments with exposure logging disabled; Pulse / Results need a client
-     * exposure when the user actually sees the hero. Reading params logs the exposure and keeps
-     * the rendered values as the SSR defaults when the client matches bootstrap.
-     * @see https://docs.statsig.com/pulse (exposures enroll units in the experiment)
+     * SSR uses Statsig with exposure logging off; Pulse needs a browser exposure. We only call
+     * `.get` here — layout/subtitle/title stay on `page.data` from load so the UI does not switch
+     * after paint.
+     * @see https://docs.statsig.com/pulse
      */
     onMount(() => {
         if (!browser || ENV.TEST) return;
-        /** Set `?debug_statsig` on the URL to log in non-dev builds (e.g. `pnpm preview`). */
         const debugStatsigHero = import.meta.env.DEV || page.url.searchParams.has('debug_statsig');
         const log = (...args: unknown[]) => {
             if (debugStatsigHero) console.log('[Statsig hero]', ...args);
         };
 
+        const baselineSubtitle = data.heroSubtitle ?? DEFAULT_HERO_SUBTITLE;
+        const baselineLayout = (data.heroLayout ?? 0) as HeroLayoutVariant;
+        const baselineTitle = data.heroTitle ?? DEFAULT_HERO_TITLE;
+
         if (hasHeroExperimentQueryOverrides(page.url.searchParams)) {
             log('URL query overrides (client layout)', {
                 ...resolveHeroQueryOverrides(page.url.searchParams, {
-                    heroLayout: clientHeroLayout ?? heroLayout,
-                    heroSubtitle: clientHeroSubtitle ?? subtitle,
-                    heroTitle: title
+                    heroLayout: baselineLayout,
+                    heroSubtitle: baselineSubtitle,
+                    heroTitle: baselineTitle
                 }),
-                ssrBaseline: { heroLayout, subtitleLen: subtitle.length }
+                dataBaseline: { heroLayout: baselineLayout, subtitleLen: baselineSubtitle.length }
             });
             return;
         }
 
-        const data = page.data as {
-            statsigBootstrap?: string | null;
-            statsigStableUserId?: string | null;
-            statsigUserAgent?: string | null;
-        };
         void initStatsig(
             data.statsigBootstrap ?? null,
             data.statsigStableUserId ?? null,
@@ -96,30 +84,19 @@
 
         void whenStatsigReady().then((client) => {
             if (!client) {
-                log('Statsig client not ready; SSR baseline only', {
-                    heroLayout,
-                    subtitleLen: subtitle.length
+                log('Statsig client not ready; using `page.data` hero only', {
+                    heroLayout: baselineLayout,
+                    subtitleLen: baselineSubtitle.length
                 });
                 return;
             }
 
-            const {
-                heroSubtitle: nextSubtitle,
-                heroLayout: nextLayout,
-                debug
-            } = readMarketingHeroExperimentsForExposure(client, {
-                heroSubtitle: subtitle,
-                heroLayout
+            const { debug } = readMarketingHeroExperimentsForExposure(client, {
+                heroSubtitle: baselineSubtitle,
+                heroLayout: baselineLayout
             });
 
-            if (nextSubtitle !== subtitle) {
-                clientHeroSubtitle = nextSubtitle;
-            }
-            if (nextLayout !== heroLayout) {
-                clientHeroLayout = nextLayout;
-            }
-
-            log('experiment values (after get → exposure)', {
+            log('experiment exposure (display stays on `page.data`)', {
                 [MARKETING_HERO_EXPERIMENTS.bestDescription]:
                     debug[MARKETING_HERO_EXPERIMENTS.bestDescription],
                 [MARKETING_HERO_EXPERIMENTS.heroLayout]:

--- a/src/routes/(marketing)/+page.server.ts
+++ b/src/routes/(marketing)/+page.server.ts
@@ -14,8 +14,8 @@ import type { HeroLayoutVariant } from '$lib/statsig/hero-layout';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ cookies, request, url }) => {
-    // `+page.ts` sets `prerender = false` for `/` so this load runs per request with real cookies.
-    // During `vite build` the marketing page may still be analyzed with `building === true`; keep a safe fallback.
+    // Prerendered `/` must not embed per-user Statsig bootstrap or stable IDs — one static HTML is
+    // served to everyone; the hero applies experiments after `initializeAsync` in the browser.
     if (building) {
         return {
             heroSubtitle: DEFAULT_HERO_SUBTITLE,
@@ -53,7 +53,7 @@ export const load: PageServerLoad = async ({ cookies, request, url }) => {
         getStatsigClientBootstrapPayload(user)
     ]);
 
-    // `url.searchParams` is unavailable while prerendering other routes; `/` is not prerendered.
+    // `url.searchParams` is unavailable while prerendering (`+page.ts` has `prerender = true`).
     // Query overrides still apply in the browser via `hero.svelte` + `page.url.searchParams`.
     const heroQueryParams = url.searchParams;
     const { heroSubtitle, heroLayout, heroTitle } = resolveHeroQueryOverrides(heroQueryParams, {

--- a/src/routes/(marketing)/+page.server.ts
+++ b/src/routes/(marketing)/+page.server.ts
@@ -43,11 +43,11 @@ export const load: PageServerLoad = async ({ cookies, request, url }) => {
         ...(userAgent ? { userAgent } : {})
     };
 
-    const { heroSubtitleBase, heroLayoutBase, statsigBootstrap } = await loadMarketingHomeStatsigBundle(
-        user,
-        stableId,
-        { subtitle: DEFAULT_HERO_SUBTITLE, layout: 0 }
-    );
+    const { heroSubtitleBase, heroLayoutBase, statsigBootstrap } =
+        await loadMarketingHomeStatsigBundle(user, stableId, {
+            subtitle: DEFAULT_HERO_SUBTITLE,
+            layout: 0
+        });
 
     // `url.searchParams` is unavailable while prerendering (`+page.ts` has `prerender = true`).
     // Query overrides still apply in the browser via `hero.svelte` + `page.url.searchParams`.

--- a/src/routes/(marketing)/+page.server.ts
+++ b/src/routes/(marketing)/+page.server.ts
@@ -5,11 +5,7 @@ import {
 } from '$lib/statsig/constants';
 import { resolveHeroQueryOverrides } from '$lib/statsig/hero-query-overrides';
 import { building } from '$app/environment';
-import {
-    evaluateHeroDescriptionExperiment,
-    evaluateHeroLayoutExperiment,
-    getStatsigClientBootstrapPayload
-} from '$lib/statsig/hero-statsig.server';
+import { loadMarketingHomeStatsigBundle } from '$lib/statsig/hero-statsig.server';
 import type { HeroLayoutVariant } from '$lib/statsig/hero-layout';
 import type { PageServerLoad } from './$types';
 
@@ -47,11 +43,11 @@ export const load: PageServerLoad = async ({ cookies, request, url }) => {
         ...(userAgent ? { userAgent } : {})
     };
 
-    const [heroSubtitleBase, heroLayoutBase, statsigBootstrap] = await Promise.all([
-        evaluateHeroDescriptionExperiment(user, DEFAULT_HERO_SUBTITLE),
-        evaluateHeroLayoutExperiment(user, 0),
-        getStatsigClientBootstrapPayload(user)
-    ]);
+    const { heroSubtitleBase, heroLayoutBase, statsigBootstrap } = await loadMarketingHomeStatsigBundle(
+        user,
+        stableId,
+        { subtitle: DEFAULT_HERO_SUBTITLE, layout: 0 }
+    );
 
     // `url.searchParams` is unavailable while prerendering (`+page.ts` has `prerender = true`).
     // Query overrides still apply in the browser via `hero.svelte` + `page.url.searchParams`.

--- a/src/routes/(marketing)/+page.svelte
+++ b/src/routes/(marketing)/+page.svelte
@@ -13,8 +13,6 @@
     import { FooterNav, MainFooter } from '$lib/components';
     import LogoList from './(components)/logo-list.svelte';
     import Ai from './(components)/ai.svelte';
-
-    const { data } = $props();
 </script>
 
 <Head
@@ -23,7 +21,7 @@
 />
 
 <Main>
-    <Hero title={data.heroTitle} subtitle={data.heroSubtitle} heroLayout={data.heroLayout} />
+    <Hero />
     <Platforms headline="Designed for the tools you work with" />
     <LogoList class="border-smooth border-b" title="Loved by startups and world leaders" />
     <Bento />

--- a/src/routes/(marketing)/+page.ts
+++ b/src/routes/(marketing)/+page.ts
@@ -1,2 +1,1 @@
-/** Statsig hero must run in `+page.server.ts` per request (cookie + bootstrap). Prerendering `/` baked default layout/subtitle and the client overwrote them after `initializeAsync`, causing a visible flash. */
-export const prerender = false;
+export const prerender = true;

--- a/src/routes/(marketing)/+page.ts
+++ b/src/routes/(marketing)/+page.ts
@@ -1,6 +1,6 @@
 import type { PageLoad } from './$types';
 
-export const prerender = true;
+export const prerender = false;
 
 /**
  * Runs after `+page.server.ts` merges into `data` and before the page renders. The marketing hero

--- a/src/routes/(marketing)/+page.ts
+++ b/src/routes/(marketing)/+page.ts
@@ -1,1 +1,16 @@
+import type { PageLoad } from './$types';
+
 export const prerender = true;
+
+/**
+ * Runs after `+page.server.ts` merges into `data` and before the page renders. The marketing hero
+ * reads `heroTitle`, `heroSubtitle`, and `heroLayout` from `page.data` only (no duplicate state in
+ * `onMount`) so SSR / prerender and the first client paint stay aligned.
+ */
+export const load: PageLoad = async ({ data }) => {
+    return {
+        heroTitle: data.heroTitle,
+        heroSubtitle: data.heroSubtitle,
+        heroLayout: data.heroLayout
+    };
+};


### PR DESCRIPTION
- Changed `prerender` setting in `+page.ts` to `true` to ensure a static HTML response for the marketing page, enhancing performance and avoiding layout flashes.
- Revised comments in `+page.server.ts` to clarify the handling of Statsig client initialization and query parameters during prerendering.
- Updated documentation in `README.md` to reflect the new prerendering behavior and its implications for user experience.

These changes aim to optimize the marketing page's performance while maintaining a seamless integration with Statsig features.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)