### PR TITLE
Add Cloud OAuth consent changelog

### DIFF
--- a/src/routes/changelog/(entries)/2026-07-03.markdoc
+++ b/src/routes/changelog/(entries)/2026-07-03.markdoc
@@ -1,0 +1,11 @@
+---
+layout: changelog
+title: Appwrite Cloud OAuth consent now supports resource-bound authorization
+date: 2026-07-03
+---
+
+Appwrite Cloud's OAuth consent flow now makes requested access easier to review before authorizing a connected app. The consent screen shows a read-only permission summary, grouping requested scopes into clear access rows so users can see what the app is asking for without accidentally changing the requested permission set.
+
+For apps using Rich Authorization Requests, Appwrite Cloud now also lets users bind requested access to specific projects and organizations through `authorization_details`-based resource selection. Users can choose whether project and organization access applies broadly or only to selected resources, and Appwrite sends the resulting resource binding back when the request is approved.
+
+This gives connected apps a clearer consent experience while keeping authorization precise: scopes describe the requested privileges, and `authorization_details` controls which Appwrite Cloud projects or organizations those privileges are bound to.


### PR DESCRIPTION
## Summary
- Add a changelog entry for the Appwrite Cloud OAuth consent redesign with RAR resource binding
- Explain the read-only permission summary and authorization_details-based project and organization selection

## Verification
- Verified wording against ../console PR #3101/#3102 implementation and PR metadata
- Not run: local formatter/checks unavailable because bun and node_modules are not installed in this environment