### PR TITLE
fix(self-hosting): add missing worker-executions service to compose generator

### DIFF
--- a/src/lib/components/compose-generator/composeData.ts
+++ b/src/lib/components/compose-generator/composeData.ts
@@ -664,6 +664,35 @@ services:
       - _APP_DOCKER_HUB_PASSWORD
       - _APP_LOGGING_CONFIG
 
+  appwrite-worker-executions:
+    image: appwrite/appwrite:1.9.0
+    entrypoint: worker-executions
+    <<: *x-logging
+    container_name: appwrite-worker-executions
+    restart: unless-stopped
+    networks:
+      - appwrite
+    depends_on:
+      redis:
+        condition: service_healthy
+      __DB_SERVICE__:
+        condition: service_healthy
+    environment:
+      - _APP_ENV
+      - _APP_WORKER_PER_CORE
+      - _APP_OPENSSL_KEY_V1
+      - _APP_DB_ADAPTER
+      - _APP_DB_HOST
+      - _APP_DB_PORT
+      - _APP_DB_SCHEMA
+      - _APP_DB_USER
+      - _APP_DB_PASS
+      - _APP_REDIS_HOST
+      - _APP_REDIS_PORT
+      - _APP_REDIS_USER
+      - _APP_REDIS_PASS
+      - _APP_LOGGING_CONFIG
+
   appwrite-worker-mails:
     image: appwrite/appwrite:1.9.0
     entrypoint: worker-mails


### PR DESCRIPTION
## What does this PR do?

Adds the missing `appwrite-worker-executions` service to the self-hosting Docker Compose generator.

In Appwrite 1.9.0, execution persistence moved out of the functions worker into a dedicated executions worker (entrypoint `worker-executions`, `Appwrite\Platform\Workers\Executions`) that consumes the `v1-executions` queue and upserts the execution document. The generated compose only includes the `schedule-executions` scheduler — there is no `worker-executions` service — so nothing drains `v1-executions`. As a result, on self-hosted installs:

- **Scheduled** executions are never recorded.
- **Async** executions get stuck in `status: waiting` forever.
- **Synchronous** executions work (the API persists them inline), which masks the issue.

The queue silently accumulates (observed ~46k stranded jobs on an affected instance). Adding the worker drains the backlog immediately and executions persist as `completed`.

## Test Plan

On a self-hosted 1.9.0 install with the added service:
- `docker compose up -d appwrite-worker-executions`
- The `v1-executions` queue drains to 0 and scheduled/async executions appear in the Console with status `completed`.

## Related PRs and Issues

Fixes #3056

The same omission exists in the main `appwrite/appwrite` compose template (`app/views/install/compose.phtml`); a corresponding change there is likely needed too.