### PR TITLE
Clarify Appwrite Auth email policies Cloud availability

### DIFF
--- a/src/partials/auth-security.md
+++ b/src/partials/auth-security.md
@@ -68,9 +68,9 @@ Disallowing personal data can be enabled in the Auth service's **Security** tab 
 
 # Email policies {% #email-policies %}
 
-Email policies let you restrict which email addresses can sign up for your project. You can independently block free email providers, aliased addresses, and disposable email services to keep throwaway accounts, signup spam, and bot registrations out of your user base. Policies run at sign-up and on email updates, and existing users can still sign in even if their address would not pass the current policy.
+Email policies are currently available on Appwrite Cloud only. They let you restrict which email addresses can sign up for your project. You can independently block free email providers, aliased addresses, and disposable email services to keep throwaway accounts, signup spam, and bot registrations out of your user base. Policies run at sign-up and on email updates, and existing users can still sign in even if their address would not pass the current policy.
 
-Email policies can be enabled in the Auth service's **Security** tab on the Appwrite Console, or programmatically through the Project service. Learn more in the [Email policies](/docs/products/auth/email-policies) docs.
+On Appwrite Cloud, email policies can be enabled in the Auth service's **Security** tab on the Appwrite Console, or programmatically through the Project service. Learn more in the [Email policies](/docs/products/auth/email-policies) docs.
 
 # Session alerts {% #session-alerts %}
 

--- a/src/routes/docs/advanced/security/abuse-protection/+page.markdoc
+++ b/src/routes/docs/advanced/security/abuse-protection/+page.markdoc
@@ -19,7 +19,7 @@ Learn more about rate limits
 {% /arrow_link %}
 
 # Email policies {% #email-policies %}
-Email policies let you block sign-ups and email updates from free, aliased, or disposable email providers. This helps keep throwaway accounts, signup spam, and bot registrations out of your project before they reach your authentication and rate-limit layers. Policies run at sign-up time and on email updates, and do not affect existing sessions.
+Email policies are currently available on Appwrite Cloud only. They let you block sign-ups and email updates from free, aliased, or disposable email providers. This helps keep throwaway accounts, signup spam, and bot registrations out of your project before they reach your authentication and rate-limit layers. Policies run at sign-up time and on email updates, and do not affect existing sessions.
 
 {% arrow_link href="/docs/products/auth/email-policies" %}
 Learn more about email policies

--- a/src/routes/docs/products/auth/accounts/+page.markdoc
+++ b/src/routes/docs/products/auth/accounts/+page.markdoc
@@ -19,7 +19,7 @@ You can signup and login a user with an account create through
 [OAuth 2](/docs/products/auth/oauth2)
 authentication.
 
-To control which email addresses can sign up, enable [email policies](/docs/products/auth/email-policies) to block free, aliased, or disposable email providers.
+On Appwrite Cloud, you can use [email policies](/docs/products/auth/email-policies) to block sign-ups from free, aliased, or disposable email providers.
 
 # Permissions {% #permissions %}
 
@@ -36,5 +36,4 @@ individual users using the `Role.user(<USER_ID>, <STATUS>)` role.
 {% arrow_link href="/docs/advanced/security/permissions" %}
 Learn more about permissions
 {% /arrow_link %}
-
 

--- a/src/routes/docs/products/auth/email-password/+page.markdoc
+++ b/src/routes/docs/products/auth/email-password/+page.markdoc
@@ -4,7 +4,7 @@ title: Email and password login
 description: Implement email and password authentication with Appwrite. Securely register and authenticate users in your applications using Appwrite's robust email-based authentication system.
 ---
 
