### PR TITLE
docs(phone-otp): refresh SMS pricing table

### DIFF
--- a/src/routes/docs/advanced/platform/phone-otp/+page.markdoc
+++ b/src/routes/docs/advanced/platform/phone-otp/+page.markdoc
@@ -30,192 +30,192 @@ SMS rates vary by country due to differences in telecom infrastructure and regul
 
 | Country code | Country name             | Price / SMS (USD) |
 |--------------|--------------------------|-------------------|
-| +213         | Algeria                  | $ 0.43            |
-| +376         | Andorra                  | $ 0.15            |
-| +244         | Angola                   | $ 0.17            |
-| +54          | Argentina                | $ 0.16            |
-| +374         | Armenia                  | $ 0.33            |
-| +297         | Aruba                    | $ 0.40            |
+| +213         | Algeria                  | $ 0.38            |
+| +376         | Andorra                  | $ 0.14            |
+| +244         | Angola                   | $ 0.15            |
+| +54          | Argentina                | $ 0.14            |
+| +374         | Armenia                  | $ 0.29            |
+| +297         | Aruba                    | $ 0.35            |
 | +61          | Australia                | $ 0.05            |
 | +43          | Austria                  | $ 0.04            |
-| +994         | Azerbaijan               | $ 0.61            |
-| +973         | Bahrain                  | $ 0.06            |
-| +880         | Bangladesh               | $ 0.70            |
-| +375         | Belarus                  | $ 0.36            |
-| +32          | Belgium                  | $ 0.16            |
-| +501         | Belize                   | $ 0.49            |
-| +229         | Benin                    | $ 0.44            |
-| +975         | Bhutan                   | $ 0.53            |
-| +591         | Bolivia                  | $ 0.35            |
-| +387         | Bosnia and Herzegovina   | $ 0.09            |
-| +267         | Botswana                 | $ 0.15            |
+| +994         | Azerbaijan               | $ 0.54            |
+| +973         | Bahrain                  | $ 0.05            |
+| +880         | Bangladesh               | $ 0.62            |
+| +375         | Belarus                  | $ 0.32            |
+| +32          | Belgium                  | $ 0.14            |
+| +501         | Belize                   | $ 0.43            |
+| +229         | Benin                    | $ 0.39            |
+| +975         | Bhutan                   | $ 0.47            |
+| +591         | Bolivia                  | $ 0.31            |
+| +387         | Bosnia and Herzegovina   | $ 0.08            |
+| +267         | Botswana                 | $ 0.13            |
 | +55          | Brazil                   | $ 0.05            |
-| +673         | Brunei                   | $ 0.10            |
-| +359         | Bulgaria                 | $ 0.26            |
-| +226         | Burkina Faso             | $ 0.38            |
-| +257         | Burundi                  | $ 0.62            |
-| +855         | Cambodia                 | $ 0.64            |
-| +237         | Cameroon                 | $ 0.43            |
-| +238         | Cape Verde Islands       | $ 0.32            |
+| +673         | Brunei                   | $ 0.09            |
+| +359         | Bulgaria                 | $ 0.23            |
+| +226         | Burkina Faso             | $ 0.34            |
+| +257         | Burundi                  | $ 0.55            |
+| +855         | Cambodia                 | $ 0.57            |
+| +237         | Cameroon                 | $ 0.38            |
+| +238         | Cape Verde Islands       | $ 0.28            |
 | +56          | Chile                    | $ 0.04            |
-| +86          | China                    | $ 0.04            |
-| +57          | Colombia                 | $ 0.06            |
-| +269         | Comoros and Mayotte      | $ 0.61            |
-| +242         | Congo                    | $ 0.44            |
-| +682         | Cook Islands             | $ 0.19            |
-| +506         | Costa Rica               | $ 0.24            |
-| +385         | Croatia                  | $ 0.21            |
-| +53          | Cuba                     | $ 0.12            |
+| +86          | China                    | $ 0.03            |
+| +57          | Colombia                 | $ 0.05            |
+| +269         | Comoros and Mayotte      | $ 0.54            |
+| +242         | Congo                    | $ 0.39            |
+| +682         | Cook Islands             | $ 0.17            |
+| +506         | Costa Rica               | $ 0.22            |
+| +385         | Croatia                  | $ 0.19            |
+| +53          | Cuba                     | $ 0.11            |
 | +357         | Cyprus                   | $ 0.02            |
-| +420         | Czech Republic           | $ 0.10            |
-| +45          | Denmark                  | $ 0.09            |
-| +253         | Djibouti                 | $ 0.21            |
-| +593         | Ecuador                  | $ 0.36            |
-| +20          | Egypt                    | $ 0.61            |
-| +503         | El Salvador              | $ 0.12            |
-| +240         | Equatorial Guinea        | $ 0.32            |
+| +420         | Czech Republic           | $ 0.09            |
+| +45          | Denmark                  | $ 0.08            |
+| +253         | Djibouti                 | $ 0.19            |
+| +593         | Ecuador                  | $ 0.32            |
+| +20          | Egypt                    | $ 0.54            |
+| +503         | El Salvador              | $ 0.11            |
+| +240         | Equatorial Guinea        | $ 0.28            |
 | +291         | Eritrea                  | $ 0.17            |
-| +372         | Estonia                  | $ 0.08            |
-| +251         | Ethiopia                 | $ 0.57            |
-| +500         | Falkland Islands         | $ 0.15            |
-| +298         | Faroe Islands            | $ 0.10            |
-| +679         | Fiji                     | $ 0.33            |
-| +358         | Finland                  | $ 0.13            |
-| +33          | France                   | $ 0.11            |
-| +594         | French Guiana            | $ 0.21            |
-| +689         | French Polynesia         | $ 0.16            |
-| +241         | Gabon                    | $ 0.47            |
-| +220         | Gambia                   | $ 0.15            |
-| +995         | Georgia                  | $ 0.22            |
-| +49          | Germany                  | $ 0.15            |
-| +233         | Ghana                    | $ 0.51            |
-| +350         | Gibraltar                | $ 0.13            |
-| +30          | Greece                   | $ 0.08            |
-| +299         | Greenland                | $ 0.05            |
-| +590         | Guadeloupe               | $ 0.24            |
-| +1671        | Guam                     | $ 0.05            |
-| +502         | Guatemala                | $ 0.35            |
-| +224         | Guinea                   | $ 0.42            |
-| +245         | Guinea-Bissau            | $ 0.41            |
-| +592         | Guyana                   | $ 0.34            |
-| +509         | Haiti                    | $ 0.52            |
-| +504         | Honduras                 | $ 0.37            |
-| +852         | Hong Kong                | $ 0.09            |
-| +36          | Hungary                  | $ 0.12            |
-| +354         | Iceland                  | $ 0.11            |
+| +372         | Estonia                  | $ 0.07            |
+| +251         | Ethiopia                 | $ 0.51            |
+| +500         | Falkland Islands         | $ 0.13            |
+| +298         | Faroe Islands            | $ 0.09            |
+| +679         | Fiji                     | $ 0.29            |
+| +358         | Finland                  | $ 0.12            |
+| +33          | France                   | $ 0.10            |
+| +594         | French Guiana            | $ 0.19            |
+| +689         | French Polynesia         | $ 0.14            |
+| +241         | Gabon                    | $ 0.42            |
+| +220         | Gambia                   | $ 0.13            |
+| +995         | Georgia                  | $ 0.20            |
+| +49          | Germany                  | $ 0.14            |
+| +233         | Ghana                    | $ 0.45            |
+| +350         | Gibraltar                | $ 0.12            |
+| +30          | Greece                   | $ 0.07            |
+| +299         | Greenland                | $ 0.04            |
+| +590         | Guadeloupe               | $ 0.21            |
+| +1671        | Guam                     | $ 0.04            |
+| +502         | Guatemala                | $ 0.31            |
+| +224         | Guinea                   | $ 0.37            |
+| +245         | Guinea-Bissau            | $ 0.37            |
+| +592         | Guyana                   | $ 0.31            |
+| +509         | Haiti                    | $ 0.47            |
+| +504         | Honduras                 | $ 0.33            |
+| +852         | Hong Kong                | $ 0.08            |
+| +36          | Hungary                  | $ 0.10            |
+| +354         | Iceland                  | $ 0.10            |
 | +91          | India                    | $ 0.003           |
