### PR TITLE
Tune website CPU and memory resources

### DIFF
--- a/deploy/website/templates/website.yaml
+++ b/deploy/website/templates/website.yaml
@@ -31,13 +31,13 @@ spec:
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           resources:
             requests:
-              cpu: 400m
-              memory: 512Mi
+              cpu: 500m
+              memory: 1Gi
             limits:
-              memory: 512Mi
+              memory: 1Gi
           env:
             - name: NODE_OPTIONS
-              value: "--max-old-space-size=400"
+              value: "--max-old-space-size=768"
             - name: STATSIG_SERVER_SECRET
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary
- Increase cpu request from 400m to 500m
- Raise memory request and limit from 512Mi to 1Gi
- Bump Node `--max-old-space-size` from 400 to 768

## Test plan
- [ ] Verify deployment rolls out successfully in staging
- [ ] Confirm pods stay within new memory limit under normal load

🤖 Generated with [Claude Code](https://claude.com/claude-code)