### PR TITLE
ci: move production deploy to declarative setup, target default.yaml

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -54,6 +54,9 @@ jobs:
         if: github.event_name != 'release' || !contains(github.event.release.tag_name, '-rc')
         needs: build
         runs-on: ubuntu-latest
+        concurrency:
+            group: declarative-deploy-website
+            cancel-in-progress: false
         steps:
             - name: Get token for ${{ env.DECLARATIVE_REPOSITORY }}
               id: app-token

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -17,17 +17,17 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout the repo
-              uses: actions/checkout@v4
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
             - name: Login to DockerHub
-              uses: docker/login-action@v3
+              uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
               with:
                   registry: ghcr.io
                   username: ${{ github.actor }}
                   password: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Build and push
-              uses: docker/build-push-action@v6
+              uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
               with:
                   context: .
                   push: true
@@ -60,7 +60,7 @@ jobs:
         steps:
             - name: Get token for ${{ env.DECLARATIVE_REPOSITORY }}
               id: app-token
-              uses: actions/create-github-app-token@v2
+              uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
               with:
                   app-id: ${{ vars.DECLARATIVE_DEPLOYMENT_GITHUB_APP_ID }}
                   private-key: ${{ secrets.DECLARATIVE_DEPLOYMENT_GITHUB_APP_PRIVATE_KEY }}
@@ -68,7 +68,7 @@ jobs:
                   repositories: ${{ env.DECLARATIVE_REPOSITORY }}
 
             - name: Checkout ${{ env.DECLARATIVE_REPOSITORY }}
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
               with:
                   repository: ${{ env.DECLARATIVE_OWNER }}/${{ env.DECLARATIVE_REPOSITORY }}
                   token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -10,7 +10,7 @@ env:
     PROJECT: website
     DECLARATIVE_OWNER: appwrite-labs
     DECLARATIVE_REPOSITORY: assets-applications
-    TAG: ${{ github.event.release.tag_name }}
+    TAG: ${{ github.event.release.tag_name || github.sha }}
 
 jobs:
     build:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -83,15 +83,7 @@ jobs:
                   git add ${{ env.ENVIRONMENT }}/${{ env.PROJECT }}/default.yaml
                   if git diff --cached --quiet; then
                     echo "No changes to commit"
-                    exit 0
+                  else
+                    git commit -m "chore(${{ env.ENVIRONMENT }}): ${{ env.PROJECT }} image tag to ${{ env.TAG }}"
+                    git push
                   fi
-                  git commit -m "chore(${{ env.ENVIRONMENT }}): ${{ env.PROJECT }} image tag to ${{ env.TAG }}"
-                  for attempt in 1 2 3 4 5; do
-                    if git push; then
-                      exit 0
-                    fi
-                    echo "Push rejected (attempt $attempt), rebasing onto latest and retrying..."
-                    git pull --rebase
-                  done
-                  echo "Failed to push after 5 attempts" >&2
-                  exit 1

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -80,7 +80,15 @@ jobs:
                   git add ${{ env.ENVIRONMENT }}/${{ env.PROJECT }}/default.yaml
                   if git diff --cached --quiet; then
                     echo "No changes to commit"
-                  else
-                    git commit -m "chore(${{ env.ENVIRONMENT }}): ${{ env.PROJECT }} image tag to ${{ env.TAG }}"
-                    git push
+                    exit 0
                   fi
+                  git commit -m "chore(${{ env.ENVIRONMENT }}): ${{ env.PROJECT }} image tag to ${{ env.TAG }}"
+                  for attempt in 1 2 3 4 5; do
+                    if git push; then
+                      exit 0
+                    fi
+                    echo "Push rejected (attempt $attempt), rebasing onto latest and retrying..."
+                    git pull --rebase
+                  done
+                  echo "Failed to push after 5 attempts" >&2
+                  exit 1

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -6,10 +6,11 @@ on:
     workflow_dispatch:
 
 env:
+    ENVIRONMENT: production
+    PROJECT: website
+    DECLARATIVE_OWNER: appwrite-labs
+    DECLARATIVE_REPOSITORY: assets-applications
     TAG: ${{ github.event.release.tag_name || github.sha }}
-    STACK_FILE: docker/production.yml
-    REPOSITORY: website
-    REGISTRY_USERNAME: christyjacob4
 
 jobs:
     build:
@@ -49,49 +50,37 @@ jobs:
                       "SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}"
                       "SENTRY_RELEASE=${{ github.event.release.tag_name }}"
 
-    deploy_kubernetes:
+    deploy:
         if: github.event_name != 'release' || !contains(github.event.release.tag_name, '-rc')
-        strategy:
-            matrix:
-                region: [{ full: fra1, short: fra }]
         needs: build
         runs-on: ubuntu-latest
         steps:
