### PR TITLE
chore(blog): feature remote MCP server post

### DIFF
--- a/src/routes/blog/post/announcing-presences-api/+page.markdoc
+++ b/src/routes/blog/post/announcing-presences-api/+page.markdoc
@@ -7,7 +7,7 @@ cover: /images/blog/announcing-presences-api/cover.avif
 timeToRead: 5
 author: aditya-oberai
 category: announcement
-featured: true
+featured: false
 callToAction: true
 faqs:
     - question: "What is the Appwrite Presences API?"

--- a/src/routes/blog/post/announcing-remote-appwrite-mcp-server/+page.markdoc
+++ b/src/routes/blog/post/announcing-remote-appwrite-mcp-server/+page.markdoc
@@ -7,7 +7,7 @@ cover: /images/blog/announcing-remote-appwrite-mcp-server/cover.avif
 timeToRead: 4
 author: aditya-oberai
 category: product, announcement
-featured: false
+featured: true
 faqs:
   - question: "What is the remote Appwrite MCP server?"
     answer: "It is a hosted version of the [Appwrite MCP server](/docs/tooling/ai/mcp-servers/api) that runs over the HTTP transport at `https://mcp.appwrite.io/`. Instead of installing and running the server locally, you add the URL to your AI tool's MCP configuration and authenticate with OAuth. It gives AI agents like Claude Code, Cursor, and Codex access to your Appwrite project and the Appwrite documentation."


### PR DESCRIPTION
Marks [The Appwrite MCP server is now remote](https://appwrite.io/blog/post/announcing-remote-appwrite-mcp-server) as the featured blog post, replacing the Presences API announcement.

The blog index picks the first `featured: true` post in date-descending order, so flipping the flag on both posts moves the hero slot to the MCP post (2026-07-31).