### PR TITLE
ci: write image tag to global.image.tag

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -86,7 +86,7 @@ jobs:
                   token: ${{ steps.app-token.outputs.token }}
 
             - name: Update image tag
-              run: yq -i '.website.image.tag = strenv(TAG)' ${{ env.ENVIRONMENT }}/${{ env.PROJECT }}/default.yaml
+              run: yq -i '.global.image.tag = strenv(TAG)' ${{ env.ENVIRONMENT }}/${{ env.PROJECT }}/default.yaml
 
             - name: Commit and push
               run: |

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -89,7 +89,7 @@ jobs:
                   token: ${{ steps.app-token.outputs.token }}
 
             - name: Update image tag
-              run: yq -i '.website.image.tag = strenv(TAG)' ${{ env.ENVIRONMENT }}/${{ env.PROJECT }}/default.yaml
+              run: yq -i '.global.image.tag = strenv(TAG)' ${{ env.ENVIRONMENT }}/${{ env.PROJECT }}/default.yaml
 
             - name: Commit and push
               run: |


### PR DESCRIPTION
The applications repo moves `image` to `global.image` (generic chart 1.7.0 — see appwrite-labs/helm-charts#17); this updates the tag-bump automation to write the single canonical path `.global.image.tag` in `default.yaml`.

**Merge order**: land appwrite-labs/assets-applications#29 first. Until then, an old-style per-alias write still overrides `global`, so deploys stay correct in either interim state (a stale per-alias tag key would just need removing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)