### PR TITLE
feat: wrap blog FAQ in outer accordion

### DIFF
--- a/src/lib/components/blog/faq.svelte
+++ b/src/lib/components/blog/faq.svelte
@@ -28,12 +28,12 @@
                     aria-controls="blog-faq"
                     on:click={() => (expanded = !expanded)}
                 >
-                    <span
+                    <h2
                         id="blog-faq-heading"
                         class="text-main-body font-aeonik-pro text-primary scroll-mt-24"
                     >
                         Frequently asked questions
-                    </span>
+                    </h2>
                     <div
                         class="icon text-primary self-center transition-transform"
                         class:rotate-180={expanded}
@@ -42,8 +42,8 @@
                     </div>
                 </button>
 
-                {#if expanded}
-                    <div transition:slide>
+                <div class="web-blog-faq-collapse" data-open={expanded} inert={!expanded}>
+                    <div class="web-blog-faq-collapse-inner">
                         <ul
                             class="collapsible w-full min-w-0 divide-y divide-white/5 border-t border-white/10 px-5"
                             use:melt={$root}
@@ -51,90 +51,63 @@
                         >
                             {#each items as faqItem, index (index)}
                                 <li class="collapsible-item">
-                                    {#if browser}
-                                        <div
-                                            class="collapsible-wrapper py-2"
-                                            use:melt={$item(`${index}`)}
-                                            {...{
-                                                open: $isSelected(`${index}`) ? true : undefined
-                                            }}
-                                        >
-                                            <h3 use:melt={$heading({ level: 3 })}>
-                                                <button
-                                                    class="flex w-full min-w-0 cursor-pointer items-center justify-between gap-2.5 py-6 text-left"
-                                                    use:melt={$trigger(`${index}`)}
-                                                >
-                                                    <span
-                                                        class="text-label font-aeonik-pro text-primary min-w-0 flex-1"
-                                                    >
-                                                        {faqItem.question}
-                                                    </span>
-                                                    <div
-                                                        class="icon text-primary self-start transition-transform"
-                                                        class:rotate-180={$isSelected(`${index}`)}
-                                                    >
-                                                        <span
-                                                            class="icon-cheveron-down"
-                                                            aria-hidden="true"
-                                                        ></span>
-                                                    </div>
-                                                </button>
-                                            </h3>
-
-                                            {#if $isSelected(`${index}`)}
-                                                <div
-                                                    class="collapsible-content pb-6"
-                                                    use:melt={$content(`${index}`)}
-                                                    transition:slide
-                                                >
-                                                    <p class="text-main-body">
-                                                        <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-                                                        {@html faqItem.answer}
-                                                    </p>
-                                                </div>
-                                            {/if}
-                                        </div>
-                                    {:else}
-                                        <details class="collapsible-wrapper">
-                                            <summary
-                                                class="collapsible-button cursor-pointer appearance-none"
+                                    <div
+                                        class="collapsible-wrapper py-2"
+                                        use:melt={$item(`${index}`)}
+                                        {...{ open: $isSelected(`${index}`) ? true : undefined }}
+                                    >
+                                        <h3 use:melt={$heading({ level: 3 })}>
+                                            <button
+                                                class="flex w-full min-w-0 cursor-pointer items-center justify-between gap-2.5 py-6 text-left"
+                                                use:melt={$trigger(`${index}`)}
                                             >
-                                                <span class="text-label text-primary">
+                                                <span
+                                                    class="text-label font-aeonik-pro text-primary min-w-0 flex-1"
+                                                >
                                                     {faqItem.question}
                                                 </span>
-                                                <div class="icon text-primary">
+                                                <div
+                                                    class="icon text-primary self-start transition-transform"
+                                                    class:rotate-180={$isSelected(`${index}`)}
+                                                >
                                                     <span
                                                         class="icon-cheveron-down"
                                                         aria-hidden="true"
                                                     ></span>
                                                 </div>
-                                            </summary>
+                                            </button>
+                                        </h3>
 
-                                            <div class="collapsible-content pb-6">
+                                        {#if $isSelected(`${index}`)}
+                                            <div
+                                                class="collapsible-content pb-6"
+                                                use:melt={$content(`${index}`)}
+                                                transition:slide
+                                            >
                                                 <p class="text-main-body">
                                                     <!-- eslint-disable-next-line svelte/no-at-html-tags -->
                                                     {@html faqItem.answer}
                                                 </p>
                                             </div>
-                                        </details>
-                                    {/if}
+                                        {/if}
+                                    </div>
                                 </li>
                             {/each}
                         </ul>
                     </div>
-                {/if}
+                </div>
             </div>
         {:else}
             <details class="web-blog-faq-outer rounded-xl border border-white/10 bg-white/[0.02]">
                 <summary
                     class="flex w-full cursor-pointer list-none items-center justify-between gap-2.5 px-5 py-4"
                 >
-                    <span
+                    <h2
                         id="blog-faq-heading"
                         class="text-main-body font-aeonik-pro text-primary scroll-mt-24"
                     >
                         Frequently asked questions
-                    </span>
+                    </h2>
                     <div class="icon text-primary self-center">
                         <span class="icon-cheveron-down" aria-hidden="true"></span>
                     </div>
@@ -171,5 +144,26 @@
 <style>
     .web-blog-faq-outer > summary::-webkit-details-marker {
         display: none;
+    }
+    .web-blog-faq-outer > summary::marker {
+        display: none;
+    }
+
+    .web-blog-faq-collapse {
+        display: grid;
+        grid-template-rows: 0fr;
+        transition: grid-template-rows 280ms ease;
+    }
+    .web-blog-faq-collapse[data-open='true'] {
+        grid-template-rows: 1fr;
+    }
+    .web-blog-faq-collapse-inner {
+        overflow: hidden;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        .web-blog-faq-collapse {
+            transition: none;
+        }
     }
 </style>

--- a/src/lib/components/blog/faq.svelte
+++ b/src/lib/components/blog/faq.svelte
@@ -13,80 +13,163 @@
         multiple: false,
         forceVisible: true
     });
+
+    let expanded = false;
 </script>
 
 {#if items.length}
     <section class="web-blog-faq mt-16" aria-labelledby="blog-faq-heading">
-        <h2 id="blog-faq-heading" class="text-title font-aeonik-pro text-primary scroll-mt-24">
-            Frequently asked questions
-        </h2>
+        {#if browser}
+            <div class="web-blog-faq-outer rounded-xl border border-white/10 bg-white/[0.02]">
+                <button
+                    type="button"
+                    class="flex w-full cursor-pointer items-center justify-between gap-2.5 px-5 py-4 text-left"
+                    aria-expanded={expanded}
+                    aria-controls="blog-faq"
+                    on:click={() => (expanded = !expanded)}
+                >
+                    <span
+                        id="blog-faq-heading"
+                        class="text-main-body font-aeonik-pro text-primary scroll-mt-24"
+                    >
+                        Frequently asked questions
+                    </span>
+                    <div
+                        class="icon text-primary self-center transition-transform"
+                        class:rotate-180={expanded}
+                    >
+                        <span class="icon-cheveron-down" aria-hidden="true"></span>
+                    </div>
+                </button>
 
-        <ul
-            class="collapsible mt-6 w-full min-w-0 divide-y divide-white/5 border-t border-white/5"
-            use:melt={$root}
-            id="blog-faq"
-        >
-            {#each items as faqItem, index (index)}
-                <li class="collapsible-item">
-                    {#if browser}
-                        <div
-                            class="collapsible-wrapper py-2"
-                            use:melt={$item(`${index}`)}
-                            {...{ open: $isSelected(`${index}`) ? true : undefined }}
+                {#if expanded}
+                    <div transition:slide>
+                        <ul
+                            class="collapsible w-full min-w-0 divide-y divide-white/5 border-t border-white/10 px-5"
+                            use:melt={$root}
+                            id="blog-faq"
                         >
-                            <h3 use:melt={$heading({ level: 3 })}>
-                                <button
-                                    class="flex w-full min-w-0 cursor-pointer items-center justify-between gap-2.5 py-6 text-left"
-                                    use:melt={$trigger(`${index}`)}
-                                >
-                                    <span
-                                        class="text-label font-aeonik-pro text-primary min-w-0 flex-1"
-                                    >
+                            {#each items as faqItem, index (index)}
+                                <li class="collapsible-item">
+                                    {#if browser}
+                                        <div
+                                            class="collapsible-wrapper py-2"
+                                            use:melt={$item(`${index}`)}
+                                            {...{
+                                                open: $isSelected(`${index}`) ? true : undefined
+                                            }}
+                                        >
+                                            <h3 use:melt={$heading({ level: 3 })}>
+                                                <button
+                                                    class="flex w-full min-w-0 cursor-pointer items-center justify-between gap-2.5 py-6 text-left"
+                                                    use:melt={$trigger(`${index}`)}
+                                                >
+                                                    <span
+                                                        class="text-label font-aeonik-pro text-primary min-w-0 flex-1"
+                                                    >
+                                                        {faqItem.question}
+                                                    </span>
+                                                    <div
+                                                        class="icon text-primary self-start transition-transform"
+                                                        class:rotate-180={$isSelected(`${index}`)}
+                                                    >
+                                                        <span
+                                                            class="icon-cheveron-down"
+                                                            aria-hidden="true"
+                                                        ></span>
+                                                    </div>
+                                                </button>
+                                            </h3>
+
+                                            {#if $isSelected(`${index}`)}
+                                                <div
+                                                    class="collapsible-content pb-6"
+                                                    use:melt={$content(`${index}`)}
+                                                    transition:slide
+                                                >
+                                                    <p class="text-main-body">
+                                                        <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+                                                        {@html faqItem.answer}
+                                                    </p>
+                                                </div>
+                                            {/if}
+                                        </div>
+                                    {:else}
+                                        <details class="collapsible-wrapper">
+                                            <summary
+                                                class="collapsible-button cursor-pointer appearance-none"
+                                            >
+                                                <span class="text-label text-primary">
+                                                    {faqItem.question}
+                                                </span>
+                                                <div class="icon text-primary">
+                                                    <span
+                                                        class="icon-cheveron-down"
+                                                        aria-hidden="true"
+                                                    ></span>
+                                                </div>
+                                            </summary>
+
+                                            <div class="collapsible-content pb-6">
+                                                <p class="text-main-body">
+                                                    <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+                                                    {@html faqItem.answer}
+                                                </p>
+                                            </div>
+                                        </details>
+                                    {/if}
+                                </li>
+                            {/each}
+                        </ul>
+                    </div>
+                {/if}
+            </div>
+        {:else}
+            <details class="web-blog-faq-outer rounded-xl border border-white/10 bg-white/[0.02]">
+                <summary
+                    class="flex w-full cursor-pointer list-none items-center justify-between gap-2.5 px-5 py-4"
+                >
+                    <span
+                        id="blog-faq-heading"
+                        class="text-main-body font-aeonik-pro text-primary scroll-mt-24"
+                    >
+                        Frequently asked questions
+                    </span>
+                    <div class="icon text-primary self-center">
+                        <span class="icon-cheveron-down" aria-hidden="true"></span>
+                    </div>
+                </summary>
+
+                <ul class="w-full min-w-0 divide-y divide-white/5 border-t border-white/10 px-5">
+                    {#each items as faqItem, index (index)}
+                        <li class="collapsible-item">
+                            <details class="collapsible-wrapper">
+                                <summary class="collapsible-button cursor-pointer appearance-none">
+                                    <span class="text-label text-primary">
                                         {faqItem.question}
                                     </span>
-                                    <div
-                                        class="icon text-primary self-start transition-transform"
-                                        class:rotate-180={$isSelected(`${index}`)}
-                                    >
+                                    <div class="icon text-primary">
                                         <span class="icon-cheveron-down" aria-hidden="true"></span>
                                     </div>
-                                </button>
-                            </h3>
+                                </summary>
 
-                            {#if $isSelected(`${index}`)}
-                                <div
-                                    class="collapsible-content pb-6"
-                                    use:melt={$content(`${index}`)}
-                                    transition:slide
-                                >
+                                <div class="collapsible-content pb-6">
                                     <p class="text-main-body">
                                         <!-- eslint-disable-next-line svelte/no-at-html-tags -->
                                         {@html faqItem.answer}
                                     </p>
                                 </div>
-                            {/if}
-                        </div>
-                    {:else}
-                        <details class="collapsible-wrapper">
-                            <summary class="collapsible-button cursor-pointer appearance-none">
-                                <span class="text-label text-primary">
-                                    {faqItem.question}
-                                </span>
-                                <div class="icon text-primary">
-                                    <span class="icon-cheveron-down" aria-hidden="true"></span>
-                                </div>
-                            </summary>
-
-                            <div class="collapsible-content pb-6">
-                                <p class="text-main-body">
-                                    <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-                                    {@html faqItem.answer}
-                                </p>
-                            </div>
-                        </details>
-                    {/if}
-                </li>
-            {/each}
-        </ul>
+                            </details>
+                        </li>
+                    {/each}
+                </ul>
+            </details>
+        {/if}
     </section>
 {/if}
+
+<style>
+    .web-blog-faq-outer > summary::-webkit-details-marker {
+        display: none;
+    }
+</style>


### PR DESCRIPTION
## Summary
- Wrap the blog FAQ component in an outer accordion so the whole section collapses by default — the FAQ block was visually heavy at the bottom of long posts.
- Outer toggle uses Svelte `transition:slide`, matching the per-question animation for visual consistency.
- SSR fallback uses nested native `<details>` so crawlers and no-JS readers still see every question and answer in the HTML body. JSON-LD `FAQPage` schema (in `Post.svelte`) is unchanged.

## Test plan
- [ ] Visit `/blog/post/backend-as-a-service` — FAQ shows as a single collapsed card by default; click expands with slide animation.
- [ ] Inner per-question accordion still toggles independently with slide.
- [ ] `curl` the page and confirm all 4 questions + answers + JSON-LD are present in the SSR HTML.
- [ ] Lighthouse / Rich Results test still recognizes the FAQPage schema.