### PR TITLE
Replace best_description with best_title Statsig experiment for hero …

### DIFF
--- a/src/lib/components/homepage-variations/custom-hero.svelte
+++ b/src/lib/components/homepage-variations/custom-hero.svelte
@@ -40,6 +40,7 @@
 
     /** Same client hydration path as marketing `hero.svelte` (Statsig + query overrides). */
     let clientHeroLayout = $state<HeroLayoutVariant | undefined>(undefined);
+    let clientHeroTitle = $state<string | undefined>(undefined);
     let clientHeroSubtitle = $state<string | undefined>(undefined);
     let clientHeroCta = $state<string | undefined>(undefined);
 
@@ -47,7 +48,7 @@
         resolveHeroQueryOverrides(building ? new URLSearchParams() : page.url.searchParams, {
             heroLayout: clientHeroLayout ?? heroLayout,
             heroSubtitle: clientHeroSubtitle ?? subtitle,
-            heroTitle: title,
+            heroTitle: clientHeroTitle ?? title,
             heroCta: clientHeroCta ?? ctaLabel
         })
     );
@@ -71,14 +72,19 @@
             if (!client) return;
 
             const {
+                heroTitle: nextTitle,
                 heroSubtitle: nextSubtitle,
                 heroLayout: nextLayout,
                 heroCta: nextCta
             } = readMarketingHeroExperimentsForExposure(client, {
+                heroTitle: title,
                 heroSubtitle: subtitle,
                 heroLayout,
                 heroCta: ctaLabel
             });
+            if (nextTitle !== title) {
+                clientHeroTitle = nextTitle;
+            }
             if (nextSubtitle !== subtitle) {
                 clientHeroSubtitle = nextSubtitle;
             }

--- a/src/lib/statsig/constants.ts
+++ b/src/lib/statsig/constants.ts
@@ -5,7 +5,7 @@ export const STATSIG_STABLE_ID_KEY = 'statsig_stable_id';
 export const STATSIG_CLIENT_SDK_KEY = 'client-TRp4ODQ3Yfsha0XwmRayqwb7WW0ujUbiGrNlB0pfhTH';
 
 export const DEFAULT_HERO_SUBTITLE =
-    'Appwrite is an open-source, all-in-one development platform. Use built-in backend infrastructure and web hosting, all from a single place.';
+    'Appwrite is an open-source alternative to Firebase and Supabase, offering Auth, Databases, Storage, Functions, Messaging, Realtime, and web hosting - all in one platform, optimized for building with AI agents.';
 
 export const DEFAULT_HERO_TITLE = 'Build like a team of hundreds';
 

--- a/src/lib/statsig/experiments/marketing-hero-client.ts
+++ b/src/lib/statsig/experiments/marketing-hero-client.ts
@@ -7,12 +7,17 @@
 import type { StatsigBrowserClient } from '../client';
 import { readLayoutVariantFromStatsigClient } from '../experiment-eval';
 import type { HeroLayoutVariant } from '../hero-layout';
