### PR TITLE
Update SMS pricing table

### DIFF
--- a/src/routes/docs/advanced/platform/phone-otp/+page.markdoc
+++ b/src/routes/docs/advanced/platform/phone-otp/+page.markdoc
@@ -30,192 +30,192 @@ SMS rates vary by country due to differences in telecom infrastructure and regul
 
 | Country code | Country name             | Price / SMS (USD) |
 |--------------|--------------------------|-------------------|
-| +213         | Algeria                  | $ 0.26            |
-| +376         | Andorra                  | $ 0.10            |
-| +244         | Angola                   | $ 0.10            |
-| +54          | Argentina                | $ 0.10            |
-| +374         | Armenia                  | $ 0.20            |
-| +297         | Aruba                    | $ 0.24            |
-| +61          | Australia                | $ 0.03            |
+| +213         | Algeria                  | $ 0.31            |
+| +376         | Andorra                  | $ 0.11            |
+| +244         | Angola                   | $ 0.12            |
+| +54          | Argentina                | $ 0.12            |
+| +374         | Armenia                  | $ 0.24            |
+| +297         | Aruba                    | $ 0.29            |
+| +61          | Australia                | $ 0.04            |
 | +43          | Austria                  | $ 0.03            |
-| +994         | Azerbaijan               | $ 0.37            |
+| +994         | Azerbaijan               | $ 0.44            |
 | +973         | Bahrain                  | $ 0.04            |
-| +880         | Bangladesh               | $ 0.43            |
-| +375         | Belarus                  | $ 0.22            |
-| +32          | Belgium                  | $ 0.10            |
-| +501         | Belize                   | $ 0.30            |
-| +229         | Benin                    | $ 0.27            |
-| +975         | Bhutan                   | $ 0.33            |
-| +591         | Bolivia                  | $ 0.21            |
-| +387         | Bosnia and Herzegovina   | $ 0.06            |
-| +267         | Botswana                 | $ 0.09            |
-| +55          | Brazil                   | $ 0.03            |
-| +673         | Brunei                   | $ 0.06            |
-| +359         | Bulgaria                 | $ 0.16            |
-| +226         | Burkina Faso             | $ 0.23            |
-| +257         | Burundi                  | $ 0.38            |
-| +855         | Cambodia                 | $ 0.39            |
-| +237         | Cameroon                 | $ 0.26            |
-| +238         | Cape Verde Islands       | $ 0.20            |
+| +880         | Bangladesh               | $ 0.50            |
+| +375         | Belarus                  | $ 0.26            |
+| +32          | Belgium                  | $ 0.12            |
+| +501         | Belize                   | $ 0.35            |
+| +229         | Benin                    | $ 0.32            |
+| +975         | Bhutan                   | $ 0.38            |
+| +591         | Bolivia                  | $ 0.25            |
+| +387         | Bosnia and Herzegovina   | $ 0.07            |
+| +267         | Botswana                 | $ 0.11            |
+| +55          | Brazil                   | $ 0.04            |
+| +673         | Brunei                   | $ 0.07            |
+| +359         | Bulgaria                 | $ 0.19            |
+| +226         | Burkina Faso             | $ 0.27            |
+| +257         | Burundi                  | $ 0.45            |
+| +855         | Cambodia                 | $ 0.46            |
+| +237         | Cameroon                 | $ 0.31            |
+| +238         | Cape Verde Islands       | $ 0.23            |
 | +56          | Chile                    | $ 0.03            |
-| +86          | China                    | $ 0.02            |
+| +86          | China                    | $ 0.03            |
 | +57          | Colombia                 | $ 0.04            |
-| +269         | Comoros and Mayotte      | $ 0.37            |
-| +242         | Congo                    | $ 0.27            |
-| +682         | Cook Islands             | $ 0.12            |
-| +506         | Costa Rica               | $ 0.15            |
-| +385         | Croatia                  | $ 0.13            |
-| +53          | Cuba                     | $ 0.08            |
+| +269         | Comoros and Mayotte      | $ 0.44            |
+| +242         | Congo                    | $ 0.32            |
+| +682         | Cook Islands             | $ 0.14            |
+| +506         | Costa Rica               | $ 0.18            |
+| +385         | Croatia                  | $ 0.16            |
+| +53          | Cuba                     | $ 0.09            |
 | +357         | Cyprus                   | $ 0.01            |
-| +420         | Czech Republic           | $ 0.06            |
-| +45          | Denmark                  | $ 0.06            |
-| +253         | Djibouti                 | $ 0.13            |
-| +593         | Ecuador                  | $ 0.22            |
-| +20          | Egypt                    | $ 0.37            |
-| +503         | El Salvador              | $ 0.08            |
-| +240         | Equatorial Guinea        | $ 0.20            |
+| +420         | Czech Republic           | $ 0.07            |
+| +45          | Denmark                  | $ 0.07            |
+| +253         | Djibouti                 | $ 0.15            |
+| +593         | Ecuador                  | $ 0.26            |
+| +20          | Egypt                    | $ 0.44            |
+| +503         | El Salvador              | $ 0.09            |
+| +240         | Equatorial Guinea        | $ 0.23            |
 | +291         | Eritrea                  | $ 0.17            |