-| +62          | Indonesia                | $ 0.65            |
-| +98          | Iran                     | $ 0.44            |
-| +964         | Iraq                     | $ 0.63            |
-| +353         | Ireland                  | $ 0.13            |
+| +62          | Indonesia                | $ 0.58            |
+| +98          | Iran                     | $ 0.39            |
+| +964         | Iraq                     | $ 0.56            |
+| +353         | Ireland                  | $ 0.11            |
 | +972         | Israel                   | $ 0.01            |
-| +39          | Italy                    | $ 0.08            |
-| +81          | Japan                    | $ 0.10            |
-| +962         | Jordan                   | $ 0.64            |
-| +254         | Kenya                    | $ 0.42            |
+| +39          | Italy                    | $ 0.07            |
+| +81          | Japan                    | $ 0.09            |
+| +962         | Jordan                   | $ 0.57            |
+| +254         | Kenya                    | $ 0.38            |
 | +686         | Kiribati                 | $ 0.08            |
 | +850         | North Korea              | $ 0.03            |
 | +82          | South Korea              | $ 0.03            |
-| +965         | Kuwait                   | $ 0.33            |
-| +996         | Kyrgyzstan               | $ 0.55            |
+| +965         | Kuwait                   | $ 0.30            |
+| +996         | Kyrgyzstan               | $ 0.49            |
 | +856         | Laos                     | $ 0.19            |
-| +371         | Latvia                   | $ 0.10            |
-| +961         | Lebanon                  | $ 0.48            |
-| +266         | Lesotho                  | $ 0.18            |
-| +231         | Liberia                  | $ 0.42            |
-| +218         | Libya                    | $ 0.67            |
-| +423         | Liechtenstein            | $ 0.06            |
-| +370         | Lithuania                | $ 0.08            |
-| +352         | Luxembourg               | $ 0.14            |
+| +371         | Latvia                   | $ 0.09            |
+| +961         | Lebanon                  | $ 0.42            |
+| +266         | Lesotho                  | $ 0.16            |
+| +231         | Liberia                  | $ 0.38            |
+| +218         | Libya                    | $ 0.60            |
+| +423         | Liechtenstein            | $ 0.05            |
+| +370         | Lithuania                | $ 0.07            |
+| +352         | Luxembourg               | $ 0.13            |
 | +853         | Macao                    | $ 0.04            |
 | +389         | Macedonia                | $ 0.07            |
-| +261         | Madagascar               | $ 0.70            |
-| +265         | Malawi                   | $ 0.45            |
-| +60          | Malaysia                 | $ 0.45            |
-| +960         | Maldives                 | $ 0.49            |
-| +223         | Mali                     | $ 0.40            |
-| +356         | Malta                    | $ 0.09            |
+| +261         | Madagascar               | $ 0.62            |
+| +265         | Malawi                   | $ 0.40            |
+| +60          | Malaysia                 | $ 0.40            |
+| +960         | Maldives                 | $ 0.44            |
+| +223         | Mali                     | $ 0.36            |
+| +356         | Malta                    | $ 0.08            |
 | +692         | Marshall Islands         | $ 0.03            |
-| +596         | Martinique               | $ 0.23            |
-| +222         | Mauritania               | $ 0.33            |
-| +52          | Mexico                   | $ 0.40            |
+| +596         | Martinique               | $ 0.21            |
+| +222         | Mauritania               | $ 0.30            |
+| +52          | Mexico                   | $ 0.35            |
 | +691         | Micronesia               | $ 0.03            |
-| +373         | Moldova                  | $ 0.12            |
-| +377         | Monaco                   | $ 0.14            |
-| +976         | Mongolia                 | $ 0.51            |
-| +212         | Morocco                  | $ 0.40            |
-| +258         | Mozambique               | $ 0.33            |
-| +95          | Myanmar                  | $ 0.66            |
-| +264         | Namibia                  | $ 0.08            |
-| +674         | Nauru                    | $ 0.32            |
-| +977         | Nepal                    | $ 0.53            |
-| +31          | Netherlands              | $ 0.17            |
-| +687         | New Caledonia            | $ 0.14            |
-| +64          | New Zealand              | $ 0.12            |
-| +505         | Nicaragua                | $ 0.24            |
-| +227         | Niger                    | $ 0.48            |
-| +234         | Nigeria                  | $ 0.69            |
+| +373         | Moldova                  | $ 0.11            |
+| +377         | Monaco                   | $ 0.13            |
+| +976         | Mongolia                 | $ 0.46            |
+| +212         | Morocco                  | $ 0.36            |
+| +258         | Mozambique               | $ 0.29            |
+| +95          | Myanmar                  | $ 0.59            |
+| +264         | Namibia                  | $ 0.07            |
+| +674         | Nauru                    | $ 0.29            |
+| +977         | Nepal                    | $ 0.47            |
+| +31          | Netherlands              | $ 0.15            |
+| +687         | New Caledonia            | $ 0.12            |
+| +64          | New Zealand              | $ 0.11            |
+| +505         | Nicaragua                | $ 0.21            |
+| +227         | Niger                    | $ 0.42            |
+| +234         | Nigeria                  | $ 0.61            |
 | +683         | Niue                     | $ 0.05            |
-| +672         | Norfolk Islands          | $ 0.08            |
+| +672         | Norfolk Islands          | $ 0.07            |
 | +1           | North America            | $ 0.02            |
 | +1670        | Northern Mariana Islands | $ 0.11            |
-| +47          | Norway                   | $ 0.12            |
-| +968         | Oman                     | $ 0.28            |
-| +680         | Palau                    | $ 0.13            |
-| +92          | Pakistan                 | $ 0.65            |
-| +507         | Panama                   | $ 0.25            |
-| +675         | Papua New Guinea         | $ 0.29            |
-| +595         | Paraguay                 | $ 0.14            |
-| +51          | Peru                     | $ 0.05            |
-| +63          | Philippines              | $ 0.38            |
-| +48          | Poland                   | $ 0.05            |
+| +47          | Norway                   | $ 0.11            |
+| +968         | Oman                     | $ 0.25            |
+| +680         | Palau                    | $ 0.12            |
+| +92          | Pakistan                 | $ 0.58            |
+| +507         | Panama                   | $ 0.22            |
+| +675         | Papua New Guinea         | $ 0.26            |
+| +595         | Paraguay                 | $ 0.12            |
+| +51          | Peru                     | $ 0.04            |
+| +63          | Philippines              | $ 0.34            |
+| +48          | Poland                   | $ 0.04            |
 | +351         | Portugal                 | $ 0.04            |
