### PR TITLE
docs: note DOCKER_API_VERSION for installer API mismatch

### DIFF
--- a/src/routes/docs/advanced/self-hosting/installation/+page.markdoc
+++ b/src/routes/docs/advanced/self-hosting/installation/+page.markdoc
@@ -65,6 +65,10 @@ docker run -it --rm `
 {% /tabsitem %}
 {% /tabs %}
 
+{% info title="Docker API version mismatch" %}
+If install fails with `client version ... is too new`, add `--env DOCKER_API_VERSION=<max from error>` (for example `1.42`) to the command, or upgrade Docker on the host.
+{% /info %}
+
 Once the command is running, open your browser and navigate to `http://localhost:20080` to access the setup wizard.
 
 # Setup wizard {% #setup-wizard %}

--- a/src/routes/docs/advanced/self-hosting/installation/+page.markdoc
+++ b/src/routes/docs/advanced/self-hosting/installation/+page.markdoc
@@ -15,6 +15,7 @@ Before installing Appwrite, ensure your system meets these minimum requirements:
 - **2GB of swap memory**
 - **Operating system** that supports Docker
 - **Docker Compose Version 2**
+- **Docker Engine** recent enough for the installer CLI, or pass `--env DOCKER_API_VERSION=<daemon max>` (for example `1.42`) if you see `client version ... is too new`
 
 # Install with Docker {% #install-with-docker %}
 
@@ -64,10 +65,6 @@ docker run -it --rm `
 ```
 {% /tabsitem %}
 {% /tabs %}
-
-{% info title="Docker API version mismatch" %}
-If install fails with `client version ... is too new`, add `--env DOCKER_API_VERSION=<max from error>` (for example `1.42`) to the command, or upgrade Docker on the host.
-{% /info %}
 
 Once the command is running, open your browser and navigate to `http://localhost:20080` to access the setup wizard.
 

--- a/src/routes/docs/advanced/self-hosting/production/updates/+page.markdoc
+++ b/src/routes/docs/advanced/self-hosting/production/updates/+page.markdoc
@@ -73,10 +73,6 @@ docker run -it --rm `
     appwrite/appwrite:<APPWRITE_VERSION>
 ```
 
-{% info title="Docker API version mismatch" %}
-If upgrade fails with `client version ... is too new`, add `--env DOCKER_API_VERSION=<max from error>` (for example `1.42`) to the command, or upgrade Docker on the host.
-{% /info %}
-
 This will pull the `docker-compose.yml` for the selected version/tag and perform the upgrade steps.
 Once the setup completes, verify that you have the latest version of Appwrite.
 

--- a/src/routes/docs/advanced/self-hosting/production/updates/+page.markdoc
+++ b/src/routes/docs/advanced/self-hosting/production/updates/+page.markdoc
@@ -73,6 +73,10 @@ docker run -it --rm `
     appwrite/appwrite:<APPWRITE_VERSION>
 ```
 
+{% info title="Docker API version mismatch" %}
+If upgrade fails with `client version ... is too new`, add `--env DOCKER_API_VERSION=<max from error>` (for example `1.42`) to the command, or upgrade Docker on the host.
+{% /info %}
+
 This will pull the `docker-compose.yml` for the selected version/tag and perform the upgrade steps.
 Once the setup completes, verify that you have the latest version of Appwrite.
 


### PR DESCRIPTION
## Summary
- Add a short note on the self-hosting [installation](https://appwrite.io/docs/advanced/self-hosting/installation) and [updates](https://appwrite.io/docs/advanced/self-hosting/production/updates) docs for `DOCKER_API_VERSION` when install/upgrade fails with `client version ... is too new`
- Related: https://github.com/appwrite/appwrite/pull/13046

## Test plan
- [ ] Confirm the info callouts render on both docs pages
- [ ] Wording is short and actionable