-| +372         | Estonia                  | $ 0.05            |
-| +251         | Ethiopia                 | $ 0.35            |
-| +500         | Falkland Islands         | $ 0.09            |
-| +298         | Faroe Islands            | $ 0.06            |
-| +679         | Fiji                     | $ 0.20            |
-| +358         | Finland                  | $ 0.08            |
-| +33          | France                   | $ 0.07            |
-| +594         | French Guiana            | $ 0.13            |
-| +689         | French Polynesia         | $ 0.10            |
-| +241         | Gabon                    | $ 0.29            |
-| +220         | Gambia                   | $ 0.09            |
-| +995         | Georgia                  | $ 0.14            |
-| +49          | Germany                  | $ 0.10            |
-| +233         | Ghana                    | $ 0.31            |
-| +350         | Gibraltar                | $ 0.08            |
-| +30          | Greece                   | $ 0.05            |
-| +299         | Greenland                | $ 0.03            |
-| +590         | Guadeloupe               | $ 0.15            |
-| +1671        | Guam                     | $ 0.03            |
-| +502         | Guatemala                | $ 0.22            |
-| +224         | Guinea                   | $ 0.26            |
-| +245         | Guinea-Bissau            | $ 0.25            |
-| +592         | Guyana                   | $ 0.21            |
-| +509         | Haiti                    | $ 0.32            |
-| +504         | Honduras                 | $ 0.23            |
-| +852         | Hong Kong                | $ 0.06            |
-| +36          | Hungary                  | $ 0.07            |
-| +354         | Iceland                  | $ 0.07            |
+| +372         | Estonia                  | $ 0.06            |
+| +251         | Ethiopia                 | $ 0.41            |
+| +500         | Falkland Islands         | $ 0.11            |
+| +298         | Faroe Islands            | $ 0.07            |
+| +679         | Fiji                     | $ 0.24            |
+| +358         | Finland                  | $ 0.10            |
+| +33          | France                   | $ 0.08            |
+| +594         | French Guiana            | $ 0.15            |
+| +689         | French Polynesia         | $ 0.12            |
+| +241         | Gabon                    | $ 0.34            |
+| +220         | Gambia                   | $ 0.11            |
+| +995         | Georgia                  | $ 0.16            |
+| +49          | Germany                  | $ 0.11            |
+| +233         | Ghana                    | $ 0.37            |
+| +350         | Gibraltar                | $ 0.10            |
+| +30          | Greece                   | $ 0.06            |
+| +299         | Greenland                | $ 0.04            |
+| +590         | Guadeloupe               | $ 0.17            |
+| +1671        | Guam                     | $ 0.04            |
+| +502         | Guatemala                | $ 0.25            |
+| +224         | Guinea                   | $ 0.30            |
+| +245         | Guinea-Bissau            | $ 0.30            |
+| +592         | Guyana                   | $ 0.25            |
+| +509         | Haiti                    | $ 0.38            |
+| +504         | Honduras                 | $ 0.27            |
+| +852         | Hong Kong                | $ 0.07            |
+| +36          | Hungary                  | $ 0.08            |
+| +354         | Iceland                  | $ 0.08            |
 | +91          | India                    | $ 0.003           |
-| +62          | Indonesia                | $ 0.40            |
-| +98          | Iran                     | $ 0.27            |
-| +964         | Iraq                     | $ 0.39            |
-| +353         | Ireland                  | $ 0.08            |
+| +62          | Indonesia                | $ 0.47            |
+| +98          | Iran                     | $ 0.32            |
+| +964         | Iraq                     | $ 0.46            |
+| +353         | Ireland                  | $ 0.09            |
 | +972         | Israel                   | $ 0.01            |
-| +39          | Italy                    | $ 0.05            |
-| +81          | Japan                    | $ 0.06            |
-| +962         | Jordan                   | $ 0.40            |
-| +254         | Kenya                    | $ 0.26            |
+| +39          | Italy                    | $ 0.06            |
+| +81          | Japan                    | $ 0.07            |
+| +962         | Jordan                   | $ 0.47            |
+| +254         | Kenya                    | $ 0.31            |
 | +686         | Kiribati                 | $ 0.08            |
 | +850         | North Korea              | $ 0.03            |
-| +82          | South Korea              | $ 0.02            |
-| +965         | Kuwait                   | $ 0.21            |
-| +996         | Kyrgyzstan               | $ 0.34            |
+| +82          | South Korea              | $ 0.03            |
+| +965         | Kuwait                   | $ 0.24            |
+| +996         | Kyrgyzstan               | $ 0.40            |
 | +856         | Laos                     | $ 0.19            |
