### PR TITLE
ci: push production image to DockerHub alongside GHCR

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -10,6 +10,9 @@ env:
     PROJECT: website
     DECLARATIVE_OWNER: appwrite-labs
     DECLARATIVE_REPOSITORY: assets-applications
+    REGISTRY_GITHUB: ghcr.io
+    REGISTRY_DOCKERHUB: docker.io
+    IMAGE_NAME: appwrite/website
     TAG: ${{ github.event.release.tag_name || github.sha }}
 
 jobs:
@@ -19,19 +22,28 @@ jobs:
             - name: Checkout the repo
               uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-            - name: Login to DockerHub
+            - name: Login to GitHub Container Registry
               uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
               with:
-                  registry: ghcr.io
+                  registry: ${{ env.REGISTRY_GITHUB }}
                   username: ${{ github.actor }}
                   password: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Login to Docker Hub
+              uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+              with:
+                  registry: ${{ env.REGISTRY_DOCKERHUB }}
+                  username: ${{ secrets.DOCKERHUB_USERNAME }}
+                  password: ${{ secrets.DOCKERHUB_TOKEN }}
 
             - name: Build and push
               uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
               with:
                   context: .
                   push: true
-                  tags: ghcr.io/appwrite/website:${{ env.TAG }}
+                  tags: |
+                      ${{ env.REGISTRY_GITHUB }}/${{ env.IMAGE_NAME }}:${{ env.TAG }}
+                      ${{ env.REGISTRY_DOCKERHUB }}/${{ env.IMAGE_NAME }}:${{ env.TAG }}
                   build-args: |
                       "PUBLIC_APPWRITE_ENDPOINT=${{ vars.PUBLIC_APPWRITE_ENDPOINT }}"
                       "PUBLIC_APPWRITE_DASHBOARD=${{ vars.PUBLIC_APPWRITE_DASHBOARD }}"


### PR DESCRIPTION
## Problem

The production deployment workflow never pushed images to DockerHub. The step named **"Login to DockerHub"** actually had its `registry:` set to `ghcr.io`, so production only ever authenticated against and pushed to GHCR. Staging, meanwhile, already pushes to both registries.

## Changes

- Renamed the existing login step to **"Login to GitHub Container Registry"** (it was always GHCR).
- Added a real **"Login to Docker Hub"** step using the `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` secrets (same as staging).
- Added `REGISTRY_GITHUB`, `REGISTRY_DOCKERHUB`, and `IMAGE_NAME` env vars.
- Build/push now emits both tags:
  - `ghcr.io/appwrite/website:<tag>`
  - `docker.io/appwrite/website:<tag>`

The production-only `SENTRY_RELEASE` build-arg is left untouched.

## Notes

- Relies on the `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` repo secrets being available to release events — staging already uses them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)