### PR TITLE
Switch staging deployment to manual trigger

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -2,9 +2,6 @@ name: Staging deployment
 
 on:
     workflow_dispatch:
-    push:
-        branches:
-            - main
 
 concurrency:
     group: ${{ github.workflow }}


### PR DESCRIPTION
## What does this PR do?

Removes the `push: main` trigger from the staging deployment workflow, leaving `workflow_dispatch` only. Staging is now deployed manually via the Run workflow button with any branch selectable, so merges to main no longer override the staging environment.

Context: we need a stable, viewable staging link for reviews. Every merge currently redeploys staging and overrides it. With manual dispatch we can pin staging to a specific branch until we choose to redeploy.

## Test Plan

Trigger the workflow manually from the Actions tab and confirm it builds and deploys the selected branch.

## Related PRs and Issues

None

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/website/blob/main/CONTRIBUTING.md)?