-            - name: Checkout the repo
-              uses: actions/checkout@v4
-            - name: Install Kubectl
-              uses: azure/setup-kubectl@v4
-            - name: Install Helm
-              uses: azure/setup-helm@v4
-            - name: Install doctl
-              uses: digitalocean/action-doctl@v2
+            - name: Get token for ${{ env.DECLARATIVE_REPOSITORY }}
+              id: app-token
+              uses: actions/create-github-app-token@v2
               with:
-                  token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
-            - name: Save DigitalOcean kubeconfig with short-lived credentials
-              run: doctl kubernetes cluster kubeconfig save --expiry-seconds 600 assets-${{ matrix.region.full }}-prod
+                  app-id: ${{ vars.DECLARATIVE_DEPLOYMENT_GITHUB_APP_ID }}
+                  private-key: ${{ secrets.DECLARATIVE_DEPLOYMENT_GITHUB_APP_PRIVATE_KEY }}
+                  owner: ${{ env.DECLARATIVE_OWNER }}
+                  repositories: ${{ env.DECLARATIVE_REPOSITORY }}
 
-            - name: Ensure namespaces exist
-              run: |
-                  kubectl create namespace website --dry-run=client -o yaml | kubectl apply -f -
+            - name: Checkout ${{ env.DECLARATIVE_REPOSITORY }}
+              uses: actions/checkout@v6
+              with:
+                  repository: ${{ env.DECLARATIVE_OWNER }}/${{ env.DECLARATIVE_REPOSITORY }}
+                  token: ${{ steps.app-token.outputs.token }}
 
-            - name: Create docker pull secret
-              run: |
-                  kubectl -n website create secret docker-registry ghcr \
-                    --docker-server=ghcr.io \
-                    --docker-username=${{ secrets.GHCR_USERNAME }} \
-                    --docker-password=${{ secrets.GHCR_TOKEN }} \
-                    --docker-email=ci@appwrite.io \
-                    --dry-run=client -o yaml | kubectl apply -f -
+            - name: Update image tag
+              run: yq -i '.website.image.tag = strenv(TAG)' ${{ env.ENVIRONMENT }}/${{ env.PROJECT }}/default.yaml
 
-            - name: Create app secrets
+            - name: Commit and push
               run: |
-                  kubectl -n website create secret generic website-secrets \
-                    --from-literal=STATSIG_SERVER_SECRET='${{ secrets.STATSIG_SERVER_SECRET }}' \
-                    --dry-run=client -o yaml | kubectl apply -f -
-
-            - name: Deploy
-              run: |
-                  helm upgrade --install --namespace website website deploy/website/ \
-                    --values deploy/website/environments/production/${{ matrix.region.full }}.values.yaml \
-                    --set imagePullSecret='ghcr' \
-                    --set version=${{ env.TAG }}
+                  git config user.name "github-actions[bot]"
+                  git config user.email "github-actions[bot]@users.noreply.github.com"
+                  git add ${{ env.ENVIRONMENT }}/${{ env.PROJECT }}/default.yaml
+                  if git diff --cached --quiet; then
+                    echo "No changes to commit"
+                  else
+                    git commit -m "chore(${{ env.ENVIRONMENT }}): ${{ env.PROJECT }} image tag to ${{ env.TAG }}"
+                    git push
+                  fi

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -10,7 +10,7 @@ env:
     PROJECT: website
     DECLARATIVE_OWNER: appwrite-labs
     DECLARATIVE_REPOSITORY: assets-applications
-    TAG: ${{ github.event.release.tag_name || github.sha }}
+    TAG: ${{ github.event.release.tag_name }}
 
 jobs:
     build:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -25,24 +25,24 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout the repo
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
             - name: Login to GitHub Container Registry
-              uses: docker/login-action@v3
+              uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
               with:
                   registry: ${{ env.REGISTRY_GITHUB }}
                   username: ${{ github.actor }}
                   password: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Login to Docker Hub
-              uses: docker/login-action@v3
+              uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
               with:
                   registry: ${{ env.REGISTRY_DOCKERHUB }}
                   username: ${{ secrets.DOCKERHUB_USERNAME }}
                   password: ${{ secrets.DOCKERHUB_TOKEN }}
 
             - name: Build and push
-              uses: docker/build-push-action@v6
+              uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
               with:
                   context: .
                   push: true
@@ -75,7 +75,7 @@ jobs:
         steps:
             - name: Get token for ${{ env.DECLARATIVE_REPOSITORY }}
               id: app-token
-              uses: actions/create-github-app-token@v2
+              uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
               with:
                   app-id: ${{ vars.DECLARATIVE_DEPLOYMENT_GITHUB_APP_ID }}
                   private-key: ${{ secrets.DECLARATIVE_DEPLOYMENT_GITHUB_APP_PRIVATE_KEY }}
