### PR TITLE
fix(blog): repair broken community image in June product update

### DIFF
--- a/src/routes/blog/post/june-product-update-react-library-password-strength-baa-and-more/+page.markdoc
+++ b/src/routes/blog/post/june-product-update-react-library-password-strength-baa-and-more/+page.markdoc
@@ -89,7 +89,7 @@ Install it with:
 
 # Community Recognitions
 
-[community.avif](June%20product%20update%20React%20library,%20Password%20streng/community.avif)
+![Community Recognitions](/images/blog/may-product-update-presences-api-rust-runtime-7x-faster-storage-uploads-and-more/community-recognitions.avif)
 
 We are excited to feature Arhan Ansari as part of our monthly Community Recognitions for June 2026. Arhan built [HRMate](https://github.com/ArhanAnsari/HRMate), a cross-platform HR management app built with Expo and Appwrite. It helps companies manage employees, attendance, leave requests, payroll, payslips, and company announcements from one place. Appwrite handles authentication, databases, storage, and realtime updates across the app. Keep in mind that this is a community-backed project and is not maintained by Appwrite.
 


### PR DESCRIPTION
The Community Recognitions section in the June product update had a Notion-export leftover: the image was written as a markdown link with a broken relative path, so nothing rendered.

This replaces it with proper image syntax pointing at the community recognitions image from the May product update.