### PR TITLE
feat(cache): set Cache-Control for sirv static assets and SSR

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,6 +29,12 @@ export default defineConfig(
         }
     },
     {
+        files: ['server/cache-static.js'],
+        rules: {
+            '@typescript-eslint/ban-ts-comment': 'off'
+        }
+    },
+    {
         files: ['**/*.svelte', '**/*.svelte.ts', '**/*.svelte.js'],
         languageOptions: {
             parserOptions: {

--- a/server/cache-static.js
+++ b/server/cache-static.js
@@ -1,0 +1,92 @@
+// @ts-nocheck — wraps `writeHead` / `write` / `end`; overloads are not worth typing in JS.
+/**
+ * Cache-Control for static assets. Used by `server/main.js` (sirv serves `build/client`
+ * before SvelteKit `handle`) and by `src/hooks.server.ts` for SSR responses.
+ */
+
+export const CACHE_IMMUTABLE = 'public, max-age=31536000, immutable';
+
+export const CACHE_IMAGES_SAFE = 'public, max-age=604800, stale-while-revalidate=86400';
+
+export const CACHE_IMAGES_DEFAULT = 'public, max-age=2592000, stale-while-revalidate=86400';
+
+export const CACHE_SCRIPTS = 'public, max-age=86400, stale-while-revalidate=604800';
+
+/** @param {string} pathname */
+export function cacheControlForPath(pathname) {
+    if (pathname === '/_app/version.json' || pathname === '/_app/env.js') {
+        return 'no-store';
+    }
+    if (pathname.startsWith('/_app/immutable/')) {
+        return CACHE_IMMUTABLE;
+    }
+    if (pathname.startsWith('/_app/')) {
+        return 'public, max-age=0, must-revalidate';
+    }
+    if (/\.(woff2?|ttf|otf|eot)$/i.test(pathname)) {
+        return CACHE_IMMUTABLE;
+    }
+    if (pathname.startsWith('/images/blog/')) {
+        if (/\.(png|jpe?g|webp|gif|avif)$/i.test(pathname)) {
+            return CACHE_IMAGES_SAFE;
+        }
+    } else if (/\.(png|jpe?g|webp|gif|avif|svg|ico)$/i.test(pathname)) {
+        return CACHE_IMAGES_DEFAULT;
+    }
+    if (pathname.startsWith('/scripts/') && pathname.endsWith('.js')) {
+        return CACHE_SCRIPTS;
+    }
+    return null;
+}
+
+/** @param {import('node:http').IncomingMessage} req */
+export function pathnameFromRequest(req) {
+    const raw = req.url ?? '/';
+    try {
+        return decodeURIComponent(new URL(raw, 'http://localhost').pathname);
+    } catch {
+        return new URL(raw, 'http://localhost').pathname;
+    }
+}
+
+/**
+ * Set Cache-Control when sirv sends the body (headers often go out on first write).
+ * @param {import('node:http').ServerResponse} res
+ * @param {string | null} directive
+ */
+export function attachStaticCacheControl(res, directive) {
+    if (!directive) return;
+    const policy = directive;
+
+    let applied = false;
+
+    /** @param {number} statusCode */
+    function tryApply(statusCode) {
+        if (applied || res.headersSent || res.getHeader('Cache-Control')) return;
+        if (statusCode !== 200 && statusCode !== 206 && statusCode !== 304) return;
+        applied = true;
+        res.setHeader('Cache-Control', policy);
+    }
+
+    const origWriteHead = res.writeHead.bind(res);
+    res.writeHead = (...args) => {
+        if (!res.headersSent) {
+            const first = args[0];
+            const code = typeof first === 'number' ? first : (res.statusCode ?? 200);
+            tryApply(code);
+        }
+        return origWriteHead(...args);
+    };
+
+    const origWrite = res.write.bind(res);
+    res.write = (...args) => {
+        if (!res.headersSent) tryApply(res.statusCode);
+        return origWrite(...args);
+    };
+
+    const origEnd = res.end.bind(res);
+    res.end = (...args) => {
+        if (!res.headersSent) tryApply(res.statusCode);
+        return origEnd(...args);
+    };
+}

--- a/server/main.js
+++ b/server/main.js
@@ -2,6 +2,19 @@ import { sitemaps } from './sitemap.js';
 import { createServer } from 'node:http';
 import { handler } from '../build/handler.js';
 import { createApp, defineEventHandler, fromNodeMiddleware, toNodeListener } from 'h3';
+import {
+    attachStaticCacheControl,
+    cacheControlForPath,
+    pathnameFromRequest
+} from './cache-static.js';
+
+/** Sirv serves `build/client` before SvelteKit; hooks never run for those files. */
+function wrapAdapterHandlerWithStaticCache(adapterHandler) {
+    return (req, res, next) => {
+        attachStaticCacheControl(res, cacheControlForPath(pathnameFromRequest(req)));
+        return adapterHandler(req, res, next);
+    };
+}
 
 async function main() {
     const port = process.env.PORT || 3000;
@@ -22,7 +35,7 @@ async function main() {
 
     app.use(['/sitemap.xml', '/sitemaps'], await sitemaps());
 
-    app.use(fromNodeMiddleware(handler));
+    app.use(fromNodeMiddleware(wrapAdapterHandlerWithStaticCache(handler)));
 
     const server = createServer(toNodeListener(app)).listen(port);
     server.addListener('listening', () => {

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/sveltekit';
 import type { Handle } from '@sveltejs/kit';
 import redirects from './redirects.json';
 import { sequence } from '@sveltejs/kit/hooks';
+import { cacheControlForPath } from '../server/cache-static.js';
 import { getMarkdownContent, processMarkdownWithPartials } from '$lib/server/markdown';
 import { type GithubUser } from '$routes/(init)/init/(utils)/auth';
 import { createInitSessionClient } from '$routes/(init)/init/(utils)/appwrite';
@@ -259,48 +260,10 @@ const seoOptimization: Handle = async ({ event, resolve }) => {
     return response;
 };
 
-/** Long-lived hashed build output from Vite/SvelteKit */
-const CACHE_IMMUTABLE = 'public, max-age=31536000, immutable';
-
-/** Blog and marketing images can be replaced at the same URL; avoid immutable */
-const CACHE_IMAGES_SAFE = 'public, max-age=604800, stale-while-revalidate=86400';
-
-/** Site UI assets (icons, illustrations) that rarely change */
-const CACHE_IMAGES_DEFAULT = 'public, max-age=2592000, stale-while-revalidate=86400';
-
-/** Third-party or vendor scripts we mirror under /scripts */
-const CACHE_SCRIPTS = 'public, max-age=86400, stale-while-revalidate=604800';
-
 /**
- * Lighthouse: static responses had no Cache-Control. Set TTLs here (Kit adapter-node
- * does not add them). Skip if something already set Cache-Control.
+ * SSR / Kit responses. Files under `build/client` are served by sirv before Kit;
+ * those get headers in `server/main.js`. Skip if something already set Cache-Control.
  */
-function cacheControlForPath(pathname: string): string | null {
-    if (pathname === '/_app/version.json' || pathname === '/_app/env.js') {
-        return 'no-store';
-    }
-    if (pathname.startsWith('/_app/immutable/')) {
-        return CACHE_IMMUTABLE;
-    }
-    if (pathname.startsWith('/_app/')) {
-        return 'public, max-age=0, must-revalidate';
-    }
-    if (/\.(woff2?|ttf|otf|eot)$/i.test(pathname)) {
-        return CACHE_IMMUTABLE;
-    }
-    if (pathname.startsWith('/images/blog/')) {
-        if (/\.(png|jpe?g|webp|gif|avif)$/i.test(pathname)) {
-            return CACHE_IMAGES_SAFE;
-        }
-    } else if (/\.(png|jpe?g|webp|gif|avif|svg|ico)$/i.test(pathname)) {
-        return CACHE_IMAGES_DEFAULT;
-    }
-    if (pathname.startsWith('/scripts/') && pathname.endsWith('.js')) {
-        return CACHE_SCRIPTS;
-    }
-    return null;
-}
-
 const staticAssetCache: Handle = async ({ event, resolve }) => {
     const response = await resolve(event);
     if (response.headers.has('Cache-Control')) {


### PR DESCRIPTION
Share rules in server/cache-static.js. server/main.js wraps the adapter handler because build/client is served before SvelteKit handle. hooks apply the same policy to Kit/SSR responses when no Cache-Control is set yet.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)