### PR TITLE
Document OAuth consent flow updates

### DIFF
--- a/src/routes/docs/products/auth/oauth2/+page.markdoc
+++ b/src/routes/docs/products/auth/oauth2/+page.markdoc
@@ -231,6 +231,14 @@ You'll be redirected to the OAuth 2 provider's login page to log in. Once comple
 
 You can optionally configure `success` or `failure` redirect links on web to handle success and failure scenarios.
 
+# Console consent redirects {% #console-consent-redirects %}
+
+Some OAuth 2 flows, such as connecting an OAuth client to Appwrite or approving access for an MCP client, show an Appwrite Console consent screen before the user is redirected back to the requesting app.
+
+When the redirect target is a native app deep link, the browser hands the redirect to the operating system. After the user approves or cancels the request, Appwrite Console shows a final outcome screen in the browser tab instead of leaving the consent screen open. On success, the screen includes an **Open app** action that retries the native redirect if the user dismissed the operating system prompt.
+
+If the user needs to sign in before approving a consent request, Appwrite Console may store the full authorize request with a Pushed Authorization Request (PAR) handle and send the user through login with only `client_id` and `request_uri` in the resume URL. After login, Console resumes the original request from that handle. This is browser-visible as a shorter login redirect URL, but it does not change the OAuth response your app receives after approval.
+
 # OAuth 2 profile {% #profile %}
 
 After authenticating a user through their OAuth 2 provider, you can fetch their profile information such as their avatar image or name. To do this you can use the access token from the OAuth 2 provider and make API calls to the provider.

--- a/src/routes/docs/tooling/ai/mcp-servers/api/+page.markdoc
+++ b/src/routes/docs/tooling/ai/mcp-servers/api/+page.markdoc
@@ -28,6 +28,12 @@ Before launching the MCP server, you must [set up an Appwrite project](https://c
 
 Ensure you save the **API key** along with the **project ID**, **region** and **endpoint URL** from the Settings page of your project as you'll need them later.
 
+## OAuth consent
+
+When an MCP client connects through Appwrite's hosted OAuth flow, the Console consent screen lets the user review the requested access before granting it. For MCP grants, users can keep the full requested access or customize the grant by narrowing project and organization resources and selecting read-only or read/write access where supported.
+
+This narrowing happens at consent time. The MCP client still receives an OAuth grant only for the access the user approved, so requests outside the approved resources or scopes are not authorized.
+
 ## Install uv
 
 Install [uv](https://docs.astral.sh/uv/getting-started/installation/) on your system with:


### PR DESCRIPTION
## What

- Document Console consent behavior for native app OAuth redirects, including the terminal outcome screen and retry action.
- Document PAR-backed authorize request resumption across login as browser-visible behavior without changing app callback expectations.
- Document MCP consent-time narrowing for project and organization resources on the API MCP server page.

## Validation

- `git diff --check`

Full repo checks were not run because `bun` is not installed in this environment, and `pnpm install --frozen-lockfile` is blocked by the current `package.json` / `pnpm-lock.yaml` mismatch on `origin/main`.