-| +974         | Qatar                    | $ 0.38            |
-| +262         | Reunion                  | $ 0.10            |
-| +40          | Romania                  | $ 0.09            |
-| +7           | Russia and Kazakhstan    | $ 0.58            |
-| +250         | Rwanda                   | $ 0.55            |
+| +974         | Qatar                    | $ 0.34            |
+| +262         | Reunion                  | $ 0.09            |
+| +40          | Romania                  | $ 0.08            |
+| +7           | Russia and Kazakhstan    | $ 0.52            |
+| +250         | Rwanda                   | $ 0.49            |
 | +378         | San Marino               | $ 0.06            |
 | +239         | Sao Tome and Principe    | $ 0.11            |
-| +966         | Saudi Arabia             | $ 0.37            |
-| +221         | Senegal                  | $ 0.52            |
-| +381         | Serbia                   | $ 0.52            |
-| +248         | Seychelles               | $ 0.48            |
-| +232         | Sierra Leone             | $ 0.39            |
-| +65          | Singapore                | $ 0.10            |
-| +421         | Slovak Republic          | $ 0.10            |
-| +386         | Slovenia                 | $ 0.20            |
-| +677         | Solomon Islands          | $ 0.13            |
-| +252         | Somalia                  | $ 0.27            |
-| +27          | South Africa             | $ 0.18            |
-| +34          | Spain                    | $ 0.08            |
-| +94          | Sri Lanka                | $ 0.67            |
+| +966         | Saudi Arabia             | $ 0.33            |
+| +221         | Senegal                  | $ 0.46            |
+| +381         | Serbia                   | $ 0.46            |
+| +248         | Seychelles               | $ 0.43            |
+| +232         | Sierra Leone             | $ 0.35            |
+| +65          | Singapore                | $ 0.09            |
+| +421         | Slovak Republic          | $ 0.09            |
+| +386         | Slovenia                 | $ 0.18            |
+| +677         | Solomon Islands          | $ 0.12            |
+| +252         | Somalia                  | $ 0.24            |
+| +27          | South Africa             | $ 0.16            |
+| +34          | Spain                    | $ 0.07            |
+| +94          | Sri Lanka                | $ 0.60            |
 | +290         | St. Helena               | $ 0.06            |
-| +249         | Sudan                    | $ 0.53            |
-| +597         | Suriname                 | $ 0.30            |
+| +249         | Sudan                    | $ 0.48            |
+| +597         | Suriname                 | $ 0.27            |
 | +268         | Swaziland                | $ 0.13            |
-| +46          | Sweden                   | $ 0.10            |
-| +41          | Switzerland              | $ 0.07            |
-| +963         | Syria                    | $ 0.67            |
-| +886         | Taiwan                   | $ 0.09            |
-| +992         | Tajikistan               | $ 0.64            |
-| +255         | Tanzania                 | $ 0.55            |
-| +66          | Thailand                 | $ 0.04            |
-| +228         | Togo                     | $ 0.60            |
-| +676         | Tonga                    | $ 0.28            |
-| +216         | Tunisia                  | $ 0.61            |
+| +46          | Sweden                   | $ 0.09            |
+| +41          | Switzerland              | $ 0.06            |
+| +963         | Syria                    | $ 0.60            |
+| +886         | Taiwan                   | $ 0.08            |
+| +992         | Tajikistan               | $ 0.57            |
+| +255         | Tanzania                 | $ 0.49            |
+| +66          | Thailand                 | $ 0.03            |
+| +228         | Togo                     | $ 0.53            |
+| +676         | Tonga                    | $ 0.25            |
+| +216         | Tunisia                  | $ 0.54            |
 | +90          | Turkey                   | $ 0.01            |
-| +993         | Turkmenistan             | $ 0.44            |
+| +993         | Turkmenistan             | $ 0.39            |
 | +688         | Tuvalu                   | $ 0.13            |
-| +256         | Uganda                   | $ 0.46            |
-| +380         | Ukraine                  | $ 0.28            |
-| +971         | United Arab Emirates     | $ 0.18            |
-| +44          | United Kingdom           | $ 0.09            |
-| +598         | Uruguay                  | $ 0.13            |
-| +998         | Uzbekistan               | $ 0.72            |
-| +678         | Vanuatu                  | $ 0.31            |
-| +58          | Venezuela                | $ 0.49            |
-| +84          | Vietnam                  | $ 0.32            |
-| +967         | Yemen                    | $ 0.38            |
-| +260         | Zambia                   | $ 0.52            |
-| +263         | Zimbabwe                 | $ 0.36            |
+| +256         | Uganda                   | $ 0.41            |
+| +380         | Ukraine                  | $ 0.25            |
+| +971         | United Arab Emirates     | $ 0.16            |
+| +44          | United Kingdom           | $ 0.08            |
+| +598         | Uruguay                  | $ 0.11            |
+| +998         | Uzbekistan               | $ 0.64            |
+| +678         | Vanuatu                  | $ 0.28            |
+| +58          | Venezuela                | $ 0.44            |
+| +84          | Vietnam                  | $ 0.28            |
+| +967         | Yemen                    | $ 0.34            |
+| +260         | Zambia                   | $ 0.46            |
+| +263         | Zimbabwe                 | $ 0.32            |

--- a/src/routes/docs/advanced/platform/phone-otp/+page.markdoc
+++ b/src/routes/docs/advanced/platform/phone-otp/+page.markdoc
@@ -30,192 +30,192 @@ SMS rates vary by country due to differences in telecom infrastructure and regul
 
 | Country code | Country name             | Price / SMS (USD) |
 |--------------|--------------------------|-------------------|
