### PR TITLE
Add changelog entry for SMS pricing update

### DIFF
--- a/src/routes/changelog/(entries)/2026-05-18.markdoc
+++ b/src/routes/changelog/(entries)/2026-05-18.markdoc
@@ -1,0 +1,9 @@
+---
+layout: changelog
+title: "Updated SMS pricing"
+date: 2026-05-18
+---
+
+We've refreshed our [SMS pricing](/docs/advanced/platform/phone-otp#sms-pricing) to reflect the latest carrier rates. Per-SMS prices have changed for a number of countries.
+
+Review the updated per-country rates before your next phone OTP rollout.


### PR DESCRIPTION
## Summary
- Adds a minimal changelog entry dated 2026-05-18 documenting the SMS pricing refresh shipped in #3005
- Links readers to the updated per-country SMS pricing table on the phone OTP docs page

## Test plan
- [ ] Verify the entry renders on `/changelog` with correct date ordering
- [ ] Confirm the link to `/docs/advanced/platform/phone-otp#sms-pricing` resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)