### PR TITLE
chore: add changelog for relationship grid fallback

### DIFF
--- a/src/routes/changelog/(entries)/2026-08-03.markdoc
+++ b/src/routes/changelog/(entries)/2026-08-03.markdoc
@@ -1,0 +1,9 @@
+---
+layout: changelog
+title: Large relationship-heavy database grids now load reliably
+date: 2026-08-03
+---
+
+The Console now loads table and collection grids with wide relationships instead of failing the entire grid with a `400 Invalid query` error when relationship resolution exceeds the query value limit.
+
+When a relationship is too large to resolve in the initial request, the Console retries the grid request and fetches the relationship data in smaller chunks. If an individual chunk cannot be resolved, the grid remains available instead of crashing, so you can continue viewing and paging through large relationship-heavy datasets.


### PR DESCRIPTION
## Summary
- add a changelog entry for the Console fix that keeps relationship-heavy database grids from failing
- explain the new fallback behavior in user-facing terms

## Testing
- set -a && source .env.example && set +a && bun run check