### PR TITLE
docs: add missing table permissions section to Vue tutorial

### DIFF
--- a/src/routes/docs/tutorials/vue/step-6/+page.markdoc
+++ b/src/routes/docs/tutorials/vue/step-6/+page.markdoc
@@ -21,6 +21,21 @@ Create a new table with the following columns:
 | title       | Varchar | Yes      |
 | description | Text    | No       |
 
+## Configure permissions {% #configure-permissions %}
+{% only_dark %}
+![Table permissions screen](/images/docs/tutorials/dark/idea-tracker-permissions.avif)
+{% /only_dark %}
+{% only_light %}
+![Table permissions screen](/images/docs/tutorials/idea-tracker-permissions.avif)
+{% /only_light %}
+
+Navigate to the **Settings** tab of your table, add the role **Any** and check the **Read** box.
+Next, add a **Users** role and give them access to **Create** by checking those boxes.
+These permissions apply to all rows in your new table.
+
+Finally, enable **Row security** to allow further permissions to be set at the row level.
+Remember to click the **Update** button to apply your changes.
+
 ## Ideas context {% #ideas-context %}
 
 Now that you have a table to hold ideas, we can read and write to it from our app. Like we did with the user data, we will create a store hold our ideas.


### PR DESCRIPTION
## What does this PR do?

The Vue idea tracker tutorial (step 6, Add database) never explains how to configure table permissions. Readers following the tutorial step by step get authorization errors when listing or creating ideas, and the app only works after manually figuring out permissions in the Console.

This PR adds a **Configure permissions** section to the Vue tutorial's step 6 (`src/routes/docs/tutorials/vue/step-6/+page.markdoc`), mirroring the section that already exists in the React and React Native versions of the same tutorial (same shared screenshots, same wording, same heading ID convention).

## Test Plan

Verified locally with Bun 1.3.14 (same major version as CI) on macOS arm64:

- `bun install --frozen-lockfile` — clean
- `bun run check` (svelte-check) — **0 errors, 0 warnings**
- `bun run format:check` (prettier) — **All matched files use Prettier code style**
- `bun run build` — **builds successfully** (observed an intermittent `node-fetch-native-with-agent` worker error in Bun on cold runs; it also occurs on an unmodified `main` checkout and is unrelated to this change — repeated runs pass consistently)

Also verified:

- The added section matches the existing React (`src/routes/docs/tutorials/react/step-6/+page.markdoc`) and React Native (`src/routes/docs/tutorials/react-native/step-6/+page.markdoc`) tutorials
- Both referenced screenshots already exist in the repo (`static/images/docs/tutorials/idea-tracker-permissions.avif` and the dark variant)
- The Markdoc structure (heading ID, `{% only_dark %}`/`{% only_light %}` blocks) matches sibling pages

## Related PRs and Issues

Closes #1467

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes — including the website repo's [CONTRIBUTING.md](https://github.com/appwrite/website/blob/main/CONTRIBUTING.md) and [STYLE.md](https://github.com/appwrite/website/blob/main/STYLE.md), and the [Code of Conduct](https://github.com/appwrite/.github/blob/main/CODE_OF_CONDUCT.md).

---

🤖 This PR was prepared with AI assistance (Kimi Code CLI), reviewed and verified by the author before submission.