-import { normalizeHeroCta, normalizeHeroSubtitle } from '../hero-query-overrides';
+import {
+    normalizeHeroCta,
+    normalizeHeroSubtitle,
+    normalizeHeroTitle
+} from '../hero-query-overrides';
 import { MARKETING_HERO_EXPERIMENTS } from './marketing-hero-ids';
 
 export { MARKETING_HERO_EXPERIMENTS };
 
 export type MarketingHeroStatsigBaseline = {
+    heroTitle: string;
     heroSubtitle: string;
     heroLayout: HeroLayoutVariant;
     heroCta: string;
@@ -28,14 +33,15 @@ export function readMarketingHeroExperimentsForExposure(
     client: StatsigBrowserClient,
     baseline: MarketingHeroStatsigBaseline
 ): {
+    heroTitle: string;
     heroSubtitle: string;
     heroLayout: HeroLayoutVariant;
     heroCta: string;
     debug: MarketingHeroClientExposureDebug;
 } {
-    const rawDescription = client
-        .getExperiment(MARKETING_HERO_EXPERIMENTS.bestDescription)
-        .get('description', baseline.heroSubtitle);
+    const bestTitleExperiment = client.getExperiment(MARKETING_HERO_EXPERIMENTS.bestTitle);
+    const rawTitle = bestTitleExperiment.get('title', baseline.heroTitle);
+    const rawDescription = bestTitleExperiment.get('description', baseline.heroSubtitle);
 
     const rawCta = client
         .getExperiment(MARKETING_HERO_EXPERIMENTS.bestCta)
@@ -47,19 +53,23 @@ export function readMarketingHeroExperimentsForExposure(
         baseline.heroLayout
     );
 
+    const heroTitle = normalizeHeroTitle(rawTitle, baseline.heroTitle);
     const heroSubtitle = normalizeHeroSubtitle(rawDescription, baseline.heroSubtitle);
     const heroCta = normalizeHeroCta(rawCta, baseline.heroCta);
 
     return {
+        heroTitle,
         heroSubtitle,
         heroLayout: layoutRead.layout,
         heroCta,
         debug: {
-            [MARKETING_HERO_EXPERIMENTS.bestDescription]: {
-                raw: rawDescription,
-                rawType: typeof rawDescription,
-                normalizedLen: heroSubtitle.length,
-                ssrBaselineLen: baseline.heroSubtitle.length
+            [MARKETING_HERO_EXPERIMENTS.bestTitle]: {
+                rawTitle,
+                rawDescription,
+                normalizedTitleLen: heroTitle.length,
+                normalizedDescriptionLen: heroSubtitle.length,
+                ssrBaselineTitleLen: baseline.heroTitle.length,
+                ssrBaselineDescriptionLen: baseline.heroSubtitle.length
             },
             [MARKETING_HERO_EXPERIMENTS.bestCta]: {
                 raw: rawCta,

--- a/src/lib/statsig/experiments/marketing-hero-ids.ts
+++ b/src/lib/statsig/experiments/marketing-hero-ids.ts
@@ -3,8 +3,8 @@
  * Safe to import from **client** code (no Node Statsig SDK).
  */
 export const MARKETING_HERO_EXPERIMENTS = {
-    /** Param: `description` (string). */
-    bestDescription: 'best_description',
+    /** Params: `title` and `description` (strings) — hero headline and supporting copy. */
+    bestTitle: 'best_title',
     /** Param: `cta` (string). Primary hero dashboard button label. */
     bestCta: 'best_cta',
     /**

--- a/src/lib/statsig/experiments/marketing-hero-server.ts
+++ b/src/lib/statsig/experiments/marketing-hero-server.ts
@@ -7,7 +7,11 @@
 import type { Statsig, StatsigUser } from '@statsig/statsig-node-core';
 import { readLayoutVariantFromStatsigEvaluation } from '../experiment-eval';
 import type { HeroLayoutVariant } from '../hero-layout';
-import { normalizeHeroCta, normalizeHeroSubtitle } from '../hero-query-overrides';
+import {
+    normalizeHeroCta,
+    normalizeHeroSubtitle,
+    normalizeHeroTitle
+} from '../hero-query-overrides';
 import {
     getStatsigClientBootstrapPayloadForClient,
     getStatsigServerClient,
@@ -21,6 +25,7 @@ export { MARKETING_HERO_EXPERIMENTS };
 const DISABLE_EXPOSURE = { disableExposureLogging: true } as const;
 
 export type MarketingHomeStatsigBundle = {
+    heroTitleBase: string;
     heroSubtitleBase: string;
     heroLayoutBase: HeroLayoutVariant;
     heroCtaBase: string;
@@ -69,21 +74,25 @@ function evictMarketingHomeStatsigCacheLru() {
     }
 }
 
-async function evaluateHeroDescriptionWithClient(
+async function evaluateBestTitleHeroWithClient(
     client: Statsig,
     statsigUser: StatsigUser,
-    fallback: string
-): Promise<string> {
+    fallbacks: { title: string; description: string }
+): Promise<{ title: string; description: string }> {
     try {
         const experiment = client.getExperiment(
             statsigUser,
-            MARKETING_HERO_EXPERIMENTS.bestDescription,
+            MARKETING_HERO_EXPERIMENTS.bestTitle,
             DISABLE_EXPOSURE
         );
-        const raw = experiment.get('description', fallback);
-        return normalizeHeroSubtitle(raw, fallback);
+        const rawTitle = experiment.get('title', fallbacks.title);
+        const rawDescription = experiment.get('description', fallbacks.description);
+        return {
+            title: normalizeHeroTitle(rawTitle, fallbacks.title),
+            description: normalizeHeroSubtitle(rawDescription, fallbacks.description)
+        };
     } catch {
-        return fallback;
+        return { title: fallbacks.title, description: fallbacks.description };
     }
 }
 
@@ -132,7 +141,7 @@ async function evaluateHeroLayoutWithClient(
 export async function loadMarketingHomeStatsigBundle(
     user: StatsigUser | StatsigServerUserInput,
     cacheKey: string,
-    fallbacks: { subtitle: string; layout: HeroLayoutVariant; cta: string }
+    fallbacks: { title: string; subtitle: string; layout: HeroLayoutVariant; cta: string }
 ): Promise<MarketingHomeStatsigBundle> {
     const now = Date.now();
     sweepExpiredMarketingHomeStatsigCache(now);
@@ -146,6 +155,7 @@ export async function loadMarketingHomeStatsigBundle(
     const client = await getStatsigServerClient();
     if (!client) {
         return {
+            heroTitleBase: fallbacks.title,
             heroSubtitleBase: fallbacks.subtitle,
             heroLayoutBase: fallbacks.layout,
             heroCtaBase: fallbacks.cta,
@@ -157,15 +167,23 @@ export async function loadMarketingHomeStatsigBundle(
 
     const bootstrapFilters = {
         experimentFilter: new Set([
-            MARKETING_HERO_EXPERIMENTS.bestDescription,
+            MARKETING_HERO_EXPERIMENTS.bestTitle,
             MARKETING_HERO_EXPERIMENTS.bestCta,
             MARKETING_HERO_EXPERIMENTS.heroLayout
         ]),
         dynamicConfigFilter: new Set([MARKETING_HERO_EXPERIMENTS.heroLayout])
     };
 
-    const [heroSubtitleBase, heroLayoutBase, heroCtaBase, statsigBootstrap] = await Promise.all([
-        evaluateHeroDescriptionWithClient(client, statsigUser, fallbacks.subtitle),
+    const [
+        { title: heroTitleBase, description: heroSubtitleBase },
+        heroLayoutBase,
+        heroCtaBase,
+        statsigBootstrap
+    ] = await Promise.all([
+        evaluateBestTitleHeroWithClient(client, statsigUser, {
+            title: fallbacks.title,
+            description: fallbacks.subtitle
+        }),
         evaluateHeroLayoutWithClient(client, statsigUser, fallbacks.layout),
         evaluateHeroCtaWithClient(client, statsigUser, fallbacks.cta),
         Promise.resolve(
@@ -174,6 +192,7 @@ export async function loadMarketingHomeStatsigBundle(
     ]);
 
     const bundle: MarketingHomeStatsigBundle = {
+        heroTitleBase,
         heroSubtitleBase,
         heroLayoutBase,
         heroCtaBase,
@@ -188,18 +207,6 @@ export async function loadMarketingHomeStatsigBundle(
     evictMarketingHomeStatsigCacheLru();
 
     return bundle;
-}
-
-/**
- * SSR: `best_description`. Client must still call `readMarketingHeroExperimentsForExposure` so Pulse gets an exposure.
- */
-export async function evaluateHeroDescriptionExperiment(
-    user: StatsigUser | StatsigServerUserInput,
-    fallback: string
-): Promise<string> {
-    const client = await getStatsigServerClient();
-    if (!client) return fallback;
-    return evaluateHeroDescriptionWithClient(client, toStatsigUser(user), fallback);
 }
 
 /**

--- a/src/lib/statsig/hero-query-overrides.ts
+++ b/src/lib/statsig/hero-query-overrides.ts
@@ -24,13 +24,21 @@ const MAX_CTA_LEN = 100;
 
 /**
  * Same rules as `hero_subtitle` URL overrides: collapse whitespace, trim, max length.
- * Use for `best_description` experiment values from Statsig (server or client).
+ * Use for `best_title` experiment `description` param from Statsig (server or client).
  */
 export function normalizeHeroSubtitle(raw: unknown, fallback: string): string {
     if (typeof raw !== 'string') return fallback;
     const t = raw.replace(/\s+/g, ' ').trim();
     if (t.length === 0) return fallback;
     return t.length > MAX_SUBTITLE_LEN ? t.slice(0, MAX_SUBTITLE_LEN) : t;
+}
+
+/** Hero headline — same clamp as `hero_title` URL override; used for `best_title` experiment `title` param. */
+export function normalizeHeroTitle(raw: unknown, fallback: string): string {
+    if (typeof raw !== 'string') return fallback;
+    const t = raw.replace(/\s+/g, ' ').trim();
+    if (t.length === 0) return fallback;
+    return t.length > MAX_TITLE_LEN ? t.slice(0, MAX_TITLE_LEN) : t;
 }
 
 /** Short button label — used for `best_cta` / `hero_cta` query override. */
@@ -94,9 +102,7 @@ function readHeroTitleOverride(params: URLSearchParams, fallback: string): strin
     if (!params.has(HERO_TITLE_QUERY_KEY)) return fallback;
     const raw = params.get(HERO_TITLE_QUERY_KEY);
     if (raw == null) return fallback;
-    const t = raw.replace(/\s+/g, ' ').trim();
-    if (t.length === 0) return fallback;
-    return t.length > MAX_TITLE_LEN ? t.slice(0, MAX_TITLE_LEN) : t;
+    return normalizeHeroTitle(raw, fallback);
 }
 
 function readHeroCtaOverride(params: URLSearchParams, fallback: string): string {

--- a/src/lib/statsig/hero-statsig.server.ts
+++ b/src/lib/statsig/hero-statsig.server.ts
@@ -10,7 +10,6 @@ export {
 } from './server';
 export {
     evaluateHeroCtaExperiment,
-    evaluateHeroDescriptionExperiment,
     evaluateHeroLayoutExperiment,
     loadMarketingHomeStatsigBundle,
     MARKETING_HERO_EXPERIMENTS,

--- a/src/routes/(marketing)/(components)/hero.svelte
+++ b/src/routes/(marketing)/(components)/hero.svelte
@@ -103,14 +103,14 @@
             }
 
             const { debug } = readMarketingHeroExperimentsForExposure(client, {
+                heroTitle: baselineTitle,
                 heroSubtitle: baselineSubtitle,
                 heroLayout: baselineLayout,
                 heroCta: baselineCta
             });
 
             log('experiment exposure (display stays on `page.data`)', {
-                [MARKETING_HERO_EXPERIMENTS.bestDescription]:
-                    debug[MARKETING_HERO_EXPERIMENTS.bestDescription],
+                [MARKETING_HERO_EXPERIMENTS.bestTitle]: debug[MARKETING_HERO_EXPERIMENTS.bestTitle],
                 [MARKETING_HERO_EXPERIMENTS.bestCta]: debug[MARKETING_HERO_EXPERIMENTS.bestCta],
                 [MARKETING_HERO_EXPERIMENTS.heroLayout]:
                     debug[MARKETING_HERO_EXPERIMENTS.heroLayout]

--- a/src/routes/(marketing)/+page.server.ts
+++ b/src/routes/(marketing)/+page.server.ts
@@ -45,8 +45,9 @@ export const load: PageServerLoad = async ({ cookies, request, url }) => {
         ...(userAgent ? { userAgent } : {})
     };
 
-    const { heroSubtitleBase, heroLayoutBase, heroCtaBase, statsigBootstrap } =
+    const { heroTitleBase, heroSubtitleBase, heroLayoutBase, heroCtaBase, statsigBootstrap } =
         await loadMarketingHomeStatsigBundle(user, stableId, {
+            title: DEFAULT_HERO_TITLE,
             subtitle: DEFAULT_HERO_SUBTITLE,
             layout: 0,
             cta: DEFAULT_HERO_CTA
@@ -60,7 +61,7 @@ export const load: PageServerLoad = async ({ cookies, request, url }) => {
         {
             heroLayout: heroLayoutBase,
             heroSubtitle: heroSubtitleBase,
-            heroTitle: DEFAULT_HERO_TITLE,
+            heroTitle: heroTitleBase,
             heroCta: heroCtaBase
         }
     );


### PR DESCRIPTION
…copy.

The best_title experiment exposes title and description parameters for SSR and client exposure. Default hero subtitle is updated to the new baseline copy. best_description and evaluateHeroDescriptionExperiment are removed.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)