### PR TITLE
Document in-place column updates and previousKey renames in the CLI

### DIFF
--- a/src/routes/changelog/(entries)/2026-07-30.markdoc
+++ b/src/routes/changelog/(entries)/2026-07-30.markdoc
@@ -1,0 +1,17 @@
+---
+layout: changelog
+title: Non-destructive column updates and renames in the Appwrite CLI
+date: 2026-07-30
+---
+
+Running `appwrite push tables` no longer deletes and recreates a column when the change is one the API can apply in place, so the column keeps its data.
+
+Settings such as `required`, `default`, `size`, `min` and `max`, enum `elements`, and relationship `onDelete` now update in place. Changes to what the column fundamentally is, such as `type` or `array`, still recreate it, and push warns you first.
+
+Columns can also be renamed. Set the column's `key` to the new name and add a `previousKey` field naming the column that still exists on the server, and push renames it instead of dropping and re-adding it.
+
+Update to the latest version of the CLI to get these changes.
+
+{% arrow_link href="/docs/tooling/command-line/tables#update-columns" %}
+Learn more about updating and renaming columns
+{% /arrow_link %}

--- a/src/routes/docs/tooling/command-line/tables/+page.markdoc
+++ b/src/routes/docs/tooling/command-line/tables/+page.markdoc
@@ -221,13 +221,7 @@ Then push the table:
 appwrite push tables
 ```
 
-Push reports the change as a rename instead of a deletion followed by an addition:
-
-```text
-  Key                       │ Action   │ Reason
- ───────────────────────────┼──────────┼────────────────────────────────────
-  headline in Posts (posts) │ renaming │ key renamed from title to headline
-```
+Push reports the change as a rename instead of a deletion followed by an addition, and the rows carry over to the new name.
 
 Indexes that reference the column follow the rename, so they are not recreated. Keep the index `columns` array in sync with the new name, as in the example above. If an index still points at the old name, the CLI treats it as a changed index and recreates it.
 
@@ -235,33 +229,12 @@ You can rename a column and change its updatable fields in the same push. The CL
 
 ## How the CLI resolves previousKey {% #how-previouskey-resolves %}
 
-The hint describes the state you want, so pushing the same config twice is safe.
+The hint describes the state you want, so pushing the same config twice is safe. Push looks at what the table already has and decides from there:
 
-{% table %}
-* State on the server
-* What push does
----
-* `title` exists, `headline` does not
-* Renames `title` to `headline`
----
-* `headline` exists, `title` does not
-* Nothing, the rename already happened and the leftover hint is ignored
----
-* Neither exists
-* Creates `headline` as a new column
----
-* Both exist
-* Warns and ignores the hint. `title` is deleted if it is absent from your config
-{% /table %}
-
-## Validation {% #previouskey-validation %}
-
-Push rejects the config before contacting the server when:
-
-- `previousKey` is the same as `key`
-- `previousKey` matches the `key` of another column in the same table
-- Two columns in the same table share the same `previousKey`
-- `previousKey` is set on an index, which the config schema does not accept, since indexes have no rename API and must be recreated
+- If the old name is still on the server and the new one isn't, push renames the column.
+- If the new name is already there, the rename has happened. Push does nothing and ignores the leftover hint.
+- If neither name is on the server, push ignores the hint and creates the column as a new one.
+- If both names are on the server, push cannot rename without a collision. It warns, ignores the hint, and deletes the old column if it is absent from your config.
 
 # Commands {% #commands %}
 

--- a/src/routes/docs/tooling/command-line/tables/+page.markdoc
+++ b/src/routes/docs/tooling/command-line/tables/+page.markdoc
@@ -146,6 +146,123 @@ Learn more about multi-file configuration
 appwrite push tables
 ```
 