-| +213         | Algeria                  | $ 0.31            |
-| +376         | Andorra                  | $ 0.11            |
-| +244         | Angola                   | $ 0.12            |
-| +54          | Argentina                | $ 0.12            |
-| +374         | Armenia                  | $ 0.24            |
-| +297         | Aruba                    | $ 0.29            |
-| +61          | Australia                | $ 0.04            |
-| +43          | Austria                  | $ 0.03            |
-| +994         | Azerbaijan               | $ 0.44            |
-| +973         | Bahrain                  | $ 0.04            |
-| +880         | Bangladesh               | $ 0.50            |
-| +375         | Belarus                  | $ 0.26            |
-| +32          | Belgium                  | $ 0.12            |
-| +501         | Belize                   | $ 0.35            |
-| +229         | Benin                    | $ 0.32            |
-| +975         | Bhutan                   | $ 0.38            |
-| +591         | Bolivia                  | $ 0.25            |
-| +387         | Bosnia and Herzegovina   | $ 0.07            |
-| +267         | Botswana                 | $ 0.11            |
-| +55          | Brazil                   | $ 0.04            |
-| +673         | Brunei                   | $ 0.07            |
-| +359         | Bulgaria                 | $ 0.19            |
-| +226         | Burkina Faso             | $ 0.27            |
-| +257         | Burundi                  | $ 0.45            |
-| +855         | Cambodia                 | $ 0.46            |
-| +237         | Cameroon                 | $ 0.31            |
-| +238         | Cape Verde Islands       | $ 0.23            |
-| +56          | Chile                    | $ 0.03            |
-| +86          | China                    | $ 0.03            |
-| +57          | Colombia                 | $ 0.04            |
-| +269         | Comoros and Mayotte      | $ 0.44            |
-| +242         | Congo                    | $ 0.32            |
-| +682         | Cook Islands             | $ 0.14            |
-| +506         | Costa Rica               | $ 0.18            |
-| +385         | Croatia                  | $ 0.16            |
-| +53          | Cuba                     | $ 0.09            |
-| +357         | Cyprus                   | $ 0.01            |
-| +420         | Czech Republic           | $ 0.07            |
-| +45          | Denmark                  | $ 0.07            |
-| +253         | Djibouti                 | $ 0.15            |
-| +593         | Ecuador                  | $ 0.26            |
-| +20          | Egypt                    | $ 0.44            |
-| +503         | El Salvador              | $ 0.09            |
-| +240         | Equatorial Guinea        | $ 0.23            |
+| +213         | Algeria                  | $ 0.43            |
+| +376         | Andorra                  | $ 0.15            |
+| +244         | Angola                   | $ 0.17            |
+| +54          | Argentina                | $ 0.16            |
+| +374         | Armenia                  | $ 0.33            |
+| +297         | Aruba                    | $ 0.40            |
+| +61          | Australia                | $ 0.05            |
+| +43          | Austria                  | $ 0.04            |
+| +994         | Azerbaijan               | $ 0.61            |
+| +973         | Bahrain                  | $ 0.06            |
+| +880         | Bangladesh               | $ 0.70            |
+| +375         | Belarus                  | $ 0.36            |
+| +32          | Belgium                  | $ 0.16            |
+| +501         | Belize                   | $ 0.49            |
+| +229         | Benin                    | $ 0.44            |
+| +975         | Bhutan                   | $ 0.53            |
+| +591         | Bolivia                  | $ 0.35            |
+| +387         | Bosnia and Herzegovina   | $ 0.09            |
+| +267         | Botswana                 | $ 0.15            |
+| +55          | Brazil                   | $ 0.05            |
+| +673         | Brunei                   | $ 0.10            |
+| +359         | Bulgaria                 | $ 0.26            |
+| +226         | Burkina Faso             | $ 0.38            |
+| +257         | Burundi                  | $ 0.62            |
+| +855         | Cambodia                 | $ 0.64            |
+| +237         | Cameroon                 | $ 0.43            |
+| +238         | Cape Verde Islands       | $ 0.32            |
+| +56          | Chile                    | $ 0.04            |
+| +86          | China                    | $ 0.04            |
+| +57          | Colombia                 | $ 0.06            |
+| +269         | Comoros and Mayotte      | $ 0.61            |
+| +242         | Congo                    | $ 0.44            |
+| +682         | Cook Islands             | $ 0.19            |
+| +506         | Costa Rica               | $ 0.24            |
+| +385         | Croatia                  | $ 0.21            |
+| +53          | Cuba                     | $ 0.12            |
+| +357         | Cyprus                   | $ 0.02            |
+| +420         | Czech Republic           | $ 0.10            |
+| +45          | Denmark                  | $ 0.09            |
+| +253         | Djibouti                 | $ 0.21            |
+| +593         | Ecuador                  | $ 0.36            |
+| +20          | Egypt                    | $ 0.61            |
+| +503         | El Salvador              | $ 0.12            |
+| +240         | Equatorial Guinea        | $ 0.32            |
 | +291         | Eritrea                  | $ 0.17            |
-| +372         | Estonia                  | $ 0.06            |
-| +251         | Ethiopia                 | $ 0.41            |
-| +500         | Falkland Islands         | $ 0.11            |
-| +298         | Faroe Islands            | $ 0.07            |
-| +679         | Fiji                     | $ 0.24            |
-| +358         | Finland                  | $ 0.10            |
-| +33          | France                   | $ 0.08            |
-| +594         | French Guiana            | $ 0.15            |
-| +689         | French Polynesia         | $ 0.12            |
-| +241         | Gabon                    | $ 0.34            |
-| +220         | Gambia                   | $ 0.11            |
-| +995         | Georgia                  | $ 0.16            |
-| +49          | Germany                  | $ 0.11            |
-| +233         | Ghana                    | $ 0.37            |
-| +350         | Gibraltar                | $ 0.10            |
-| +30          | Greece                   | $ 0.06            |
-| +299         | Greenland                | $ 0.04            |
-| +590         | Guadeloupe               | $ 0.17            |
-| +1671        | Guam                     | $ 0.04            |
-| +502         | Guatemala                | $ 0.25            |
-| +224         | Guinea                   | $ 0.30            |
-| +245         | Guinea-Bissau            | $ 0.30            |
-| +592         | Guyana                   | $ 0.25            |
-| +509         | Haiti                    | $ 0.38            |
-| +504         | Honduras                 | $ 0.27            |
-| +852         | Hong Kong                | $ 0.07            |
-| +36          | Hungary                  | $ 0.08            |
-| +354         | Iceland                  | $ 0.08            |
+| +372         | Estonia                  | $ 0.08            |
+| +251         | Ethiopia                 | $ 0.57            |
+| +500         | Falkland Islands         | $ 0.15            |
+| +298         | Faroe Islands            | $ 0.10            |
+| +679         | Fiji                     | $ 0.33            |
+| +358         | Finland                  | $ 0.13            |
+| +33          | France                   | $ 0.11            |
+| +594         | French Guiana            | $ 0.21            |
+| +689         | French Polynesia         | $ 0.16            |
+| +241         | Gabon                    | $ 0.47            |
+| +220         | Gambia                   | $ 0.15            |
+| +995         | Georgia                  | $ 0.22            |
+| +49          | Germany                  | $ 0.15            |
+| +233         | Ghana                    | $ 0.51            |
+| +350         | Gibraltar                | $ 0.13            |
+| +30          | Greece                   | $ 0.08            |
+| +299         | Greenland                | $ 0.05            |
+| +590         | Guadeloupe               | $ 0.24            |
+| +1671        | Guam                     | $ 0.05            |
+| +502         | Guatemala                | $ 0.35            |
+| +224         | Guinea                   | $ 0.42            |
+| +245         | Guinea-Bissau            | $ 0.41            |
+| +592         | Guyana                   | $ 0.34            |
+| +509         | Haiti                    | $ 0.52            |
+| +504         | Honduras                 | $ 0.37            |
+| +852         | Hong Kong                | $ 0.09            |
+| +36          | Hungary                  | $ 0.12            |
+| +354         | Iceland                  | $ 0.11            |
 | +91          | India                    | $ 0.003           |
-| +62          | Indonesia                | $ 0.47            |
-| +98          | Iran                     | $ 0.32            |
-| +964         | Iraq                     | $ 0.46            |
-| +353         | Ireland                  | $ 0.09            |
+| +62          | Indonesia                | $ 0.65            |
+| +98          | Iran                     | $ 0.44            |
+| +964         | Iraq                     | $ 0.63            |
+| +353         | Ireland                  | $ 0.13            |
 | +972         | Israel                   | $ 0.01            |
-| +39          | Italy                    | $ 0.06            |
-| +81          | Japan                    | $ 0.07            |
-| +962         | Jordan                   | $ 0.47            |
-| +254         | Kenya                    | $ 0.31            |
+| +39          | Italy                    | $ 0.08            |
+| +81          | Japan                    | $ 0.10            |
+| +962         | Jordan                   | $ 0.64            |
+| +254         | Kenya                    | $ 0.42            |
 | +686         | Kiribati                 | $ 0.08            |
 | +850         | North Korea              | $ 0.03            |
 | +82          | South Korea              | $ 0.03            |