-| +371         | Latvia                   | $ 0.06            |
-| +961         | Lebanon                  | $ 0.29            |
-| +266         | Lesotho                  | $ 0.11            |
-| +231         | Liberia                  | $ 0.26            |
-| +218         | Libya                    | $ 0.41            |
+| +371         | Latvia                   | $ 0.07            |
+| +961         | Lebanon                  | $ 0.35            |
+| +266         | Lesotho                  | $ 0.13            |
+| +231         | Liberia                  | $ 0.31            |
+| +218         | Libya                    | $ 0.49            |
 | +423         | Liechtenstein            | $ 0.04            |
-| +370         | Lithuania                | $ 0.05            |
-| +352         | Luxembourg               | $ 0.09            |
+| +370         | Lithuania                | $ 0.06            |
+| +352         | Luxembourg               | $ 0.10            |
 | +853         | Macao                    | $ 0.04            |
 | +389         | Macedonia                | $ 0.05            |
-| +261         | Madagascar               | $ 0.43            |
-| +265         | Malawi                   | $ 0.28            |
-| +60          | Malaysia                 | $ 0.23            |
-| +960         | Maldives                 | $ 0.30            |
-| +223         | Mali                     | $ 0.25            |
-| +356         | Malta                    | $ 0.06            |
+| +261         | Madagascar               | $ 0.50            |
+| +265         | Malawi                   | $ 0.33            |
+| +60          | Malaysia                 | $ 0.27            |
+| +960         | Maldives                 | $ 0.36            |
+| +223         | Mali                     | $ 0.29            |
+| +356         | Malta                    | $ 0.07            |
 | +692         | Marshall Islands         | $ 0.03            |
-| +596         | Martinique               | $ 0.14            |
-| +222         | Mauritania               | $ 0.21            |
-| +52          | Mexico                   | $ 0.25            |
+| +596         | Martinique               | $ 0.17            |
+| +222         | Mauritania               | $ 0.24            |
+| +52          | Mexico                   | $ 0.29            |
 | +691         | Micronesia               | $ 0.03            |
-| +373         | Moldova                  | $ 0.08            |
-| +377         | Monaco                   | $ 0.09            |
-| +976         | Mongolia                 | $ 0.32            |
-| +212         | Morocco                  | $ 0.25            |
-| +258         | Mozambique               | $ 0.20            |
-| +95          | Myanmar                  | $ 0.41            |
-| +264         | Namibia                  | $ 0.05            |
-| +674         | Nauru                    | $ 0.20            |
-| +977         | Nepal                    | $ 0.33            |
-| +31          | Netherlands              | $ 0.11            |
-| +687         | New Caledonia            | $ 0.09            |
-| +64          | New Zealand              | $ 0.08            |
-| +505         | Nicaragua                | $ 0.15            |
-| +227         | Niger                    | $ 0.29            |
-| +234         | Nigeria                  | $ 0.42            |
+| +373         | Moldova                  | $ 0.09            |
+| +377         | Monaco                   | $ 0.11            |
+| +976         | Mongolia                 | $ 0.37            |
+| +212         | Morocco                  | $ 0.29            |
+| +258         | Mozambique               | $ 0.24            |
+| +95          | Myanmar                  | $ 0.48            |
+| +264         | Namibia                  | $ 0.06            |
+| +674         | Nauru                    | $ 0.23            |
+| +977         | Nepal                    | $ 0.38            |
+| +31          | Netherlands              | $ 0.12            |
+| +687         | New Caledonia            | $ 0.10            |
+| +64          | New Zealand              | $ 0.09            |
+| +505         | Nicaragua                | $ 0.18            |
+| +227         | Niger                    | $ 0.35            |
+| +234         | Nigeria                  | $ 0.50            |
 | +683         | Niue                     | $ 0.05            |
-| +672         | Norfolk Islands          | $ 0.05            |
-| +1           | North America            | $ 0.008           |
+| +672         | Norfolk Islands          | $ 0.06            |
+| +1           | North America            | $ 0.01            |
 | +1670        | Northern Mariana Islands | $ 0.11            |
-| +47          | Norway                   | $ 0.07            |
-| +968         | Oman                     | $ 0.17            |
-| +680         | Palau                    | $ 0.08            |
-| +92          | Pakistan                 | $ 0.40            |
-| +507         | Panama                   | $ 0.15            |
-| +675         | Papua New Guinea         | $ 0.18            |
-| +595         | Paraguay                 | $ 0.09            |
-| +51          | Peru                     | $ 0.03            |
-| +63          | Philippines              | $ 0.23            |
-| +48          | Poland                   | $ 0.03            |
+| +47          | Norway                   | $ 0.09            |
+| +968         | Oman                     | $ 0.21            |
+| +680         | Palau                    | $ 0.10            |
+| +92          | Pakistan                 | $ 0.47            |
+| +507         | Panama                   | $ 0.18            |
+| +675         | Papua New Guinea         | $ 0.21            |
+| +595         | Paraguay                 | $ 0.10            |
+| +51          | Peru                     | $ 0.04            |
+| +63          | Philippines              | $ 0.28            |
+| +48          | Poland                   | $ 0.04            |
 | +351         | Portugal                 | $ 0.03            |
