### PR TITLE
Add changelog entry for paused free project deletion

### DIFF
--- a/src/routes/changelog/(entries)/2026-06-29.markdoc
+++ b/src/routes/changelog/(entries)/2026-06-29.markdoc
@@ -1,0 +1,9 @@
+---
+layout: changelog
+title: 'Paused free projects are deleted after 90 days'
+date: 2026-06-29
+---
+
+Free projects are paused after one week of inactivity. A free project that stays paused for 90 days will now be deleted, including all of its resources.
+
+This only applies to projects on free-tier organizations. To keep a paused project, open it in the Appwrite Console to resume it, or upgrade its organization to a paid plan before the 90-day window ends.

--- a/src/routes/changelog/(entries)/2026-06-29.markdoc
+++ b/src/routes/changelog/(entries)/2026-06-29.markdoc
@@ -4,6 +4,8 @@ title: 'Paused free projects are deleted after 90 days'
 date: 2026-06-29
 ---
 
-Free projects are paused after one week of inactivity. A free project that stays paused for 90 days will now be deleted, including all of its resources.
+Starting today, free projects that stay paused for 90 days will be deleted, including all of their resources. Affected projects receive email alerts before anything is deleted.
+
+Reclaiming resources from long-inactive free projects keeps the platform sustainable, affordable, and reliable for everyone building on Appwrite. Projects on Pro and Enterprise plans are never paused or deleted for inactivity, so your production workloads stay untouched.
 
 This only applies to projects on free-tier organizations. To keep a paused project, open it in the Appwrite Console to resume it, or upgrade its organization to a paid plan before the 90-day window ends.


### PR DESCRIPTION
Adds a changelog entry announcing that free projects are deleted after 90 days of being paused.
Changelog only; no other changes.