### PR TITLE
feat(marketing): point hero pill to State of Appwrite Cloud survey

### DIFF
--- a/src/routes/(marketing)/(components)/hero-banner.svelte
+++ b/src/routes/(marketing)/(components)/hero-banner.svelte
@@ -12,7 +12,12 @@
     const { title, href, icon = 'sparkle' }: Props = $props();
 </script>
 
-<a {href} class="web-hero-banner-button relative mb-4 flex items-center!">
+<a
+    {href}
+    target={href.startsWith('http') ? '_blank' : undefined}
+    rel={href.startsWith('http') ? 'noopener noreferrer' : undefined}
+    class="web-hero-banner-button relative mb-4 flex items-center!"
+>
     {#if icon === 'mongo'}
         <span class="mongo-icon-badge shrink-0" aria-hidden="true">
             <Icon name="mongo" style="width: 0.75rem; height: 1.125rem; color: #00ED64;" />

--- a/src/routes/(marketing)/(components)/hero.svelte
+++ b/src/routes/(marketing)/(components)/hero.svelte
@@ -152,16 +152,16 @@
         >
             {#if layoutAside}
                 <HeroBanner
-                    title="New: Announcing the Presences API"
-                    href="/blog/post/announcing-presences-api"
-                    icon="presences"
+                    title="State of Appwrite Cloud: Take the survey"
+                    href="https://forms.gle/5cvWxTwhonoDCWsi7"
+                    icon="sparkle"
                 />
             {:else}
                 <div class="flex w-full justify-center">
                     <HeroBanner
-                        title="New: Announcing the Presences API"
-                        href="/blog/post/announcing-presences-api"
-                        icon="presences"
+                        title="State of Appwrite Cloud: Take the survey"
+                        href="https://forms.gle/5cvWxTwhonoDCWsi7"
+                        icon="sparkle"
                     />
                 </div>
             {/if}


### PR DESCRIPTION
## What does this PR do?

Updates the homepage hero pill (both layout variants) from the Presences API announcement to the **State of Appwrite Cloud** survey:

- Title: "State of Appwrite Cloud: Take the survey"
- Link: https://forms.gle/5cvWxTwhonoDCWsi7
- Icon: `sparkle`
- `hero-banner.svelte`: external (http) links now open in a new tab with `noopener noreferrer` — the pill previously only pointed at internal blog posts

## Test Plan

Verified locally on dev server — pill renders with new text and opens the survey form in a new tab.

## Related PRs and Issues

Console counterpart: appwrite/console#3113