### PR TITLE
Feature Presences API blog and add homepage eyebrow

### DIFF
--- a/src/routes/(marketing)/(components)/hero-banner.svelte
+++ b/src/routes/(marketing)/(components)/hero-banner.svelte
@@ -5,7 +5,7 @@
     type Props = {
         title: string;
         href: string;
-        icon?: Extract<IconType, 'mongo' | 'sparkle'> | 'claude';
+        icon?: Extract<IconType, 'mongo' | 'sparkle'> | 'claude' | 'presences';
         class?: string;
     };
 
@@ -27,6 +27,8 @@
                 class="claude-icon-badge-img"
             />
         </span>
+    {:else if icon === 'presences'}
+        <span class="icon-status-online presences-icon-glyph shrink-0" aria-hidden="true"></span>
     {:else}
         <Icon name="sparkle" class="shrink-0" aria-hidden="true" />
     {/if}
@@ -62,5 +64,11 @@
         display: block;
         width: 0.875rem;
         height: 0.875rem;
+    }
+
+    .presences-icon-glyph {
+        color: #fd366e;
+        font-size: 1rem;
+        line-height: 1;
     }
 </style>

--- a/src/routes/(marketing)/(components)/hero.svelte
+++ b/src/routes/(marketing)/(components)/hero.svelte
@@ -152,14 +152,14 @@
         >
             {#if layoutAside}
                 <HeroBanner
-                    title="Announcing the Presences API"
+                    title="New: Announcing the Presences API"
                     href="/blog/post/announcing-presences-api"
                     icon="presences"
                 />
             {:else}
                 <div class="flex w-full justify-center">
                     <HeroBanner
-                        title="Announcing the Presences API"
+                        title="New: Announcing the Presences API"
                         href="/blog/post/announcing-presences-api"
                         icon="presences"
                     />

--- a/src/routes/(marketing)/(components)/hero.svelte
+++ b/src/routes/(marketing)/(components)/hero.svelte
@@ -152,14 +152,14 @@
         >
             {#if layoutAside}
                 <HeroBanner
-                    title="New: Presences API"
+                    title="Announcing the Presences API"
                     href="/blog/post/announcing-presences-api"
                     icon="presences"
                 />
             {:else}
                 <div class="flex w-full justify-center">
                     <HeroBanner
-                        title="New: Presences API"
+                        title="Announcing the Presences API"
                         href="/blog/post/announcing-presences-api"
                         icon="presences"
                     />

--- a/src/routes/(marketing)/(components)/hero.svelte
+++ b/src/routes/(marketing)/(components)/hero.svelte
@@ -152,16 +152,16 @@
         >
             {#if layoutAside}
                 <HeroBanner
-                    title="New: Appwrite plugin for Claude Code"
-                    href="/blog/post/announcing-appwrite-claude-code-plugin"
-                    icon="claude"
+                    title="New: Presences API"
+                    href="/blog/post/announcing-presences-api"
+                    icon="presences"
                 />
             {:else}
                 <div class="flex w-full justify-center">
                     <HeroBanner
-                        title="New: Appwrite plugin for Claude Code"
-                        href="/blog/post/announcing-appwrite-claude-code-plugin"
-                        icon="claude"
+                        title="New: Presences API"
+                        href="/blog/post/announcing-presences-api"
+                        icon="presences"
                     />
                 </div>
             {/if}

--- a/src/routes/blog/post/announcing-presences-api/+page.markdoc
+++ b/src/routes/blog/post/announcing-presences-api/+page.markdoc
@@ -7,7 +7,7 @@ cover: /images/blog/announcing-presences-api/cover.avif
 timeToRead: 5
 author: aditya-oberai
 category: announcement
-featured: false
+featured: true
 callToAction: true
 faqs:
     - question: "What is the Appwrite Presences API?"


### PR DESCRIPTION
Mark the Presences API blog post as featured so it surfaces on /blog.
Add a homepage hero eyebrow linking to the post, using the Presences API reference glyph.