### PR TITLE
Add changelog entry for the Go CLI rewrite

### DIFF
--- a/src/routes/changelog/(entries)/2026-08-09.markdoc
+++ b/src/routes/changelog/(entries)/2026-08-09.markdoc
@@ -1,0 +1,15 @@
+---
+layout: changelog
+title: The Appwrite CLI is now powered by Go
+date: 2026-08-09
+---
+
+The Appwrite CLI has been rewritten in Go, giving it a faster, more robust foundation while keeping the commands and workflows you already use. Startup is significantly faster, and standalone binaries remain available across macOS, Windows, and Linux.
+
+The first rollout updates also make installation and updates more reliable. Release candidates now stay on the prerelease channel when you run `appwrite update`, while stable releases continue to follow the stable channel. Function and site deployments can package source directories correctly, longer-running changes avoid premature timeouts, and `init function` no longer suggests an install step that is not required.
+
+Command input is smoother too. Repeated JSON flags now decode objects correctly for bulk operations, and GraphQL commands accept raw query and mutation documents in addition to JSON request objects and batches. For headless automation, `appwrite init skill` can select skills, agent directories, and the installation method without an interactive terminal.
+
+{% arrow_link href="/docs/tooling/command-line/installation#update-your-cli" %}
+Update the Appwrite CLI
+{% /arrow_link %}


### PR DESCRIPTION
## What does this PR do?

Adds a focused public changelog entry for the Appwrite CLI rewrite in Go and the immediate rollout improvements shipped on August 5–7, 2026. It highlights faster startup, install and update reliability, prerelease channel safety, smoother init and deployment flows, safer mutation timeout handling, improved JSON and GraphQL inputs, and headless skill installation.

The entry links to the existing CLI update documentation.

## Test plan

- `git diff --check`
- `bun run check` *(blocked by 37 missing environment-variable declarations in the local environment; no diagnostics involve this entry)*