-| +965         | Kuwait                   | $ 0.24            |
-| +996         | Kyrgyzstan               | $ 0.40            |
+| +965         | Kuwait                   | $ 0.33            |
+| +996         | Kyrgyzstan               | $ 0.55            |
 | +856         | Laos                     | $ 0.19            |
-| +371         | Latvia                   | $ 0.07            |
-| +961         | Lebanon                  | $ 0.35            |
-| +266         | Lesotho                  | $ 0.13            |
-| +231         | Liberia                  | $ 0.31            |
-| +218         | Libya                    | $ 0.49            |
-| +423         | Liechtenstein            | $ 0.04            |
-| +370         | Lithuania                | $ 0.06            |
-| +352         | Luxembourg               | $ 0.10            |
+| +371         | Latvia                   | $ 0.10            |
+| +961         | Lebanon                  | $ 0.48            |
+| +266         | Lesotho                  | $ 0.18            |
+| +231         | Liberia                  | $ 0.42            |
+| +218         | Libya                    | $ 0.67            |
+| +423         | Liechtenstein            | $ 0.06            |
+| +370         | Lithuania                | $ 0.08            |
+| +352         | Luxembourg               | $ 0.14            |
 | +853         | Macao                    | $ 0.04            |
-| +389         | Macedonia                | $ 0.05            |
-| +261         | Madagascar               | $ 0.50            |
-| +265         | Malawi                   | $ 0.33            |
-| +60          | Malaysia                 | $ 0.27            |
-| +960         | Maldives                 | $ 0.36            |
-| +223         | Mali                     | $ 0.29            |
-| +356         | Malta                    | $ 0.07            |
+| +389         | Macedonia                | $ 0.07            |
+| +261         | Madagascar               | $ 0.70            |
+| +265         | Malawi                   | $ 0.45            |
+| +60          | Malaysia                 | $ 0.45            |
+| +960         | Maldives                 | $ 0.49            |
+| +223         | Mali                     | $ 0.40            |
+| +356         | Malta                    | $ 0.09            |
 | +692         | Marshall Islands         | $ 0.03            |
-| +596         | Martinique               | $ 0.17            |
-| +222         | Mauritania               | $ 0.24            |
-| +52          | Mexico                   | $ 0.29            |
+| +596         | Martinique               | $ 0.23            |
+| +222         | Mauritania               | $ 0.33            |
+| +52          | Mexico                   | $ 0.40            |
 | +691         | Micronesia               | $ 0.03            |
-| +373         | Moldova                  | $ 0.09            |
-| +377         | Monaco                   | $ 0.11            |
-| +976         | Mongolia                 | $ 0.37            |
-| +212         | Morocco                  | $ 0.29            |
-| +258         | Mozambique               | $ 0.24            |
-| +95          | Myanmar                  | $ 0.48            |
-| +264         | Namibia                  | $ 0.06            |
-| +674         | Nauru                    | $ 0.23            |
-| +977         | Nepal                    | $ 0.38            |
-| +31          | Netherlands              | $ 0.12            |
-| +687         | New Caledonia            | $ 0.10            |
-| +64          | New Zealand              | $ 0.09            |
-| +505         | Nicaragua                | $ 0.18            |
-| +227         | Niger                    | $ 0.35            |
-| +234         | Nigeria                  | $ 0.50            |
+| +373         | Moldova                  | $ 0.12            |
+| +377         | Monaco                   | $ 0.14            |
+| +976         | Mongolia                 | $ 0.51            |
+| +212         | Morocco                  | $ 0.40            |
+| +258         | Mozambique               | $ 0.33            |
+| +95          | Myanmar                  | $ 0.66            |
+| +264         | Namibia                  | $ 0.08            |
+| +674         | Nauru                    | $ 0.32            |
+| +977         | Nepal                    | $ 0.53            |
+| +31          | Netherlands              | $ 0.17            |
+| +687         | New Caledonia            | $ 0.14            |
+| +64          | New Zealand              | $ 0.12            |
+| +505         | Nicaragua                | $ 0.24            |
+| +227         | Niger                    | $ 0.48            |
+| +234         | Nigeria                  | $ 0.69            |
 | +683         | Niue                     | $ 0.05            |
-| +672         | Norfolk Islands          | $ 0.06            |
-| +1           | North America            | $ 0.01            |
+| +672         | Norfolk Islands          | $ 0.08            |
+| +1           | North America            | $ 0.02            |
 | +1670        | Northern Mariana Islands | $ 0.11            |
-| +47          | Norway                   | $ 0.09            |
-| +968         | Oman                     | $ 0.21            |
-| +680         | Palau                    | $ 0.10            |
-| +92          | Pakistan                 | $ 0.47            |
-| +507         | Panama                   | $ 0.18            |
-| +675         | Papua New Guinea         | $ 0.21            |
-| +595         | Paraguay                 | $ 0.10            |
-| +51          | Peru                     | $ 0.04            |
-| +63          | Philippines              | $ 0.28            |
-| +48          | Poland                   | $ 0.04            |
-| +351         | Portugal                 | $ 0.03            |
-| +974         | Qatar                    | $ 0.27            |
-| +262         | Reunion                  | $ 0.07            |
-| +40          | Romania                  | $ 0.07            |
-| +7           | Russia and Kazakhstan    | $ 0.42            |
-| +250         | Rwanda                   | $ 0.40            |
+| +47          | Norway                   | $ 0.12            |
+| +968         | Oman                     | $ 0.28            |
+| +680         | Palau                    | $ 0.13            |
+| +92          | Pakistan                 | $ 0.65            |
+| +507         | Panama                   | $ 0.25            |
+| +675         | Papua New Guinea         | $ 0.29            |
+| +595         | Paraguay                 | $ 0.14            |
+| +51          | Peru                     | $ 0.05            |
+| +63          | Philippines              | $ 0.38            |
+| +48          | Poland                   | $ 0.05            |
+| +351         | Portugal                 | $ 0.04            |
+| +974         | Qatar                    | $ 0.38            |
+| +262         | Reunion                  | $ 0.10            |
+| +40          | Romania                  | $ 0.09            |
+| +7           | Russia and Kazakhstan    | $ 0.58            |
+| +250         | Rwanda                   | $ 0.55            |
 | +378         | San Marino               | $ 0.06            |
 | +239         | Sao Tome and Principe    | $ 0.11            |
-| +966         | Saudi Arabia             | $ 0.27            |
-| +221         | Senegal                  | $ 0.38            |
-| +381         | Serbia                   | $ 0.37            |
-| +248         | Seychelles               | $ 0.35            |
-| +232         | Sierra Leone             | $ 0.28            |
-| +65          | Singapore                | $ 0.07            |
-| +421         | Slovak Republic          | $ 0.07            |
-| +386         | Slovenia                 | $ 0.15            |
-| +677         | Solomon Islands          | $ 0.10            |
-| +252         | Somalia                  | $ 0.20            |
-| +27          | South Africa             | $ 0.13            |
-| +34          | Spain                    | $ 0.06            |
-| +94          | Sri Lanka                | $ 0.49            |
+| +966         | Saudi Arabia             | $ 0.37            |
+| +221         | Senegal                  | $ 0.52            |
+| +381         | Serbia                   | $ 0.52            |
+| +248         | Seychelles               | $ 0.48            |
+| +232         | Sierra Leone             | $ 0.39            |
+| +65          | Singapore                | $ 0.10            |
+| +421         | Slovak Republic          | $ 0.10            |
+| +386         | Slovenia                 | $ 0.20            |
+| +677         | Solomon Islands          | $ 0.13            |
+| +252         | Somalia                  | $ 0.27            |
+| +27          | South Africa             | $ 0.18            |
+| +34          | Spain                    | $ 0.08            |
+| +94          | Sri Lanka                | $ 0.67            |
 | +290         | St. Helena               | $ 0.06            |