+# Update columns {% #update-columns %}
+
+When you change a column that already exists on the server, the CLI updates it in place instead of deleting and recreating it, so the rows in that column keep their data. Only a subset of fields can change this way. Every other change still needs a delete and recreate, which clears the data in that column, and push warns you before it does that.
+
+{% table %}
+* Change
+* Behavior
+---
+* `required` and `default` on any column except relationship columns
+* Updated in place
+---
+* `size` on `varchar` columns and on `string` columns without a `format`
+* Updated in place
+---
+* `min` and `max` on `integer`, `bigint`, and `double` columns
+* Updated in place
+---
+* `elements` on enum columns
+* Updated in place
+---
+* `onDelete` on relationship columns
+* Updated in place
+---
+* `type`, `array`, `encrypt`, and `format`
+* Recreated, data in the column is lost
+---
+* `relatedTable`, `relationType`, `twoWay`, and `twoWayKey` on relationship columns
+* Recreated, data in the column is lost
+---
+* Any change to an index
+* Recreated, indexes hold no row data
+{% /table %}
+
+If an in-place update fails, for example when a new `size` is too small for the values already stored, push stops with an error before it deletes anything, so a failed update cannot leave your table half-migrated.
+
+# Rename a column {% #rename-column %}
+
+Renaming a column in `appwrite.config.json` looks like a delete and an add to the CLI, which would drop the column's data. To rename without losing data, set the column's `key` to the new name and add a `previousKey` field pointing at the name that still exists on the server.
+
+You always add `previousKey` yourself. The CLI never writes it for you, and `appwrite pull tables` removes it from your config because pull replaces the `columns` array with the server's version.
+
+```json
+{
+    "tables": [
+        {
+            "$id": "posts",
+            "databaseId": "blog",
+            "name": "Posts",
+            "columns": [
+                {
+                    "key": "headline",
+                    "previousKey": "title",
+                    "type": "varchar",
+                    "size": 255,
+                    "required": true
+                }
+            ],
+            "indexes": [
+                {
+                    "key": "by_headline",
+                    "type": "key",
+                    "columns": ["headline"]
+                }
+            ]
+        }
+    ]
+}
+```
+
+Then push the table:
+
+```sh
+appwrite push tables
+```
+
+Push reports the change as a rename instead of a deletion followed by an addition:
+
+```text
+  Key                       │ Action   │ Reason
+ ───────────────────────────┼──────────┼────────────────────────────────────
+  headline in Posts (posts) │ renaming │ key renamed from title to headline
+```
+
+Indexes that reference the column follow the rename, so they are not recreated. Keep the index `columns` array in sync with the new name, as in the example above. If an index still points at the old name, the CLI treats it as a changed index and recreates it.
+
+You can rename a column and change its updatable fields in the same push. The CLI applies the rename first, then the field update.
+
+## How the CLI resolves previousKey {% #how-previouskey-resolves %}
+
+The hint describes the state you want, so pushing the same config twice is safe.
+
+{% table %}
+* State on the server
+* What push does
+---
+* `title` exists, `headline` does not
+* Renames `title` to `headline`
+---
+* `headline` exists, `title` does not
+* Nothing, the rename already happened and the leftover hint is ignored
+---
+* Neither exists
+* Creates `headline` as a new column
+---
+* Both exist
+* Warns and ignores the hint. `title` is deleted if it is absent from your config
+{% /table %}
+
+## Validation {% #previouskey-validation %}
+
+Push rejects the config before contacting the server when:
+
+- `previousKey` is the same as `key`
+- `previousKey` matches the `key` of another column in the same table
+- Two columns in the same table share the same `previousKey`
+- `previousKey` is set on an index, which the config schema does not accept, since indexes have no rename API and must be recreated
+
 # Commands {% #commands %}
 
 The tables-db command allows you to create structured tables of rows, queries, and filter lists of rows. Appwrite TablesDB CLI commands generally follow the following syntax:


### PR DESCRIPTION
## What does this PR do?

Documents the CLI's non-destructive column updates and the new `previousKey` rename hint for `appwrite push tables`.

**Docs** (`/docs/tooling/command-line/tables`), two new sections:

- **Update columns** — a table of which fields push can update in place (`required`/`default` on every column except relationships, `size` on `varchar` and unformatted `string`, `min`/`max` on the numeric types, enum `elements`, relationship `onDelete`) versus which still require a delete and recreate. Notes that in-place updates run before any deletion, so a failed update leaves data intact.
- **Rename a column** — setting `key` to the new name plus a `previousKey` hint, with a config example, the push output, index behavior, the four server-state resolution cases, and the config validations that reject a bad hint.

**Changelog** — a short entry for the release linking back to the docs.

## Test Plan

- Every rule was checked against the CLI source rather than the PR description: the per-type updatable/recreate sets, the rename resolution branches, the validation rules, and the index reference rewrite.
- Sample push output matches the CLI's actual table renderer (blank outer borders, cyan column separators) and the real reason string.
- Markdoc parses and validates against the site schema; anchors referenced by the changelog exist.

## Related PRs and Issues

Documents the CLI changes from appwrite/sdk-generator#1703 and appwrite/sdk-generator#1704.

## Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.