-Email and password login is the most commonly used authentication method. Appwrite Authentication promotes a safer internet by providing secure APIs and promoting better password choices to end users. Appwrite supports added security features like password strength requirements, blocking personal info in passwords, password dictionary, and password history to help users choose good passwords. You can also restrict which addresses can sign up by enabling [email policies](/docs/products/auth/email-policies) to block free, aliased, or disposable email providers.
+Email and password login is the most commonly used authentication method. Appwrite Authentication promotes a safer internet by providing secure APIs and promoting better password choices to end users. Appwrite supports added security features like password strength requirements, blocking personal info in passwords, password dictionary, and password history to help users choose good passwords. On Appwrite Cloud, you can also restrict which addresses can sign up by enabling [email policies](/docs/products/auth/email-policies) to block free, aliased, or disposable email providers.
 
 # Signup {% #sign-up %}
 

--- a/src/routes/docs/products/auth/email-policies/+page.markdoc
+++ b/src/routes/docs/products/auth/email-policies/+page.markdoc
@@ -1,10 +1,14 @@
 ---
 layout: article
 title: Email policies
-description: Control which email addresses can sign up for your Appwrite project by blocking free, aliased, or disposable email providers from the Console or Project API.
+description: On Appwrite Cloud, control which email addresses can sign up for your Appwrite project by blocking free, aliased, or disposable email providers from the Console or Project API.
 ---
 
-Email policies let you restrict which email addresses can be used for user creation and email updates on a project. Each policy is an independent toggle that runs at sign-up time and when an existing user changes their email. Policies do not affect session creation, so existing users can still sign in if their address would not pass the current policy.
+Email policies are currently available on Appwrite Cloud only. They let you restrict which email addresses can be used for user creation and email updates on a project. Each policy is an independent toggle that runs at sign-up time and when an existing user changes their email. Policies do not affect session creation, so existing users can still sign in if their address would not pass the current policy.
+
+{% info title="Availability" %}
+Email policies are not available in self-hosted Appwrite deployments. In self-hosted projects, the Appwrite Console does not show the email-policy controls.
+{% /info %}
 
 Three policies are available:
 
@@ -14,7 +18,7 @@ Three policies are available:
 | Deny aliased emails | Addresses with aliases, tags, subaddresses, or any provider-specific variation | `user+folder1@gmail.com` |
 | Deny disposable emails | Temporary and disposable email providers | `alex9734@mailinator.com` |
 
-Policies can be configured from the Appwrite Console or programmatically through any server SDK using the Project service.
+On Appwrite Cloud, policies can be configured from the Appwrite Console or programmatically through any server SDK using the Project service.
 
 # Manage from the Console {% #manage-console %}
 

--- a/src/routes/docs/references/[version]/[platform]/[service]/descriptions/project.md
+++ b/src/routes/docs/references/[version]/[platform]/[service]/descriptions/project.md
@@ -2,4 +2,4 @@ The Project service allows you to manage all the core settings and resources of 
 
 Register new client platforms such as [Web](/docs/references/1.9.x/server-nodejs/project#createWebPlatform), [Apple](/docs/references/1.9.x/server-nodejs/project#createApplePlatform), and [Android](/docs/references/1.9.x/server-nodejs/project#createAndroidPlatform) so your applications can securely communicate with the Appwrite API. Create, update, and revoke [API keys](/docs/references/1.9.x/server-nodejs/project#createKey) to control server-to-server access with the exact scopes your integrations need.
 
-This service also lets you manage [project variables](/docs/references/1.9.x/server-nodejs/project#createVariable) that are available to all your functions and sites, and update email-handling preferences such as disposable, free, and canonical email policies for your project.
+This service also lets you manage [project variables](/docs/references/1.9.x/server-nodejs/project#createVariable) that are available to all your functions and sites. On Appwrite Cloud, it can also update email-handling preferences such as disposable, free, and canonical email policies for your project.


### PR DESCRIPTION
## Summary
- Clarify that Auth email policies are currently available on Appwrite Cloud only
- Add the availability note to the main email policies docs and related Auth/security docs
- Scope the Project service reference description so email-policy updates do not imply self-hosted availability

## Validation
- git diff --check
- Prettier was not run because local dependencies and bunx are not available in this environment