### PR TITLE
Claude Code official plugin

### DIFF
--- a/src/routes/changelog/(entries)/2026-06-08.markdoc
+++ b/src/routes/changelog/(entries)/2026-06-08.markdoc
@@ -1,0 +1,15 @@
+---
+layout: changelog
+title: "The Appwrite plugin is now in the official Claude marketplace"
+date: 2026-06-08
+---
+
+The [**Appwrite plugin**](https://claude.com/plugins/appwrite) for Claude Code is now listed in the official Claude marketplace. Adding the Appwrite marketplace as a separate step is no longer required, so a single command installs the plugin along with its agent skills and MCP servers for the Appwrite API and documentation:
+
+```bash
+claude plugin install appwrite
+```
+
+{% arrow_link href="/docs/tooling/ai/agents/claude-code" %}
+Learn more
+{% /arrow_link %}

--- a/src/routes/changelog/(entries)/2026-06-08.markdoc
+++ b/src/routes/changelog/(entries)/2026-06-08.markdoc
@@ -7,7 +7,7 @@ date: 2026-06-08
 The [**Appwrite plugin**](https://claude.com/plugins/appwrite) for Claude Code is now listed in the official Claude marketplace. Adding the Appwrite marketplace as a separate step is no longer required, so a single command installs the plugin along with its agent skills and MCP servers for the Appwrite API and documentation:
 
 ```bash
-claude plugin install appwrite
+claude plugin install appwrite@claude-plugins-official
 ```
 
 {% arrow_link href="/docs/tooling/ai/agents/claude-code" %}

--- a/src/routes/docs/tooling/ai/agents/claude-code/+page.markdoc
+++ b/src/routes/docs/tooling/ai/agents/claude-code/+page.markdoc
@@ -6,16 +6,12 @@ description: Learn how to use Claude Code with Appwrite through the Appwrite plu
 
 {% section #install-plugin step=1 title="Install the Appwrite plugin" %}
 
-The fastest way to get started with Appwrite in Claude Code is to install the **Appwrite plugin** from the Appwrite marketplace. The plugin includes agent skills for the CLI and all major SDKs and sets up MCP servers for both the Appwrite API and documentation, giving Claude Code everything it needs to work with your Appwrite projects.
+The fastest way to get started with Appwrite in Claude Code is to install the [**Appwrite plugin**](https://claude.com/plugins/appwrite) from the official marketplace. The plugin includes agent skills for the CLI and all major SDKs and sets up MCP servers for both the Appwrite API and documentation, giving Claude Code everything it needs to work with your Appwrite projects.
 
-To install the plugin, run the following commands in your terminal:
+To install the plugin, run the following command in your terminal:
 
 ```bash
-# Add the marketplace
-claude plugins marketplace add appwrite/claude-plugin
-
-# Install the plugin
-claude plugins install appwrite@appwrite
+claude plugin install appwrite
 
 ```
 

--- a/src/routes/docs/tooling/ai/agents/claude-code/+page.markdoc
+++ b/src/routes/docs/tooling/ai/agents/claude-code/+page.markdoc
@@ -12,7 +12,6 @@ To install the plugin, run the following command in your terminal:
 
 ```bash
 claude plugin install appwrite
-
 ```
 
 Once installed, run Claude Code and configure the plugin:

--- a/src/routes/docs/tooling/ai/agents/claude-code/+page.markdoc
+++ b/src/routes/docs/tooling/ai/agents/claude-code/+page.markdoc
@@ -11,7 +11,7 @@ The fastest way to get started with Appwrite in Claude Code is to install the [*
 To install the plugin, run the following command in your terminal:
 
 ```bash
-claude plugin install appwrite
+claude plugin install appwrite@claude-plugins-official
 ```
 
 Once installed, run Claude Code and configure the plugin:


### PR DESCRIPTION
The Appwrite plugin for Claude Code is now listed in the official Claude marketplace, so installation is a single `claude plugin install appwrite` command with no separate marketplace to add. Updates the Claude Code docs accordingly and adds a changelog entry.