-| +974         | Qatar                    | $ 0.23            |
-| +262         | Reunion                  | $ 0.06            |
-| +40          | Romania                  | $ 0.06            |
-| +7           | Russia and Kazakhstan    | $ 0.36            |
-| +250         | Rwanda                   | $ 0.34            |
+| +974         | Qatar                    | $ 0.27            |
+| +262         | Reunion                  | $ 0.07            |
+| +40          | Romania                  | $ 0.07            |
+| +7           | Russia and Kazakhstan    | $ 0.42            |
+| +250         | Rwanda                   | $ 0.40            |
 | +378         | San Marino               | $ 0.06            |
 | +239         | Sao Tome and Principe    | $ 0.11            |
-| +966         | Saudi Arabia             | $ 0.23            |
-| +221         | Senegal                  | $ 0.32            |
-| +381         | Serbia                   | $ 0.32            |
-| +248         | Seychelles               | $ 0.30            |
-| +232         | Sierra Leone             | $ 0.24            |
-| +65          | Singapore                | $ 0.06            |
-| +421         | Slovak Republic          | $ 0.06            |
-| +386         | Slovenia                 | $ 0.12            |
-| +677         | Solomon Islands          | $ 0.08            |
-| +252         | Somalia                  | $ 0.17            |
-| +27          | South Africa             | $ 0.11            |
-| +34          | Spain                    | $ 0.05            |
-| +94          | Sri Lanka                | $ 0.41            |
+| +966         | Saudi Arabia             | $ 0.27            |
+| +221         | Senegal                  | $ 0.38            |
+| +381         | Serbia                   | $ 0.37            |
+| +248         | Seychelles               | $ 0.35            |
+| +232         | Sierra Leone             | $ 0.28            |
+| +65          | Singapore                | $ 0.07            |
+| +421         | Slovak Republic          | $ 0.07            |
+| +386         | Slovenia                 | $ 0.15            |
+| +677         | Solomon Islands          | $ 0.10            |
+| +252         | Somalia                  | $ 0.20            |
+| +27          | South Africa             | $ 0.13            |
+| +34          | Spain                    | $ 0.06            |
+| +94          | Sri Lanka                | $ 0.49            |
 | +290         | St. Helena               | $ 0.06            |
-| +249         | Sudan                    | $ 0.33            |
-| +597         | Suriname                 | $ 0.19            |
+| +249         | Sudan                    | $ 0.39            |
+| +597         | Suriname                 | $ 0.22            |
 | +268         | Swaziland                | $ 0.13            |
-| +46          | Sweden                   | $ 0.06            |
+| +46          | Sweden                   | $ 0.07            |
 | +41          | Switzerland              | $ 0.05            |
-| +963         | Syria                    | $ 0.41            |
-| +886         | Taiwan                   | $ 0.06            |
-| +992         | Tajikistan               | $ 0.39            |
-| +255         | Tanzania                 | $ 0.34            |
-| +66          | Thailand                 | $ 0.02            |
-| +228         | Togo                     | $ 0.37            |
-| +676         | Tonga                    | $ 0.17            |
-| +216         | Tunisia                  | $ 0.37            |
-| +90          | Turkey                   | $ 0.008           |
-| +993         | Turkmenistan             | $ 0.27            |
+| +963         | Syria                    | $ 0.49            |
+| +886         | Taiwan                   | $ 0.07            |
+| +992         | Tajikistan               | $ 0.46            |
+| +255         | Tanzania                 | $ 0.40            |
+| +66          | Thailand                 | $ 0.03            |
+| +228         | Togo                     | $ 0.43            |
+| +676         | Tonga                    | $ 0.20            |
+| +216         | Tunisia                  | $ 0.44            |
+| +90          | Turkey                   | $ 0.01            |
+| +993         | Turkmenistan             | $ 0.32            |
 | +688         | Tuvalu                   | $ 0.13            |
-| +256         | Uganda                   | $ 0.28            |
-| +380         | Ukraine                  | $ 0.17            |
-| +971         | United Arab Emirates     | $ 0.11            |
-| +44          | United Kingdom           | $ 0.06            |
-| +598         | Uruguay                  | $ 0.08            |
-| +998         | Uzbekistan               | $ 0.44            |
-| +678         | Vanuatu                  | $ 0.19            |
-| +58          | Venezuela                | $ 0.30            |
-| +84          | Vietnam                  | $ 0.20            |
-| +967         | Yemen                    | $ 0.24            |
-| +260         | Zambia                   | $ 0.32            |
-| +263         | Zimbabwe                 | $ 0.21            |
+| +256         | Uganda                   | $ 0.33            |
+| +380         | Ukraine                  | $ 0.20            |
+| +971         | United Arab Emirates     | $ 0.13            |
+| +44          | United Kingdom           | $ 0.07            |
+| +598         | Uruguay                  | $ 0.09            |
+| +998         | Uzbekistan               | $ 0.52            |
+| +678         | Vanuatu                  | $ 0.23            |
+| +58          | Venezuela                | $ 0.36            |
+| +84          | Vietnam                  | $ 0.23            |
+| +967         | Yemen                    | $ 0.28            |
+| +260         | Zambia                   | $ 0.38            |
+| +263         | Zimbabwe                 | $ 0.25            |