@@ -83,7 +83,7 @@ jobs:
                   repositories: ${{ env.DECLARATIVE_REPOSITORY }}
 
             - name: Checkout ${{ env.DECLARATIVE_REPOSITORY }}
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
               with:
                   repository: ${{ env.DECLARATIVE_OWNER }}/${{ env.DECLARATIVE_REPOSITORY }}
                   token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -69,6 +69,9 @@ jobs:
     deploy:
         needs: build
         runs-on: ubuntu-latest
+        concurrency:
+            group: declarative-deploy-website
+            cancel-in-progress: false
         steps:
             - name: Get token for ${{ env.DECLARATIVE_REPOSITORY }}
               id: app-token

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -95,7 +95,15 @@ jobs:
                   git add ${{ env.ENVIRONMENT }}/${{ env.PROJECT }}/default.yaml
                   if git diff --cached --quiet; then
                     echo "No changes to commit"
-                  else
-                    git commit -m "chore(${{ env.ENVIRONMENT }}): ${{ env.PROJECT }} image tag to ${{ env.TAG }}"
-                    git push
+                    exit 0
                   fi
+                  git commit -m "chore(${{ env.ENVIRONMENT }}): ${{ env.PROJECT }} image tag to ${{ env.TAG }}"
+                  for attempt in 1 2 3 4 5; do
+                    if git push; then
+                      exit 0
+                    fi
+                    echo "Push rejected (attempt $attempt), rebasing onto latest and retrying..."
+                    git pull --rebase
+                  done
+                  echo "Failed to push after 5 attempts" >&2
+                  exit 1

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -98,15 +98,7 @@ jobs:
                   git add ${{ env.ENVIRONMENT }}/${{ env.PROJECT }}/default.yaml
                   if git diff --cached --quiet; then
                     echo "No changes to commit"
-                    exit 0
+                  else
+                    git commit -m "chore(${{ env.ENVIRONMENT }}): ${{ env.PROJECT }} image tag to ${{ env.TAG }}"
+                    git push
                   fi
-                  git commit -m "chore(${{ env.ENVIRONMENT }}): ${{ env.PROJECT }} image tag to ${{ env.TAG }}"
-                  for attempt in 1 2 3 4 5; do
-                    if git push; then
-                      exit 0
-                    fi
-                    echo "Push rejected (attempt $attempt), rebasing onto latest and retrying..."
-                    git pull --rebase
-                  done
-                  echo "Failed to push after 5 attempts" >&2
-                  exit 1

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -86,13 +86,13 @@ jobs:
                   token: ${{ steps.app-token.outputs.token }}
 
             - name: Update image tag
-              run: yq -i '.website.image.tag = strenv(TAG)' ${{ env.ENVIRONMENT }}/${{ env.PROJECT }}/fra1.yaml
+              run: yq -i '.website.image.tag = strenv(TAG)' ${{ env.ENVIRONMENT }}/${{ env.PROJECT }}/default.yaml
 
             - name: Commit and push
               run: |
                   git config user.name "github-actions[bot]"
                   git config user.email "github-actions[bot]@users.noreply.github.com"
-                  git add ${{ env.ENVIRONMENT }}/${{ env.PROJECT }}/fra1.yaml
+                  git add ${{ env.ENVIRONMENT }}/${{ env.PROJECT }}/default.yaml
                   if git diff --cached --quiet; then
                     echo "No changes to commit"
                   else


### PR DESCRIPTION
## What

Moves the **production** pipeline off the imperative Helm deploy and onto the same **declarative setup** that staging already uses, and points **both** workflows at `default.yaml` instead of `fra1.yaml`.

## Changes

### `production.yml`
- Dropped the `deploy_kubernetes` job (doctl + kubectl + Helm against the DigitalOcean cluster).
- Added a `deploy` job mirroring staging: mint a GitHub App token → checkout `appwrite-labs/assets-applications` → `yq` bump the image tag → commit & push.
- Updated the `env` block: removed the now-unused `STACK_FILE` / `REPOSITORY` / `REGISTRY_USERNAME`; added `ENVIRONMENT`, `PROJECT`, `DECLARATIVE_OWNER`, `DECLARATIVE_REPOSITORY`.
- Preserved the existing `-rc` release guard.

### `staging.yml`
- Repointed the `yq` update and `git add` from `fra1.yaml` to `default.yaml`.

Both pipelines now write the image tag to `${ENVIRONMENT}/website/default.yaml` in the declarative repo.

## Before merging
- [ ] Confirm `vars.DECLARATIVE_DEPLOYMENT_GITHUB_APP_ID` and `secrets.DECLARATIVE_DEPLOYMENT_GITHUB_APP_PRIVATE_KEY` are available in the production context.
- [ ] Ensure `production/website/default.yaml` and `staging/website/default.yaml` exist in `assets-applications` (renamed/copied from `fra1.yaml`) — `yq -i` fails if the file is missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)