-| +249         | Sudan                    | $ 0.39            |
-| +597         | Suriname                 | $ 0.22            |
+| +249         | Sudan                    | $ 0.53            |
+| +597         | Suriname                 | $ 0.30            |
 | +268         | Swaziland                | $ 0.13            |
-| +46          | Sweden                   | $ 0.07            |
-| +41          | Switzerland              | $ 0.05            |
-| +963         | Syria                    | $ 0.49            |
-| +886         | Taiwan                   | $ 0.07            |
-| +992         | Tajikistan               | $ 0.46            |
-| +255         | Tanzania                 | $ 0.40            |
-| +66          | Thailand                 | $ 0.03            |
-| +228         | Togo                     | $ 0.43            |
-| +676         | Tonga                    | $ 0.20            |
-| +216         | Tunisia                  | $ 0.44            |
+| +46          | Sweden                   | $ 0.10            |
+| +41          | Switzerland              | $ 0.07            |
+| +963         | Syria                    | $ 0.67            |
+| +886         | Taiwan                   | $ 0.09            |
+| +992         | Tajikistan               | $ 0.64            |
+| +255         | Tanzania                 | $ 0.55            |
+| +66          | Thailand                 | $ 0.04            |
+| +228         | Togo                     | $ 0.60            |
+| +676         | Tonga                    | $ 0.28            |
+| +216         | Tunisia                  | $ 0.61            |
 | +90          | Turkey                   | $ 0.01            |
-| +993         | Turkmenistan             | $ 0.32            |
+| +993         | Turkmenistan             | $ 0.44            |
 | +688         | Tuvalu                   | $ 0.13            |
-| +256         | Uganda                   | $ 0.33            |
-| +380         | Ukraine                  | $ 0.20            |
-| +971         | United Arab Emirates     | $ 0.13            |
-| +44          | United Kingdom           | $ 0.07            |
-| +598         | Uruguay                  | $ 0.09            |
-| +998         | Uzbekistan               | $ 0.52            |
-| +678         | Vanuatu                  | $ 0.23            |
-| +58          | Venezuela                | $ 0.36            |
-| +84          | Vietnam                  | $ 0.23            |
-| +967         | Yemen                    | $ 0.28            |
-| +260         | Zambia                   | $ 0.38            |
-| +263         | Zimbabwe                 | $ 0.25            |
+| +256         | Uganda                   | $ 0.46            |
+| +380         | Ukraine                  | $ 0.28            |
+| +971         | United Arab Emirates     | $ 0.18            |
+| +44          | United Kingdom           | $ 0.09            |
+| +598         | Uruguay                  | $ 0.13            |
+| +998         | Uzbekistan               | $ 0.72            |
+| +678         | Vanuatu                  | $ 0.31            |
+| +58          | Venezuela                | $ 0.49            |
+| +84          | Vietnam                  | $ 0.32            |
+| +967         | Yemen                    | $ 0.38            |
+| +260         | Zambia                   | $ 0.52            |
+| +263         | Zimbabwe                 | $ 0.36            |


### PR DESCRIPTION
## Summary

Refresh the SMS pricing table on https://appwrite.io/docs/advanced/platform/phone-otp.