--- a/src/routes/docs/advanced/platform/phone-otp/+page.markdoc
+++ b/src/routes/docs/advanced/platform/phone-otp/+page.markdoc
@@ -30,192 +30,192 @@ SMS rates vary by country due to differences in telecom infrastructure and regul
 
 | Country code | Country name             | Price / SMS (USD) |
 |--------------|--------------------------|-------------------|
-| +213         | Algeria                  | $ 0.28            |
+| +213         | Algeria                  | $ 0.26            |
 | +376         | Andorra                  | $ 0.10            |
-| +244         | Angola                   | $ 0.11            |
+| +244         | Angola                   | $ 0.10            |
 | +54          | Argentina                | $ 0.10            |
-| +374         | Armenia                  | $ 0.21            |
-| +297         | Aruba                    | $ 0.26            |
-| +61          | Australia                | $ 0.04            |
+| +374         | Armenia                  | $ 0.20            |
+| +297         | Aruba                    | $ 0.24            |
+| +61          | Australia                | $ 0.03            |
 | +43          | Austria                  | $ 0.03            |
-| +994         | Azerbaijan               | $ 0.39            |
+| +994         | Azerbaijan               | $ 0.37            |
 | +973         | Bahrain                  | $ 0.04            |
-| +880         | Bangladesh               | $ 0.44            |
-| +375         | Belarus                  | $ 0.24            |
-| +32          | Belgium                  | $ 0.11            |
-| +501         | Belize                   | $ 0.32            |
-| +229         | Benin                    | $ 0.29            |
-| +975         | Bhutan                   | $ 0.34            |
-| +591         | Bolivia                  | $ 0.22            |
+| +880         | Bangladesh               | $ 0.43            |
+| +375         | Belarus                  | $ 0.22            |
+| +32          | Belgium                  | $ 0.10            |
+| +501         | Belize                   | $ 0.30            |
+| +229         | Benin                    | $ 0.27            |
+| +975         | Bhutan                   | $ 0.33            |
+| +591         | Bolivia                  | $ 0.21            |
 | +387         | Bosnia and Herzegovina   | $ 0.06            |
-| +267         | Botswana                 | $ 0.10            |
-| +55          | Brazil                   | $ 0.04            |
+| +267         | Botswana                 | $ 0.09            |
+| +55          | Brazil                   | $ 0.03            |
 | +673         | Brunei                   | $ 0.06            |
-| +359         | Bulgaria                 | $ 0.14            |
-| +226         | Burkina Faso             | $ 0.25            |
-| +257         | Burundi                  | $ 0.40            |
-| +855         | Cambodia                 | $ 0.41            |
-| +237         | Cameroon                 | $ 0.28            |
-| +238         | Cape Verde Islands       | $ 0.21            |
+| +359         | Bulgaria                 | $ 0.16            |
+| +226         | Burkina Faso             | $ 0.23            |
+| +257         | Burundi                  | $ 0.38            |
+| +855         | Cambodia                 | $ 0.39            |
+| +237         | Cameroon                 | $ 0.26            |
+| +238         | Cape Verde Islands       | $ 0.20            |
 | +56          | Chile                    | $ 0.03            |
-| +86          | China                    | $ 0.03            |
+| +86          | China                    | $ 0.02            |
 | +57          | Colombia                 | $ 0.04            |
-| +269         | Comoros and Mayotte      | $ 0.34            |
-| +242         | Congo                    | $ 0.28            |
-| +682         | Cook Islands             | $ 0.13            |
-| +506         | Costa Rica               | $ 0.16            |
-| +385         | Croatia                  | $ 0.11            |
+| +269         | Comoros and Mayotte      | $ 0.37            |
+| +242         | Congo                    | $ 0.27            |
+| +682         | Cook Islands             | $ 0.12            |
+| +506         | Costa Rica               | $ 0.15            |
+| +385         | Croatia                  | $ 0.13            |
 | +53          | Cuba                     | $ 0.08            |
 | +357         | Cyprus                   | $ 0.01            |
 | +420         | Czech Republic           | $ 0.06            |
 | +45          | Denmark                  | $ 0.06            |
-| +253         | Djibouti                 | $ 0.14            |
-| +593         | Ecuador                  | $ 0.23            |
-| +20          | Egypt                    | $ 0.39            |
+| +253         | Djibouti                 | $ 0.13            |
+| +593         | Ecuador                  | $ 0.22            |
+| +20          | Egypt                    | $ 0.37            |
 | +503         | El Salvador              | $ 0.08            |
-| +240         | Equatorial Guinea        | $ 0.21            |
+| +240         | Equatorial Guinea        | $ 0.20            |
 | +291         | Eritrea                  | $ 0.17            |
