### PR TITLE
Add BigInt type documentation for Databases

### DIFF
--- a/src/routes/changelog/(entries)/2026-05-06.markdoc
+++ b/src/routes/changelog/(entries)/2026-05-06.markdoc
@@ -1,0 +1,20 @@
+---
+layout: changelog
+title: "Databases: BigInt support for large integers"
+date: 2026-05-06
+---
+
+Appwrite Databases now supports a **bigint** column type for both TablesDB and legacy Databases. Use `bigint` when you need to store 64-bit integer values that exceed the 32-bit range of the standard `integer` type.
+
+BigInt columns support values from **-9,223,372,036,854,775,808** to **9,223,372,036,854,775,807**, making them ideal for:
+
+- Timestamps in milliseconds
+- Large counters and analytics metrics
+- External IDs from third-party systems
+- Financial calculations requiring large whole numbers
+
+Create a BigInt column using the Console, Server SDKs, or CLI, just like any other column type. BigInt columns support `min`, `max`, and `default` value constraints.
+
+{% arrow_link href="/docs/products/databases/tables" %}
+Learn more about Databases column types
+{% /arrow_link %}

--- a/src/routes/docs/products/databases/legacy/collections/+page.markdoc
+++ b/src/routes/docs/products/databases/legacy/collections/+page.markdoc
@@ -308,6 +308,7 @@ You can choose between the following types.
 |--------------|------------------------------------------------------------------|
 | `string`     | String attribute.                                                |
 | `integer`    | Integer attribute.                                               |
+| `bigint`     | 64-bit integer attribute. Supports values from -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807. Use for values that exceed 32-bit integer limits. |
 | `float`      | Float attribute.                                                 |
 | `boolean`    | Boolean attribute.                                               |
 | `datetime`   | Datetime attribute formatted as an ISO 8601 string.              |

--- a/src/routes/docs/products/databases/tables/+page.markdoc
+++ b/src/routes/docs/products/databases/tables/+page.markdoc
@@ -73,6 +73,11 @@ const promise = tablesDB.createTable({
             required: false
         },
         {
+            key: 'total_views',
+            type: 'bigint',
+            required: false
+        },
+        {
             key: 'score',
             type: 'float',
             required: false
@@ -202,6 +207,11 @@ let promise = tablesDB.createTable({
         {
             key: 'age',
             type: 'integer',
+            required: false
+        },
+        {
+            key: 'total_views',
+            type: 'bigint',
             required: false
         },
         {
@@ -339,6 +349,11 @@ $result = $tablesDB->createTable(
             'required' => false
         ],
         [
+            'key' => 'total_views',
+            'type' => 'bigint',
+            'required' => false
+        ],
+        [
             'key' => 'score',
             'type' => 'float',
             'required' => false
@@ -465,6 +480,11 @@ result = tablesDB.create_table(
             'required': False
         },
         {
+            'key': 'total_views',
+            'type': 'bigint',
+            'required': False
+        },
+        {
             'key': 'score',
             'type': 'float',
             'required': False
@@ -586,6 +606,11 @@ response = tablesDB.create_table(
         {
             key: 'age',
             type: 'integer',
+            required: false
+        },
+        {
+            key: 'total_views',
+            type: 'bigint',
             required: false
         },
         {
@@ -719,6 +744,12 @@ Table result = await tablesDB.CreateTable(
         {
             { "key", "age" },
             { "type", "integer" },
+            { "required", false }
+        },
+        new Dictionary<string, object>
+        {
+            { "key", "total_views" },
+            { "type", "bigint" },
             { "required", false }
         },
         new Dictionary<string, object>
@@ -860,6 +891,11 @@ void main() { // Init SDK
             'required': false
         },
         {
+            'key': 'total_views',
+            'type': 'bigint',
+            'required': false
+        },
+        {
             'key': 'score',
             'type': 'float',
             'required': false
@@ -991,6 +1027,11 @@ val response = tablesDB.createTable(
             "required" to false
         ),
         mapOf(
+            "key" to "total_views",
+            "type" to "bigint",
+            "required" to false
+        ),
+        mapOf(
             "key" to "score",
             "type" to "float",
             "required" to false
@@ -1109,6 +1150,11 @@ List<Map<String, Object>> columns = Arrays.asList(
     new HashMap<String, Object>() {{
         put("key", "age");
         put("type", "integer");
+        put("required", false);
+    }},
+    new HashMap<String, Object>() {{
+        put("key", "total_views");
+        put("type", "bigint");
         put("required", false);
     }},
     new HashMap<String, Object>() {{
@@ -1379,6 +1425,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 "required": false
             }),
             json!({
+                "key": "total_views",
+                "type": "bigint",
+                "required": false
+            }),
+            json!({
                 "key": "score",
                 "type": "float",
                 "required": false
@@ -1517,6 +1568,7 @@ You can choose between the following types.
 | `mediumtext` | Text column. Prefix indexing only. Maximum 4,194,303 characters. |
 | `longtext`   | Text column. Prefix indexing only. Maximum 1,073,741,823 characters. |
 | `integer`    | Integer column.                                               |
+| `bigint`     | 64-bit integer column. Supports values from -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807. Use for values that exceed 32-bit integer limits, such as timestamps in milliseconds, large counters, or external IDs. |
 | `float`      | Float column.                                                 |
 | `boolean`    | Boolean column.                                               |
 | `datetime`   | Datetime column formatted as an ISO 8601 string.              |


### PR DESCRIPTION
## Summary
- Adds `bigint` column type to the TablesDB columns reference table with range details and use cases
- Adds `bigint` attribute type to the legacy Databases collections reference table
- Adds `bigint` SDK examples across all 10 language blocks in the TablesDB create-table code samples
- Adds a changelog entry for 2026-05-06 announcing BigInt support

Corresponds to backend PR appwrite/appwrite#11673 (merge 1273bcd33afbd3694c52ec216d27d3cd101da68a).

## Test plan
- [ ] Verify the Tables docs page renders the `bigint` row correctly in the Columns table
- [ ] Verify all 10 SDK code samples include the `total_views` bigint column example
- [ ] Verify the legacy Collections docs page renders the `bigint` attribute row
- [ ] Verify the changelog entry renders at `/changelog`

🤖 Generated with [Claude Code](https://claude.com/claude-code)