### PR TITLE
chore(deploy): expose resources/nodeOptions, lower staging memory

### DIFF
--- a/deploy/website/environments/staging/fra1.values.yaml
+++ b/deploy/website/environments/staging/fra1.values.yaml
@@ -1,3 +1,12 @@
 domain:
   - stage.appwrite.io
   - www.stage.appwrite.io
+
+resources:
+  requests:
+    cpu: 500m
+    memory: 500Mi
+  limits:
+    memory: 500Mi
+
+nodeOptions: "--max-old-space-size=384"

--- a/deploy/website/templates/website.yaml
+++ b/deploy/website/templates/website.yaml
@@ -30,14 +30,10 @@ spec:
           image: "ghcr.io/appwrite/website:{{ .Values.version }}"
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           resources:
-            requests:
-              cpu: 500m
-              memory: 1Gi
-            limits:
-              memory: 1Gi
+            {{- toYaml .Values.resources | nindent 12 }}
           env:
             - name: NODE_OPTIONS
-              value: "--max-old-space-size=768"
+              value: {{ .Values.nodeOptions | quote }}
             - name: STATSIG_SERVER_SECRET
               valueFrom:
                 secretKeyRef:

--- a/deploy/website/values.yaml
+++ b/deploy/website/values.yaml
@@ -6,3 +6,12 @@ imagePullPolicy: IfNotPresent
 minReplicas: 2
 maxReplicas: 3
 maxUnavailable: 1
+
+resources:
+  requests:
+    cpu: 500m
+    memory: 1Gi
+  limits:
+    memory: 1Gi
+
+nodeOptions: "--max-old-space-size=768"


### PR DESCRIPTION
## Summary
- Parameterize the `resources` block and `NODE_OPTIONS` env in the website Helm chart so each environment can size its own pod
- Default values keep production at 1Gi memory (request+limit) with `--max-old-space-size=768`
- Staging fra1 now runs at 500Mi (request+limit) with `--max-old-space-size=384` to match the smaller heap

## Test plan
- [ ] `helm template` renders production values to current 1Gi / 768 settings
- [ ] `helm template` with staging overlay renders 500Mi / 384
- [ ] Staging pod starts and serves `/healthz` under the lower limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)