-| +372         | Estonia                  | $ 0.06            |
-| +251         | Ethiopia                 | $ 0.37            |
-| +500         | Falkland Islands         | $ 0.10            |
-| +298         | Faroe Islands            | $ 0.07            |
+| +372         | Estonia                  | $ 0.05            |
+| +251         | Ethiopia                 | $ 0.35            |
+| +500         | Falkland Islands         | $ 0.09            |
+| +298         | Faroe Islands            | $ 0.06            |
 | +679         | Fiji                     | $ 0.20            |
-| +358         | Finland                  | $ 0.09            |
+| +358         | Finland                  | $ 0.08            |
 | +33          | France                   | $ 0.07            |
-| +594         | French Guiana            | $ 0.14            |
-| +689         | French Polynesia         | $ 0.11            |
-| +241         | Gabon                    | $ 0.31            |
-| +220         | Gambia                   | $ 0.10            |
-| +995         | Georgia                  | $ 0.15            |
+| +594         | French Guiana            | $ 0.13            |
+| +689         | French Polynesia         | $ 0.10            |
+| +241         | Gabon                    | $ 0.29            |
+| +220         | Gambia                   | $ 0.09            |
+| +995         | Georgia                  | $ 0.14            |
 | +49          | Germany                  | $ 0.10            |
-| +233         | Ghana                    | $ 0.33            |
-| +350         | Gibraltar                | $ 0.09            |
-| +30          | Greece                   | $ 0.06            |
+| +233         | Ghana                    | $ 0.31            |
+| +350         | Gibraltar                | $ 0.08            |
+| +30          | Greece                   | $ 0.05            |
 | +299         | Greenland                | $ 0.03            |
-| +590         | Guadeloupe               | $ 0.16            |
+| +590         | Guadeloupe               | $ 0.15            |
 | +1671        | Guam                     | $ 0.03            |
 | +502         | Guatemala                | $ 0.22            |
-| +224         | Guinea                   | $ 0.22            |
-| +245         | Guinea-Bissau            | $ 0.27            |
-| +592         | Guyana                   | $ 0.22            |
-| +509         | Haiti                    | $ 0.34            |
-| +504         | Honduras                 | $ 0.24            |
+| +224         | Guinea                   | $ 0.26            |
+| +245         | Guinea-Bissau            | $ 0.25            |
+| +592         | Guyana                   | $ 0.21            |
+| +509         | Haiti                    | $ 0.32            |
+| +504         | Honduras                 | $ 0.23            |
 | +852         | Hong Kong                | $ 0.06            |
-| +36          | Hungary                  | $ 0.08            |
+| +36          | Hungary                  | $ 0.07            |
 | +354         | Iceland                  | $ 0.07            |
 | +91          | India                    | $ 0.003           |
 | +62          | Indonesia                | $ 0.40            |
-| +98          | Iran                     | $ 0.29            |
-| +964         | Iraq                     | $ 0.41            |
+| +98          | Iran                     | $ 0.27            |
+| +964         | Iraq                     | $ 0.39            |
 | +353         | Ireland                  | $ 0.08            |
 | +972         | Israel                   | $ 0.01            |
-| +39          | Italy                    | $ 0.06            |
-| +81          | Japan                    | $ 0.07            |
-| +962         | Jordan                   | $ 0.42            |
-| +254         | Kenya                    | $ 0.28            |
+| +39          | Italy                    | $ 0.05            |
+| +81          | Japan                    | $ 0.06            |
+| +962         | Jordan                   | $ 0.40            |
+| +254         | Kenya                    | $ 0.26            |
 | +686         | Kiribati                 | $ 0.08            |
 | +850         | North Korea              | $ 0.03            |
 | +82          | South Korea              | $ 0.02            |
-| +965         | Kuwait                   | $ 0.22            |
+| +965         | Kuwait                   | $ 0.21            |
 | +996         | Kyrgyzstan               | $ 0.34            |
 | +856         | Laos                     | $ 0.19            |
 | +371         | Latvia                   | $ 0.06            |
-| +961         | Lebanon                  | $ 0.31            |
-| +266         | Lesotho                  | $ 0.12            |
-| +231         | Liberia                  | $ 0.28            |
-| +218         | Libya                    | $ 0.44            |
+| +961         | Lebanon                  | $ 0.29            |
+| +266         | Lesotho                  | $ 0.11            |
+| +231         | Liberia                  | $ 0.26            |
+| +218         | Libya                    | $ 0.41            |
 | +423         | Liechtenstein            | $ 0.04            |
 | +370         | Lithuania                | $ 0.05            |
 | +352         | Luxembourg               | $ 0.09            |
 | +853         | Macao                    | $ 0.04            |
 | +389         | Macedonia                | $ 0.05            |
-| +261         | Madagascar               | $ 0.39            |
+| +261         | Madagascar               | $ 0.43            |
 | +265         | Malawi                   | $ 0.28            |
