### PR TITLE
feat(blog): add FAQs to Kimi K2.6 Arena post

### DIFF
--- a/src/routes/blog/post/kimi-k2-6-arena-leaderboard-refresh/+page.markdoc
+++ b/src/routes/blog/post/kimi-k2-6-arena-leaderboard-refresh/+page.markdoc
@@ -8,6 +8,15 @@ timeToRead: 6
 author: atharva
 category: ai
 featured: false
+faqs:
+  - question: "What is Kimi K2.6 and who makes it?"
+    answer: "Kimi K2.6 is the latest open-weight large language model from MoonshotAI. On Appwrite Arena it is accessed through OpenRouter at the model ID moonshotai/kimi-k2.6, with pricing around $0.75 per million input tokens and $3.50 per million output tokens."
+  - question: "Where does Kimi K2.6 rank on the May 2026 Arena leaderboard?"
+    answer: "Kimi K2.6 ranks #4 of 11 with skills at 96.3% overall and #3 of 11 without skills at 93.6% overall. Without skills, only Claude Opus 4.7 and GPT 5.5 score higher, both at roughly four times the per-run cost."
+  - question: "Why does Kimi K2.6 score differently with and without skills?"
+    answer: "With-skills mode includes Appwrite documentation in the prompt, while without-skills relies on the model's training data alone. Kimi K2.6 gains 8.4 points on free-form questions when skills are added, going from 83.5% to 91.9%, which suggests the model uses Appwrite documentation effectively when it is in the prompt."
+  - question: "What changed in the May 2026 Arena update beyond adding Kimi K2.6?"
+    answer: "The full model roster was refreshed to current frontier versions, including DeepSeek V4 Flash, Qwen 3.6 Plus, MiniMax M2.7, Mistral Large 3 2512, GLM 5.1, Grok 4.3, GPT 5.5, Claude Opus 4.7, and both Gemini 3.1 Pro (Preview) and Gemini 3.1 Flash Lite (Preview). The benchmark runner also added retries with backoff, deterministic output ordering, atomic JSON writes, and a configurable concurrency setting."
 ---
 
 [Appwrite Arena](https://arena.appwrite.io) measures how well AI models understand Appwrite. The May 2026 update is the leaderboard's biggest change since launch: Kimi K2.6 from MoonshotAI is the new headline addition, the model roster is now refreshed to current frontier versions across the board, and the benchmark runner has picked up retries, deterministic output, and configurable concurrency.


### PR DESCRIPTION
Adds four FAQs to the FAQ section of the merged Kimi K2.6 Arena post.
Covers Kimi K2.6 background, leaderboard ranks, the with-skills score gap, and the broader May 2026 update.