### PR TITLE
Normalize docs code fence languages

### DIFF
--- a/src/lib/utils/code.test.ts
+++ b/src/lib/utils/code.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from 'vitest';
+import { getCodeHtml, type Language } from './code';
+
+describe('getCodeHtml', () => {
+    test('normalizes code fence language before highlighting', () => {
+        const html = getCodeHtml({
+            content: 'using Appwrite;',
+            language: 'csharp ' as Language
+        });
+
+        expect(html).toContain('language-csharp');
+        expect(html).not.toContain('language-csharp ');
+        expect(html).toContain('hljs-keyword');
+    });
+});

--- a/src/lib/utils/code.test.ts
+++ b/src/lib/utils/code.test.ts
@@ -12,4 +12,13 @@ describe('getCodeHtml', () => {
         expect(html).not.toContain('language-csharp ');
         expect(html).toContain('hljs-keyword');
     });
+
+    test('uses the fallback language class when language is omitted', () => {
+        const html = getCodeHtml({
+            content: 'echo appwrite'
+        });
+
+        expect(html).toContain('language-sh');
+        expect(html).not.toContain('language-undefined');
+    });
 });

--- a/src/lib/utils/code.ts
+++ b/src/lib/utils/code.ts
@@ -116,6 +116,8 @@ hljs.registerAliases(['hcl', 'terraform', 'tf'], { languageName: 'ini' });
 
 export type Language = keyof typeof languages | Platform;
 
+const normalizeLanguage = (language?: Language) => language?.trim() as Language | undefined;
+
 type Args = {
     content: string;
     language?: Language;
@@ -124,7 +126,8 @@ type Args = {
 
 export const getCodeHtml = (args: Args) => {
     const { content, language, withLineNumbers } = args;
-    const res = hljs.highlight(content, { language: language ?? 'sh' }).value;
+    const highlightedLanguage = normalizeLanguage(language) ?? 'sh';
+    const res = hljs.highlight(content, { language: highlightedLanguage }).value;
     const lines = res.split(/\n/g);
 
     while (lines.length > 0 && lines[lines.length - 1] === '') {
@@ -136,7 +139,7 @@ export const getCodeHtml = (args: Args) => {
         return carry;
     }, '');
 
-    return `<pre class="web-code-pre"><code class="web-code web-code-body language-${language} ${
+    return `<pre class="web-code-pre"><code class="web-code web-code-body language-${highlightedLanguage} ${
         withLineNumbers ? 'line-numbers' : ''
     }">${final}</code></pre>`;
 };


### PR DESCRIPTION
## What does this PR do?

Normalizes code fence language strings before handing them to the docs code highlighter and before emitting the `language-*` class. This keeps values like `csharp ` from missing the registered `csharp` highlighter or producing a trailing-space CSS class.

It also adds a focused unit test for the `.NET`/`csharp ` case.

## Test Plan

- `git diff --check`

I could not run the Bun-based project checks locally because Bun is not installed in this environment; the project CI installs Bun and should cover `bun run check` and tests.

## Related PRs and Issues

- Fixes appwrite/appwrite#12333

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?

This was implemented with Codex assistance, with the patch kept focused and manually reviewed before sending.