### PR TITLE
Hide draft blog posts from listings, feeds, and search

### DIFF
--- a/src/markdoc/layouts/Post.svelte
+++ b/src/markdoc/layouts/Post.svelte
@@ -43,6 +43,8 @@
     export let callToAction: BlogCallToActionInput;
     export let lastUpdated: string;
     export let faqs: { question: string; answer: string }[] | undefined = undefined;
+    /** Frontmatter `draft: true`: the post stays reachable by its direct URL but is hidden from all listings/feeds and marked noindex. */
+    export let draft = false;
 
     const posts = getContext<PostsData[]>('posts')?.filter(
         (post) => !(post.unlisted ?? false) && !(post.draft ?? false)
@@ -133,6 +135,10 @@
 </script>
 
 <svelte:head>
+    {#if draft}
+        <!-- Draft: reachable by direct URL but kept out of search indexes -->
+        <meta name="robots" content="noindex" />
+    {/if}
     <!-- Titles -->
     <title>{resolvedMetaTitle + TITLE_SUFFIX}</title>
     <meta property="og:title" content={resolvedMetaTitle} />

--- a/src/routes/blog/+layout.ts
+++ b/src/routes/blog/+layout.ts
@@ -1,8 +1,8 @@
-import { posts, authors, categories } from './content';
+import { publishedPosts, authors, categories } from './content';
 
 export async function load({ data }) {
     return {
-        posts,
+        posts: publishedPosts,
         authors,
         categories,
         rawContent: data.rawContent

--- a/src/routes/blog/content.ts
+++ b/src/routes/blog/content.ts
@@ -81,6 +81,11 @@ export const posts = Object.entries(postsGlob)
         return b.date.getTime() - a.date.getTime();
     });
 
+// Posts visible to the public. Drafts are excluded everywhere except their own
+// direct URL: the /blog/post/<slug> route still renders a draft (and emits a
+// noindex meta via Post.svelte), but it never appears in any listing or feed.
+export const publishedPosts = posts.filter((post) => !post.draft);
+
 export const authors = Object.values(authorsGlob).map((authorList) => {
     const { frontmatter } = authorList as {
         frontmatter: AuthorData;
@@ -115,12 +120,14 @@ export const normalizeCategory = (str: string) => str?.replace(/\s+/g, '-').toLo
 
 export const getBlogEntries = () => {
     const filteredCategories = categories.filter((category) =>
-        posts.some((post) => normalizeCategory(post.category) === normalizeCategory(category.name))
+        publishedPosts.some(
+            (post) => normalizeCategory(post.category) === normalizeCategory(category.name)
+        )
     );
 
     return {
         authors,
         filteredCategories,
-        posts: posts.filter((post) => !post.unlisted)
+        posts: publishedPosts.filter((post) => !post.unlisted)
     };
 };

--- a/src/routes/blog/feed.json/+server.ts
+++ b/src/routes/blog/feed.json/+server.ts
@@ -1,12 +1,12 @@
 import type { RequestHandler } from './$types';
-import { posts } from '../content';
+import { publishedPosts } from '../content';
 import { json } from '@sveltejs/kit';
 
 export const prerender = true;
 
 export const GET: RequestHandler = () => {
     return json({
-        posts,
-        total: Object.keys(posts).length
+        posts: publishedPosts,
+        total: publishedPosts.length
     });
 };

--- a/src/routes/blog/rss.xml/+server.ts
+++ b/src/routes/blog/rss.xml/+server.ts
@@ -1,5 +1,5 @@
 import type { RequestHandler } from './$types';
-import { posts } from '../content';
+import { publishedPosts } from '../content';
 
 export const prerender = true;
 
@@ -26,7 +26,7 @@ export const GET: RequestHandler = () => {
     <link>https://appwrite.io</link>
     <atom:link href="https://appwrite.io/blog/rss.xml" rel="self" type="application/rss+xml" />
     <description>Appwrite is an open-source platform for building applications at any scale, using your preferred programming languages and tools.</description>
-    ${posts
+    ${publishedPosts
         .map(
             (post) => `<item>
         <title>${encodeText(post.title)}</title>

--- a/src/routes/llms-full.txt/+server.ts
+++ b/src/routes/llms-full.txt/+server.ts
@@ -1,5 +1,6 @@
 import type { RequestHandler } from '@sveltejs/kit';
 import { SPECIAL_PAGES } from '../llms-config';
+import { publishedPosts } from '../blog/content';
 
 export const prerender = true;
 
@@ -8,6 +9,11 @@ const markdocAndMarkdownFiles = import.meta.glob('$routes/**/*.{markdoc,md}', {
     import: 'default',
     eager: true
 });
+
+// Published (non-draft) blog post slugs — the single source of truth for what is public.
+const PUBLISHED_BLOG_SLUGS = new Set(
+    publishedPosts.map((p) => p.href.split('/blog/post/')[1]).filter(Boolean)
+);
 
 function stripRouteGroups(routePath: string): string {
     return routePath.replace(/\([^/]+\)\//g, '');
@@ -126,6 +132,12 @@ ${page.fullContent}
             // Skip stub pages with no useful content
             if (href === '/docs/advanced/integration' || href === '/blog/category/integrations') {
                 continue;
+            }
+
+            // Skip draft blog posts: only include published ones (single source of truth)
+            if (href.startsWith('/blog/post')) {
+                const slug = href.split('/blog/post/')[1]?.replace(/\/+$/, '');
+                if (!slug || !PUBLISHED_BLOG_SLUGS.has(slug)) continue;
             }
 
             const url = new URL(href, base).toString();

--- a/src/routes/llms.txt/+server.ts
+++ b/src/routes/llms.txt/+server.ts
@@ -1,5 +1,6 @@
 import type { RequestHandler } from '@sveltejs/kit';
 import { SPECIAL_PAGES } from '../llms-config';
+import { publishedPosts } from '../blog/content';
 
 export const prerender = true;
 
@@ -9,6 +10,11 @@ const markdocAndMarkdownFiles = import.meta.glob('$routes/**/*.{markdoc,md}', {
     import: 'default',
     eager: true
 });
+
+// Published (non-draft) blog post slugs — the single source of truth for what is public.
+const PUBLISHED_BLOG_SLUGS = new Set(
+    publishedPosts.map((p) => p.href.split('/blog/post/')[1]).filter(Boolean)
+);
 
 // Strip group directories like (marketing) from a route path
 function stripRouteGroups(routePath: string): string {
@@ -146,6 +152,12 @@ export const GET: RequestHandler = ({ request }) => {
             // Skip stub pages with no useful content
             if (href === '/docs/advanced/integration' || href === '/blog/category/integrations') {
                 continue;
+            }
+
+            // Skip draft blog posts: only include published ones (single source of truth)
+            if (href.startsWith('/blog/post')) {
+                const slug = href.split('/blog/post/')[1]?.replace(/\/+$/, '');
+                if (!slug || !PUBLISHED_BLOG_SLUGS.has(slug)) continue;
             }
 
             const url = new URL(href, base).toString();


### PR DESCRIPTION
## What

Makes `draft: true` in a blog post's frontmatter hide the post everywhere except its own direct URL.

A draft post:
- stays reachable at `/blog/post/<slug>` (renders normally)
- is excluded from: the blog listing (plus the featured hero and pagination), author pages, category pages and chips, the "read next" list, RSS (`/blog/rss.xml`), the JSON feed (`/blog/feed.json`), and `llms.txt` / `llms-full.txt`
- emits `<meta name="robots" content="noindex">` so search engines drop it while the URL stays live

## How

A single source of truth: a new `publishedPosts` (non-draft) export in `blog/content.ts`, reused by:
- the blog layout context (covers author pages, category pages, and "read next")
- `getBlogEntries()` for the listing and category chips
- both feeds (`rss.xml`, `feed.json`)
- both `llms` generators (matched by slug)

`Post.svelte` gains a `draft` prop and the conditional `noindex` meta. The post route itself is untouched, so the URL keeps working. `unlisted` behavior is unchanged.

## Testing

- `svelte-check`: 0 errors, 0 warnings
- Verified with a browser (Playwright) and curl: the draft is absent from every listing/feed surface, present only at its direct URL with `noindex`; published posts are unaffected

## Call-outs (not included here)

- The sitemap (`server/sitemap.js`) builds from the route manifest, not frontmatter, so a draft URL can still appear in `sitemap.xml`. `noindex` still prevents indexing; excluding it from the sitemap would be a small follow-up.
- On-site search is handled by an external Meilisearch crawler, which is not guaranteed to skip drafts from this change alone.