Source-of-truth pricing was regenerated in [appwrite-labs/cloud#4071](https://github.com/appwrite-labs/cloud/pull/4071):
- MSG91 scraper origin switched from US to India to match our actual dispatch path
- Scraper pinned to MSG91 route `4` (Transactional) rather than route `106` (International / Service-Implicit), since customer Flow-API templates dispatch on route `4`

Table content was produced by running the existing `task-create-sms-pricing-table` task against the updated pricing config and pasted verbatim. No other content on the page changed.

## Aggregate impact (displayed prices, including margin)

- 189 countries shown — 165 up, 0 down, 24 unchanged at 2-decimal display precision
- Basket sum across displayed prices: **$38.17 → $46.57 (+22.0%)**
- North America (`+1`) doubles ($0.01 → $0.02) — it loses its previous US-domestic discount now that were routing from India
- India (`+91`) stays at $0.003 — it was already manually set to the domestic rate in the old table
- The remaining ~170 international destinations move up by ~20–35%, with the cluster centered around +25% as expected for India-outbound Transactional routing

## Per-country delta

Sorted by % change, descending. Prices are USD per SMS, displayed at the same precision the page uses (2 decimals for ≥$0.01, 3 decimals below).

| Code | Country | Old ($) | New ($) | Δ ($) | Δ % |
|------|---------|--------:|--------:|------:|----:|
| +357 | Cyprus | 0.010 | 0.020 | +0.010 | +100.0% |
| +1 | North America | 0.010 | 0.020 | +0.010 | +100.0% |
| +60 | Malaysia | 0.270 | 0.400 | +0.130 | +48.1% |
| +389 | Macedonia | 0.050 | 0.070 | +0.020 | +40.0% |
| +43 | Austria | 0.030 | 0.040 | +0.010 | +33.3% |
| +56 | Chile | 0.030 | 0.040 | +0.010 | +33.3% |
| +351 | Portugal | 0.030 | 0.040 | +0.010 | +33.3% |
| +352 | Luxembourg | 0.100 | 0.130 | +0.030 | +30.0% |
| +673 | Brunei | 0.070 | 0.090 | +0.020 | +28.6% |
| +420 | Czech Republic | 0.070 | 0.090 | +0.020 | +28.6% |
| +298 | Faroe Islands | 0.070 | 0.090 | +0.020 | +28.6% |
| +81 | Japan | 0.070 | 0.090 | +0.020 | +28.6% |
| +371 | Latvia | 0.070 | 0.090 | +0.020 | +28.6% |
| +262 | Reunion | 0.070 | 0.090 | +0.020 | +28.6% |
| +65 | Singapore | 0.070 | 0.090 | +0.020 | +28.6% |
| +421 | Slovak Republic | 0.070 | 0.090 | +0.020 | +28.6% |
| +46 | Sweden | 0.070 | 0.090 | +0.020 | +28.6% |
| +263 | Zimbabwe | 0.250 | 0.320 | +0.070 | +28.0% |
| +376 | Andorra | 0.110 | 0.140 | +0.030 | +27.3% |
| +49 | Germany | 0.110 | 0.140 | +0.030 | +27.3% |
| +253 | Djibouti | 0.150 | 0.190 | +0.040 | +26.7% |
| +594 | French Guiana | 0.150 | 0.190 | +0.040 | +26.7% |
| +674 | Nauru | 0.230 | 0.290 | +0.060 | +26.1% |
| +226 | Burkina Faso | 0.270 | 0.340 | +0.070 | +25.9% |
| +974 | Qatar | 0.270 | 0.340 | +0.070 | +25.9% |
| +61 | Australia | 0.040 | 0.050 | +0.010 | +25.0% |
| +973 | Bahrain | 0.040 | 0.050 | +0.010 | +25.0% |
| +55 | Brazil | 0.040 | 0.050 | +0.010 | +25.0% |
| +57 | Colombia | 0.040 | 0.050 | +0.010 | +25.0% |
| +33 | France | 0.080 | 0.100 | +0.020 | +25.0% |
| +995 | Georgia | 0.160 | 0.200 | +0.040 | +25.0% |
| +36 | Hungary | 0.080 | 0.100 | +0.020 | +25.0% |
| +354 | Iceland | 0.080 | 0.100 | +0.020 | +25.0% |
| +423 | Liechtenstein | 0.040 | 0.050 | +0.010 | +25.0% |
| +244 | Angola | 0.120 | 0.150 | +0.030 | +25.0% |
| +965 | Kuwait | 0.240 | 0.300 | +0.060 | +25.0% |
| +222 | Mauritania | 0.240 | 0.300 | +0.060 | +25.0% |
| +31 | Netherlands | 0.120 | 0.150 | +0.030 | +25.0% |
| +676 | Tonga | 0.200 | 0.250 | +0.050 | +25.0% |
| +380 | Ukraine | 0.200 | 0.250 | +0.050 | +25.0% |
| +232 | Sierra Leone | 0.280 | 0.350 | +0.070 | +25.0% |
| +251 | Ethiopia | 0.410 | 0.510 | +0.100 | +24.4% |
| +976 | Mongolia | 0.370 | 0.460 | +0.090 | +24.3% |
| +381 | Serbia | 0.370 | 0.460 | +0.090 | +24.3% |
| +256 | Uganda | 0.330 | 0.410 | +0.080 | +24.2% |
| +223 | Mali | 0.290 | 0.360 | +0.070 | +24.1% |
| +212 | Morocco | 0.290 | 0.360 | +0.070 | +24.1% |
| +880 | Bangladesh | 0.500 | 0.620 | +0.120 | +24.0% |
| +591 | Bolivia | 0.250 | 0.310 | +0.060 | +24.0% |
| +502 | Guatemala | 0.250 | 0.310 | +0.060 | +24.0% |
| +592 | Guyana | 0.250 | 0.310 | +0.060 | +24.0% |
| +261 | Madagascar | 0.500 | 0.620 | +0.120 | +24.0% |
| +855 | Cambodia | 0.460 | 0.570 | +0.110 | +23.9% |
| +992 | Tajikistan | 0.460 | 0.570 | +0.110 | +23.9% |
| +675 | Papua New Guinea | 0.210 | 0.260 | +0.050 | +23.8% |
| +7 | Russia and Kazakhstan | 0.420 | 0.520 | +0.100 | +23.8% |
| +975 | Bhutan | 0.380 | 0.470 | +0.090 | +23.7% |
| +509 | Haiti | 0.380 | 0.470 | +0.090 | +23.7% |
| +977 | Nepal | 0.380 | 0.470 | +0.090 | +23.7% |
| +241 | Gabon | 0.340 | 0.420 | +0.080 | +23.5% |
| +590 | Guadeloupe | 0.170 | 0.210 | +0.040 | +23.5% |
| +596 | Martinique | 0.170 | 0.210 | +0.040 | +23.5% |
| +62 | Indonesia | 0.470 | 0.580 | +0.110 | +23.4% |
| +92 | Pakistan | 0.470 | 0.580 | +0.110 | +23.4% |
| +224 | Guinea | 0.300 | 0.370 | +0.070 | +23.3% |
| +245 | Guinea-Bissau | 0.300 | 0.370 | +0.070 | +23.3% |
| +228 | Togo | 0.430 | 0.530 | +0.100 | +23.3% |
| +375 | Belarus | 0.260 | 0.320 | +0.060 | +23.1% |
| +593 | Ecuador | 0.260 | 0.320 | +0.060 | +23.1% |
| +266 | Lesotho | 0.130 | 0.160 | +0.030 | +23.1% |
| +27 | South Africa | 0.130 | 0.160 | +0.030 | +23.1% |
| +971 | United Arab Emirates | 0.130 | 0.160 | +0.030 | +23.1% |
| +998 | Uzbekistan | 0.520 | 0.640 | +0.120 | +23.1% |
| +249 | Sudan | 0.390 | 0.480 | +0.090 | +23.1% |
| +95 | Myanmar | 0.480 | 0.590 | +0.110 | +22.9% |
| +501 | Belize | 0.350 | 0.430 | +0.080 | +22.9% |
| +248 | Seychelles | 0.350 | 0.430 | +0.080 | +22.9% |
| +994 | Azerbaijan | 0.440 | 0.540 | +0.100 | +22.7% |
| +269 | Comoros and Mayotte | 0.440 | 0.540 | +0.100 | +22.7% |
| +20 | Egypt | 0.440 | 0.540 | +0.100 | +22.7% |
| +597 | Suriname | 0.220 | 0.270 | +0.050 | +22.7% |
| +216 | Tunisia | 0.440 | 0.540 | +0.100 | +22.7% |
| +213 | Algeria | 0.310 | 0.380 | +0.070 | +22.6% |
| +237 | Cameroon | 0.310 | 0.380 | +0.070 | +22.6% |
| +254 | Kenya | 0.310 | 0.380 | +0.070 | +22.6% |
| +231 | Liberia | 0.310 | 0.380 | +0.070 | +22.6% |
| +996 | Kyrgyzstan | 0.400 | 0.490 | +0.090 | +22.5% |
| +250 | Rwanda | 0.400 | 0.490 | +0.090 | +22.5% |
| +255 | Tanzania | 0.400 | 0.490 | +0.090 | +22.5% |
| +218 | Libya | 0.490 | 0.600 | +0.110 | +22.4% |
| +94 | Sri Lanka | 0.490 | 0.600 | +0.110 | +22.4% |
| +963 | Syria | 0.490 | 0.600 | +0.110 | +22.4% |
| +257 | Burundi | 0.450 | 0.550 | +0.100 | +22.2% |
| +506 | Costa Rica | 0.180 | 0.220 | +0.040 | +22.2% |
| +53 | Cuba | 0.090 | 0.110 | +0.020 | +22.2% |
| +503 | El Salvador | 0.090 | 0.110 | +0.020 | +22.2% |
| +353 | Ireland | 0.090 | 0.110 | +0.020 | +22.2% |
| +960 | Maldives | 0.360 | 0.440 | +0.080 | +22.2% |
| +373 | Moldova | 0.090 | 0.110 | +0.020 | +22.2% |
| +64 | New Zealand | 0.090 | 0.110 | +0.020 | +22.2% |
| +47 | Norway | 0.090 | 0.110 | +0.020 | +22.2% |
| +507 | Panama | 0.180 | 0.220 | +0.040 | +22.2% |
| +598 | Uruguay | 0.090 | 0.110 | +0.020 | +22.2% |
| +58 | Venezuela | 0.360 | 0.440 | +0.080 | +22.2% |
| +504 | Honduras | 0.270 | 0.330 | +0.060 | +22.2% |
| +966 | Saudi Arabia | 0.270 | 0.330 | +0.060 | +22.2% |
| +234 | Nigeria | 0.500 | 0.610 | +0.110 | +22.0% |
| +229 | Benin | 0.320 | 0.390 | +0.070 | +21.9% |
| +242 | Congo | 0.320 | 0.390 | +0.070 | +21.9% |
| +98 | Iran | 0.320 | 0.390 | +0.070 | +21.9% |
| +993 | Turkmenistan | 0.320 | 0.390 | +0.070 | +21.9% |
| +238 | Cape Verde Islands | 0.230 | 0.280 | +0.050 | +21.7% |
| +240 | Equatorial Guinea | 0.230 | 0.280 | +0.050 | +21.7% |
| +964 | Iraq | 0.460 | 0.560 | +0.100 | +21.7% |
| +678 | Vanuatu | 0.230 | 0.280 | +0.050 | +21.7% |
| +84 | Vietnam | 0.230 | 0.280 | +0.050 | +21.7% |
| +233 | Ghana | 0.370 | 0.450 | +0.080 | +21.6% |
| +682 | Cook Islands | 0.140 | 0.170 | +0.030 | +21.4% |
| +63 | Philippines | 0.280 | 0.340 | +0.060 | +21.4% |
| +967 | Yemen | 0.280 | 0.340 | +0.060 | +21.4% |
| +962 | Jordan | 0.470 | 0.570 | +0.100 | +21.3% |
| +265 | Malawi | 0.330 | 0.400 | +0.070 | +21.2% |
| +359 | Bulgaria | 0.190 | 0.230 | +0.040 | +21.1% |
| +221 | Senegal | 0.380 | 0.460 | +0.080 | +21.1% |
| +260 | Zambia | 0.380 | 0.460 | +0.080 | +21.1% |
| +374 | Armenia | 0.240 | 0.290 | +0.050 | +20.8% |
| +679 | Fiji | 0.240 | 0.290 | +0.050 | +20.8% |
| +258 | Mozambique | 0.240 | 0.290 | +0.050 | +20.8% |
| +297 | Aruba | 0.290 | 0.350 | +0.060 | +20.7% |
| +52 | Mexico | 0.290 | 0.350 | +0.060 | +20.7% |
| +961 | Lebanon | 0.350 | 0.420 | +0.070 | +20.0% |
| +227 | Niger | 0.350 | 0.420 | +0.070 | +20.0% |
| +386 | Slovenia | 0.150 | 0.180 | +0.030 | +20.0% |
| +358 | Finland | 0.100 | 0.120 | +0.020 | +20.0% |
| +350 | Gibraltar | 0.100 | 0.120 | +0.020 | +20.0% |
| +687 | New Caledonia | 0.100 | 0.120 | +0.020 | +20.0% |
| +680 | Palau | 0.100 | 0.120 | +0.020 | +20.0% |
| +595 | Paraguay | 0.100 | 0.120 | +0.020 | +20.0% |
| +677 | Solomon Islands | 0.100 | 0.120 | +0.020 | +20.0% |
| +252 | Somalia | 0.200 | 0.240 | +0.040 | +20.0% |
| +41 | Switzerland | 0.050 | 0.060 | +0.010 | +20.0% |
| +968 | Oman | 0.210 | 0.250 | +0.040 | +19.0% |
| +385 | Croatia | 0.160 | 0.190 | +0.030 | +18.8% |
| +267 | Botswana | 0.110 | 0.130 | +0.020 | +18.2% |
| +500 | Falkland Islands | 0.110 | 0.130 | +0.020 | +18.2% |
| +220 | Gambia | 0.110 | 0.130 | +0.020 | +18.2% |
| +377 | Monaco | 0.110 | 0.130 | +0.020 | +18.2% |
| +54 | Argentina | 0.120 | 0.140 | +0.020 | +16.7% |
| +32 | Belgium | 0.120 | 0.140 | +0.020 | +16.7% |
| +372 | Estonia | 0.060 | 0.070 | +0.010 | +16.7% |
| +689 | French Polynesia | 0.120 | 0.140 | +0.020 | +16.7% |
| +30 | Greece | 0.060 | 0.070 | +0.010 | +16.7% |
| +39 | Italy | 0.060 | 0.070 | +0.010 | +16.7% |
| +370 | Lithuania | 0.060 | 0.070 | +0.010 | +16.7% |
| +264 | Namibia | 0.060 | 0.070 | +0.010 | +16.7% |
| +672 | Norfolk Islands | 0.060 | 0.070 | +0.010 | +16.7% |
| +34 | Spain | 0.060 | 0.070 | +0.010 | +16.7% |
| +505 | Nicaragua | 0.180 | 0.210 | +0.030 | +16.7% |
| +387 | Bosnia and Herzegovina | 0.070 | 0.080 | +0.010 | +14.3% |
| +45 | Denmark | 0.070 | 0.080 | +0.010 | +14.3% |
| +852 | Hong Kong | 0.070 | 0.080 | +0.010 | +14.3% |
| +356 | Malta | 0.070 | 0.080 | +0.010 | +14.3% |
| +40 | Romania | 0.070 | 0.080 | +0.010 | +14.3% |
| +886 | Taiwan | 0.070 | 0.080 | +0.010 | +14.3% |
| +44 | United Kingdom | 0.070 | 0.080 | +0.010 | +14.3% |
| +86 | China | 0.030 | 0.030 | +0.000 | +0.0% |
| +291 | Eritrea | 0.170 | 0.170 | +0.000 | +0.0% |
| +299 | Greenland | 0.040 | 0.040 | +0.000 | +0.0% |
| +1671 | Guam | 0.040 | 0.040 | +0.000 | +0.0% |
| +91 | India | 0.003 | 0.003 | +0.000 | +0.0% |
| +972 | Israel | 0.010 | 0.010 | +0.000 | +0.0% |
| +686 | Kiribati | 0.080 | 0.080 | +0.000 | +0.0% |
| +850 | North Korea | 0.030 | 0.030 | +0.000 | +0.0% |
| +82 | South Korea | 0.030 | 0.030 | +0.000 | +0.0% |
| +856 | Laos | 0.190 | 0.190 | +0.000 | +0.0% |
| +853 | Macao | 0.040 | 0.040 | +0.000 | +0.0% |
| +692 | Marshall Islands | 0.030 | 0.030 | +0.000 | +0.0% |
| +691 | Micronesia | 0.030 | 0.030 | +0.000 | +0.0% |
| +683 | Niue | 0.050 | 0.050 | +0.000 | +0.0% |
| +1670 | Northern Mariana Islands | 0.110 | 0.110 | +0.000 | +0.0% |
| +51 | Peru | 0.040 | 0.040 | +0.000 | +0.0% |
| +48 | Poland | 0.040 | 0.040 | +0.000 | +0.0% |
| +378 | San Marino | 0.060 | 0.060 | +0.000 | +0.0% |
| +239 | Sao Tome and Principe | 0.110 | 0.110 | +0.000 | +0.0% |
| +290 | St. Helena | 0.060 | 0.060 | +0.000 | +0.0% |
| +268 | Swaziland | 0.130 | 0.130 | +0.000 | +0.0% |
| +66 | Thailand | 0.030 | 0.030 | +0.000 | +0.0% |
| +90 | Turkey | 0.010 | 0.010 | +0.000 | +0.0% |
| +688 | Tuvalu | 0.130 | 0.130 | +0.000 | +0.0% |

## Test plan

- [ ] Page renders without table-layout regressions on `/docs/advanced/platform/phone-otp`
- [ ] Spot-check a few prices against the cloud PR table (which is the source of truth)
- [ ] Confirm only the table region of the markdoc changed (no preamble drift)