-| +60          | Malaysia                 | $ 0.25            |
-| +960         | Maldives                 | $ 0.32            |
-| +223         | Mali                     | $ 0.26            |
+| +60          | Malaysia                 | $ 0.23            |
+| +960         | Maldives                 | $ 0.30            |
+| +223         | Mali                     | $ 0.25            |
 | +356         | Malta                    | $ 0.06            |
 | +692         | Marshall Islands         | $ 0.03            |
-| +596         | Martinique               | $ 0.15            |
-| +222         | Mauritania               | $ 0.22            |
-| +52          | Mexico                   | $ 0.26            |
+| +596         | Martinique               | $ 0.14            |
+| +222         | Mauritania               | $ 0.21            |
+| +52          | Mexico                   | $ 0.25            |
 | +691         | Micronesia               | $ 0.03            |
 | +373         | Moldova                  | $ 0.08            |
 | +377         | Monaco                   | $ 0.09            |
-| +976         | Mongolia                 | $ 0.33            |
-| +212         | Morocco                  | $ 0.26            |
-| +258         | Mozambique               | $ 0.10            |
-| +95          | Myanmar                  | $ 0.43            |
+| +976         | Mongolia                 | $ 0.32            |
+| +212         | Morocco                  | $ 0.25            |
+| +258         | Mozambique               | $ 0.20            |
+| +95          | Myanmar                  | $ 0.41            |
 | +264         | Namibia                  | $ 0.05            |
-| +674         | Nauru                    | $ 0.21            |
-| +977         | Nepal                    | $ 0.34            |
+| +674         | Nauru                    | $ 0.20            |
+| +977         | Nepal                    | $ 0.33            |
 | +31          | Netherlands              | $ 0.11            |
 | +687         | New Caledonia            | $ 0.09            |
 | +64          | New Zealand              | $ 0.08            |
-| +505         | Nicaragua                | $ 0.16            |
-| +227         | Niger                    | $ 0.31            |
-| +234         | Nigeria                  | $ 0.45            |
+| +505         | Nicaragua                | $ 0.15            |
+| +227         | Niger                    | $ 0.29            |
+| +234         | Nigeria                  | $ 0.42            |
 | +683         | Niue                     | $ 0.05            |
-| +672         | Norfolk Islands          | $ 0.06            |
-| +1           | North America            | $ 0.009           |
+| +672         | Norfolk Islands          | $ 0.05            |
+| +1           | North America            | $ 0.008           |
 | +1670        | Northern Mariana Islands | $ 0.11            |
-| +47          | Norway                   | $ 0.08            |
-| +968         | Oman                     | $ 0.18            |
-| +680         | Palau                    | $ 0.09            |
-| +92          | Pakistan                 | $ 0.42            |
+| +47          | Norway                   | $ 0.07            |
+| +968         | Oman                     | $ 0.17            |
+| +680         | Palau                    | $ 0.08            |
+| +92          | Pakistan                 | $ 0.40            |
 | +507         | Panama                   | $ 0.15            |
-| +675         | Papua New Guinea         | $ 0.19            |
+| +675         | Papua New Guinea         | $ 0.18            |
 | +595         | Paraguay                 | $ 0.09            |
 | +51          | Peru                     | $ 0.03            |
-| +63          | Philippines              | $ 0.21            |
+| +63          | Philippines              | $ 0.23            |
 | +48          | Poland                   | $ 0.03            |
 | +351         | Portugal                 | $ 0.03            |
-| +974         | Qatar                    | $ 0.25            |
+| +974         | Qatar                    | $ 0.23            |
 | +262         | Reunion                  | $ 0.06            |
 | +40          | Romania                  | $ 0.06            |
-| +7           | Russia and Kazakhstan    | $ 0.38            |
-| +250         | Rwanda                   | $ 0.33            |
+| +7           | Russia and Kazakhstan    | $ 0.36            |
+| +250         | Rwanda                   | $ 0.34            |
 | +378         | San Marino               | $ 0.06            |
 | +239         | Sao Tome and Principe    | $ 0.11            |
-| +966         | Saudi Arabia             | $ 0.20            |
-| +221         | Senegal                  | $ 0.29            |
-| +381         | Serbia                   | $ 0.34            |
-| +248         | Seychelles               | $ 0.31            |
-| +232         | Sierra Leone             | $ 0.25            |
+| +966         | Saudi Arabia             | $ 0.23            |
+| +221         | Senegal                  | $ 0.32            |
+| +381         | Serbia                   | $ 0.32            |
+| +248         | Seychelles               | $ 0.30            |
+| +232         | Sierra Leone             | $ 0.24            |
 | +65          | Singapore                | $ 0.06            |
