### PR TITLE
fix(docs): clear sticky article header on reference anchor jumps

### DIFF
--- a/src/routes/docs/references/[version]/[platform]/[service]/+page.svelte
+++ b/src/routes/docs/references/[version]/[platform]/[service]/+page.svelte
@@ -430,9 +430,13 @@
             margin-bottom: 0;
         }
     }
-    /* The article header is sticky at --p-grid-huge-navs-secondary-sticky-position (189px),
-       so anchor jumps must clear it or the method heading lands behind the sticky bar. */
-    :global(.web-article-content-header :is(h2, h3, h4, h5, h6)) {
+    /* :global is required because Heading is a child component; scope the rule to this
+       route via .web-article-content-grid-6-4 (used only by the reference page) so it
+       does not leak into Section.svelte / DocsTutorial.svelte. The sticky article
+       header sits at --p-grid-huge-navs-secondary-sticky-position (~189px). */
+    :global(
+        .web-article-content-grid-6-4 .web-article-content-header :is(h2, h3, h4, h5, h6)
+    ) {
         scroll-margin-top: calc(var(--p-grid-huge-navs-secondary-sticky-position) + 1.5rem);
     }
 </style>

--- a/src/routes/docs/references/[version]/[platform]/[service]/+page.svelte
+++ b/src/routes/docs/references/[version]/[platform]/[service]/+page.svelte
@@ -430,4 +430,9 @@
             margin-bottom: 0;
         }
     }
+    /* The article header is sticky at --p-grid-huge-navs-secondary-sticky-position (189px),
+       so anchor jumps must clear it or the method heading lands behind the sticky bar. */
+    :global(.web-article-content-header :is(h2, h3, h4, h5, h6)) {
+        scroll-margin-top: calc(var(--p-grid-huge-navs-secondary-sticky-position) + 1.5rem);
+    }
 </style>

--- a/src/routes/docs/references/[version]/[platform]/[service]/+page.svelte
+++ b/src/routes/docs/references/[version]/[platform]/[service]/+page.svelte
@@ -434,9 +434,7 @@
        route via .web-article-content-grid-6-4 (used only by the reference page) so it
        does not leak into Section.svelte / DocsTutorial.svelte. The sticky article
        header sits at --p-grid-huge-navs-secondary-sticky-position (~189px). */
-    :global(
-        .web-article-content-grid-6-4 .web-article-content-header :is(h2, h3, h4, h5, h6)
-    ) {
+    :global(.web-article-content-grid-6-4 .web-article-content-header :is(h2, h3, h4, h5, h6)) {
         scroll-margin-top: calc(var(--p-grid-huge-navs-secondary-sticky-position) + 1.5rem);
     }
 </style>


### PR DESCRIPTION
## Summary
- Method headings on API reference pages (e.g. `/docs/references/cloud/client-web/databases#createDocument`) landed behind the sticky `.web-article-header` when reached via an anchor link.
- The sticky bar extends to `--p-grid-huge-navs-secondary-sticky-position` (~189px from the viewport top), but anchor jumps were only clearing the default `scroll-margin-top` of 128px, leaving the heading buried.
- Adds `scroll-margin-top: calc(var(--p-grid-huge-navs-secondary-sticky-position) + 1.5rem)` to `h2`–`h6` inside `.web-article-content-header`, so anchor jumps land 1.5rem below the sticky bar. The selector is scoped to the reference page only.

## Before / After

| Before | After |
| --- | --- |
| ![before-fix](https://github.com/ChiragAgg5k/gitshot-images/releases/download/_gitshot/before-fix-9a12b5b0.png) | ![after-fix](https://github.com/ChiragAgg5k/gitshot-images/releases/download/_gitshot/after-fix-07597ea9.png) |

Verified locally with Playwright at 1440×900:

| | Heading top | Sticky bar bottom | Clearance |
| --- | --- | --- | --- |
| Before | 128px | 189px | **−61px (buried)** |
| After | 213px | 189px | **+24px (1.5rem gap)** |

## Test plan
- [ ] Visit `/docs/references/cloud/client-web/databases` and click any method link in the left TOC; the heading should appear with breathing room below the sticky bar.
- [ ] Hard-load the same URL with a `#methodId` fragment directly; same result.
- [ ] Repeat across a few platforms/services to confirm the fix applies everywhere the layout is used.
- [ ] Sanity-check other pages that use `.web-article-content-header` (e.g. `Section.svelte`, `DocsTutorial.svelte`) are unaffected — the rule is scoped via the `+page.svelte` `:global(...)` selector and only applies inside the reference route.