### PR TITLE
docs(changelog): cover recent auth and console fixes

### DIFF
--- a/src/routes/changelog/(entries)/2026-08-12-1.markdoc
+++ b/src/routes/changelog/(entries)/2026-08-12-1.markdoc
@@ -1,0 +1,9 @@
+---
+layout: changelog
+title: External CIMD URLs work across Console OAuth flows again
+date: 2026-08-12
+---
+
+The Console once again supports OAuth clients whose metadata is hosted at an external Client ID Metadata Document (CIMD) URL. Consent and device authorization flows can now load URL-based client metadata directly instead of relying on the Appwrite API to resolve the URL as an application ID.
+
+Connected applications that use external CIMD URLs also display correctly in account settings. Existing OAuth clients do not need to change their client IDs or metadata URLs.

--- a/src/routes/changelog/(entries)/2026-08-12-2.markdoc
+++ b/src/routes/changelog/(entries)/2026-08-12-2.markdoc
@@ -1,0 +1,9 @@
+---
+layout: changelog
+title: Free organizations no longer become read-only because of seat limits
+date: 2026-08-12
+---
+
+Starter and free-plan organizations are no longer incorrectly switched to read-only mode when their billing data reports a seat limit of zero. For plans without a seat cap, the Console now treats that value as unlimited instead of as a reached limit.
+
+Affected organizations can create projects and invite members again without changing plans or billing settings.

--- a/src/routes/changelog/(entries)/2026-08-12.markdoc
+++ b/src/routes/changelog/(entries)/2026-08-12.markdoc
@@ -1,0 +1,13 @@
+---
+layout: changelog
+title: JWTs now respect linked session expiration
+date: 2026-08-12
+---
+
+JSON Web Tokens (JWTs) created from a user session now stop working as soon as that linked session expires. Previously, a JWT could remain valid until its own 15-minute expiration even after the session that created it had expired.
+
+JWTs continue to stop working when their linked session is deleted. No changes are required in your application; this fix ensures JWT authentication consistently follows the lifetime of the originating session.
+
+{% arrow_link href="/docs/products/auth/jwt" %}
+Learn more about JWT authentication
+{% /arrow_link %}


### PR DESCRIPTION
## Summary

- document that JWTs stop working when their linked session expires (appwrite#13169)
- document restored Console support for external CIMD URLs across OAuth flows (console#3154)
- document the free-plan seat-limit fix that restores project creation and member invitations (console#3149)

## Validation

- `git diff --check`
- reviewed against nearby changelog entry conventions

The repository formatter could not run because dependencies are not installed in this checkout.