### PR TITLE
Fix TablesDB CLI command namespace in docs

### DIFF
--- a/src/routes/docs/tooling/command-line/commands/+page.markdoc
+++ b/src/routes/docs/tooling/command-line/commands/+page.markdoc
@@ -285,13 +285,13 @@ appwrite users list \
 To get a list of all your [tables](/docs/tooling/command-line/tables), you can use the `list-tables` command.
 
 ```sh
-appwrite databases list-tables --database-id "<DATABASE_ID>"
+appwrite tables-db list-tables --database-id "<DATABASE_ID>"
 ```
 
 If you wish to parse the output from the CLI, you can request the CLI output in JSON format using the `--json` flag
 
 ```sh
-appwrite databases list-tables --database-id "<DATABASE_ID>" --json
+appwrite tables-db list-tables --database-id "<DATABASE_ID>" --json
 ```
 
 ## Get table {% #get-table %}
@@ -299,7 +299,7 @@ appwrite databases list-tables --database-id "<DATABASE_ID>" --json
 To get more information on a particular table, you can make use of the `get-table` command and pass in the table-id.
 
 ```sh
-appwrite databases get-table --database-id "<DATABASE_ID>" --table-id "<TABLE_ID>"
+appwrite tables-db get-table --database-id "<DATABASE_ID>" --table-id "<TABLE_ID>"
 ```
 
 ## Create row {% #create-row %}
@@ -307,7 +307,7 @@ appwrite databases get-table --database-id "<DATABASE_ID>" --table-id "<TABLE_ID
 To create a new row in an existing table, use the `create-row` command.
 
 ```sh
-appwrite databases create-row \
+appwrite tables-db create-row \
     --database-id "<DATABASE_ID>" --table-id "<TABLE_ID>" \
     --row-id 'unique()' --data '{ "Name": "Iron Man" }' \
     --permissions 'read("any")' 'write("team:abc")' 

--- a/src/routes/docs/tooling/command-line/commands/+page.markdoc
+++ b/src/routes/docs/tooling/command-line/commands/+page.markdoc
@@ -189,7 +189,7 @@ appwrite login --report
 Many resources support the option to view them in the console. Use the `--console` flag to get a direct link to the console, and add the optional `--open` flag to automatically open it in the default browser.
 
 ```sh
-appwrite databases get-row \
+appwrite tables-db get-row \
   --database-id "<DATABASE_ID>" \
   --table-id "<TABLE_ID>" \
   --row-id "<ROW_ID>" \

--- a/src/routes/docs/tooling/command-line/tables/+page.markdoc
+++ b/src/routes/docs/tooling/command-line/tables/+page.markdoc
@@ -142,10 +142,10 @@ appwrite push tables
 
 # Commands {% #commands %}
 
-The databases command allows you to create structured tables of rows, queries, and filter lists of rows. Appwrite database CLI commands generally follow the following syntax:
+The tables-db command allows you to create structured tables of rows, queries, and filter lists of rows. Appwrite TablesDB CLI commands generally follow the following syntax:
 
 ```sh
-appwrite databases [COMMAND] [OPTIONS]
+appwrite tables-db [COMMAND] [OPTIONS]
 ```
 
 {% table %}


### PR DESCRIPTION
## Summary
- updates the Tables CLI docs to use the current `appwrite tables-db` command namespace
- fixes list/get table and create row examples that still used `appwrite databases`

## Verification
- `rg "appwrite databases (list-tables|get-table|create-row)|appwrite databases \\[COMMAND\\]" src/routes/docs/tooling/command-line -g '*.markdoc'`
- `git diff --check`