-| +421         | Slovak Republic          | $ 0.07            |
-| +386         | Slovenia                 | $ 0.13            |
-| +677         | Solomon Islands          | $ 0.09            |
-| +252         | Somalia                  | $ 0.18            |
-| +27          | South Africa             | $ 0.12            |
-| +34          | Spain                    | $ 0.06            |
-| +94          | Sri Lanka                | $ 0.44            |
+| +421         | Slovak Republic          | $ 0.06            |
+| +386         | Slovenia                 | $ 0.12            |
+| +677         | Solomon Islands          | $ 0.08            |
+| +252         | Somalia                  | $ 0.17            |
+| +27          | South Africa             | $ 0.11            |
+| +34          | Spain                    | $ 0.05            |
+| +94          | Sri Lanka                | $ 0.41            |
 | +290         | St. Helena               | $ 0.06            |
-| +249         | Sudan                    | $ 0.35            |
-| +597         | Suriname                 | $ 0.20            |
+| +249         | Sudan                    | $ 0.33            |
+| +597         | Suriname                 | $ 0.19            |
 | +268         | Swaziland                | $ 0.13            |
 | +46          | Sweden                   | $ 0.06            |
 | +41          | Switzerland              | $ 0.05            |
-| +963         | Syria                    | $ 0.44            |
+| +963         | Syria                    | $ 0.41            |
 | +886         | Taiwan                   | $ 0.06            |
-| +992         | Tajikistan               | $ 0.41            |
-| +255         | Tanzania                 | $ 0.36            |
-| +66          | Thailand                 | $ 0.03            |
-| +228         | Togo                     | $ 0.39            |
-| +676         | Tonga                    | $ 0.18            |
-| +216         | Tunisia                  | $ 0.39            |
-| +90          | Turkey                   | $ 0.009           |
-| +993         | Turkmenistan             | $ 0.29            |
+| +992         | Tajikistan               | $ 0.39            |
+| +255         | Tanzania                 | $ 0.34            |
+| +66          | Thailand                 | $ 0.02            |
+| +228         | Togo                     | $ 0.37            |
+| +676         | Tonga                    | $ 0.17            |
+| +216         | Tunisia                  | $ 0.37            |
+| +90          | Turkey                   | $ 0.008           |
+| +993         | Turkmenistan             | $ 0.27            |
 | +688         | Tuvalu                   | $ 0.13            |
-| +256         | Uganda                   | $ 0.29            |
-| +380         | Ukraine                  | $ 0.18            |
-| +971         | United Arab Emirates     | $ 0.12            |
-| +44          | United Kingdom           | $ 0.05            |
-| +598         | Uruguay                  | $ 0.07            |
-| +998         | Uzbekistan               | $ 0.47            |
-| +678         | Vanuatu                  | $ 0.20            |
-| +58          | Venezuela                | $ 0.22            |
-| +84          | Vietnam                  | $ 0.21            |
-| +967         | Yemen                    | $ 0.25            |
-| +260         | Zambia                   | $ 0.33            |
-| +263         | Zimbabwe                 | $ 0.23            |
+| +256         | Uganda                   | $ 0.28            |
+| +380         | Ukraine                  | $ 0.17            |
+| +971         | United Arab Emirates     | $ 0.11            |
+| +44          | United Kingdom           | $ 0.06            |
+| +598         | Uruguay                  | $ 0.08            |
+| +998         | Uzbekistan               | $ 0.44            |
+| +678         | Vanuatu                  | $ 0.19            |
+| +58          | Venezuela                | $ 0.30            |
+| +84          | Vietnam                  | $ 0.20            |
+| +967         | Yemen                    | $ 0.24            |
+| +260         | Zambia                   | $ 0.32            |
+| +263         | Zimbabwe                 | $ 0.21            |


### PR DESCRIPTION
## Summary
- Updated the Phone OTP SMS rates table in the docs using the SMS pricing table generator.
- Syncs website pricing with the Cloud SMS pricing config after updating the Cloud scraper to select the highest MSG91 route price when multiple routes are returned.
- Only the rates table in the Phone OTP docs was changed.

## Pricing table change summary

| Metric | Count |
|---|---:|
| Countries in rates table | 189 |
| Changed displayed pricing entries | 151 |
| Unchanged displayed pricing entries | 38 |
| Displayed prices decreased | 0 |
| Displayed prices increased | 151 |

## Notable displayed increases

| Country | Old | New | Change |
|---|---:|---:|---:|
| Mozambique | 0.100 | 0.240 | +140.0% |
| Venezuela | 0.220 | 0.360 | +63.6% |
| Senegal | 0.290 | 0.380 | +31.0% |
| Comoros and Mayotte | 0.340 | 0.440 | +29.4% |
| Madagascar | 0.390 | 0.500 | +28.2% |

## High-volume / reviewed countries

| Country | Old | New |
|---|---:|---:|
| North America | 0.009 | 0.010 |
| Saudi Arabia | 0.200 | 0.270 |
| Yemen | 0.250 | 0.280 |
| Oman | 0.180 | 0.210 |
| Iraq | 0.410 | 0.460 |
| Jordan | 0.420 | 0.470 |
| Kuwait | 0.220 | 0.240 |
| Vietnam | 0.210 | 0.230 |

## Validation
- Generated table with: `php app/cli.php create-sms-pricing-table`
- Ran: `git diff --check`
