### PR TITLE
fix: broken mobile layout of 1

### DIFF
--- a/src/lib/components/homepage-variations/custom-hero.svelte
+++ b/src/lib/components/homepage-variations/custom-hero.svelte
@@ -87,7 +87,7 @@
         'relative flex max-w-screen items-center',
         layoutAside
             ? 'overflow-hidden py-10 md:py-0 lg:min-h-[680px]'
-            : 'overflow-x-visible overflow-y-clip pt-10 pb-6 md:pt-14 md:pb-8 lg:min-h-[560px] lg:pt-16'
+            : 'overflow-hidden overflow-y-clip pt-10 pb-6 md:pt-14 md:pb-8 lg:min-h-[560px] lg:pt-16'
     )}
 >
     <div

--- a/src/routes/(marketing)/(components)/hero.svelte
+++ b/src/routes/(marketing)/(components)/hero.svelte
@@ -112,7 +112,7 @@
         /** Aside: clip mockup bleed. Stacked: avoid clipping long titles on tablet (overflow-hidden + nowrap). */
         layoutAside
             ? 'overflow-hidden py-10 md:py-0 lg:min-h-[680px]'
-            : 'overflow-x-visible overflow-y-clip pt-10 pb-6 md:pt-14 md:pb-8 lg:min-h-[560px] lg:pt-16'
+            : 'overflow-hidden overflow-y-clip pt-10 pb-6 md:pt-14 md:pb-8 lg:min-h-[560px] lg:pt-16'
     )}
 >
     <div


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?
before:
<img width="542" height="735" alt="image" src="https://github.com/user-attachments/assets/5836ae32-a70c-4bf1-8afa-8e5a0e9f3941" />


after:
<img width="581" height="603" alt="image" src="https://github.com/user-attachments/assets/4974b073-35b8-427d-a2b6-d55662f1102c" />


## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)