### PR TITLE
docs: document recent CLI command-surface changes

### DIFF
--- a/src/routes/docs/tooling/ai/skills/+page.markdoc
+++ b/src/routes/docs/tooling/ai/skills/+page.markdoc
@@ -30,6 +30,39 @@ Skills work across all major AI dev tools that support them. They are installed 
 When you run `appwrite init project`, the Appwrite CLI auto-detects your project configuration and installs relevant skills automatically. You can also install skills manually using the steps below.
 {% /info %}
 
+## Install with the Appwrite CLI {% #install-with-appwrite-cli %}
+
+Run `appwrite init skill` from an Appwrite project to choose the skills, agent directories, and installation method interactively:
+
+```sh
+appwrite init skill
+```
+
+For a manual installation without prompts, select all available skills or name individual skill directories:
+
+```sh
+appwrite init skill --all
+
+appwrite init skill \
+    --skill <SKILL_DIRECTORY> \
+    --skill <ANOTHER_SKILL_DIRECTORY>
+```
+
+`--skill` is repeatable. Do not combine it with `--all`. Unknown skill directory names fail with a list of the available names.
+
+Choose one or both supported agent directories with repeatable `--agent` options, and choose how files are installed with `--method`:
+
+```sh
+appwrite init skill --all \
+    --agent .agents \
+    --agent .claude \
+    --method symlink
+```
+
+`--agent` accepts `.agents` and `.claude`. `--method` accepts `symlink` and `copy`. Once you pass `--all` or at least one `--skill`, installation does not prompt: omitted agent and method options default to `.agents` and `symlink`, respectively.
+
+## Install with the skills installer {% #install-with-skills-installer %}
+
 {% section #step-1 step=1 title="Run the install command" %}
 Run the following command in your project directory:
 

--- a/src/routes/docs/tooling/command-line/commands/+page.markdoc
+++ b/src/routes/docs/tooling/command-line/commands/+page.markdoc
@@ -52,6 +52,37 @@ Run `appwrite --help` to browse commands grouped by what you want to do, includi
 ---
 {% /table %}
 
+## GraphQL requests {% #graphql-requests %}
+
+Both `appwrite graphql query` and `appwrite graphql mutation` accept a raw GraphQL document with `--query`:
+
+```sh
+appwrite graphql query --query 'query { usersList { total } }'
+
+appwrite graphql mutation --query 'mutation { usersCreate(userId: "unique()", email: "user@example.com", password: "very_strong_password") { _id } }'
+```
+
+For variables or `operationName`, pass a JSON request object whose `query` field contains the document:
+
+```sh
+appwrite graphql query --query '{
+  "query": "query GetUser($id: String!) { usersGet(userId: $id) { _id name } }",
+  "variables": { "id": "USER_ID" },
+  "operationName": "GetUser"
+}'
+```
+
+To batch operations, pass a JSON array of request objects:
+
+```sh
+appwrite graphql query --query '[
+  { "query": "query { usersList { total } }" },
+  { "query": "query { teamsList { total } }" }
+]'
+```
+
+The value of `--query` must be a non-empty raw GraphQL document, a JSON request object, or a JSON array of request objects. A JSON string containing a GraphQL document is also accepted. JSON booleans, numbers, and `null` are rejected.
+
 ## Account commands {% #account-commands %}
 
 {% table %}
@@ -172,7 +203,7 @@ When only a project ID is available, the CLI can discover its organization. Proj
 * Skip confirmation prompts
 ---
 * `-a,--all`          
-* Flag to push all resources
+* Select every applicable resource or skill
 ---
 * `--id [id...]`      
 * Flag to pass a list of ids for a given action
@@ -212,7 +243,7 @@ appwrite client --reset --force
 By default, the CLI formats responses for quick reading. It summarizes long lists of enabled settings, adds readable hints to timestamps, durations, and byte sizes, and hides secret values. Use `--json` for filtered JSON or `--raw` for the complete API response when you need machine-readable output. Add `--show-secrets` only when you intentionally need secret values in the output.
 
 # All {% #all %}
-By default, when pushing or pulling resources, Appwrite CLI would ask you to select specific resources. Use the `--all` flag to select all available options.
+By default, the Appwrite CLI asks you to select specific resources when pushing or pulling. Use the `--all` flag to select all available resources. The same flag installs every available agent skill with `appwrite init skill --all`.
 
 ```sh
 appwrite pull functions --all

--- a/src/routes/docs/tooling/command-line/installation/+page.markdoc
+++ b/src/routes/docs/tooling/command-line/installation/+page.markdoc
@@ -172,6 +172,16 @@ appwrite login --switch
 
 The CLI lists the available accounts and endpoints for you to choose from. You can also run `appwrite whoami` to see the active account or get recovery instructions when another saved account is available.
 
+To select a saved account without a prompt, pass its endpoint, email, or both:
+
+```sh
+appwrite login --switch --endpoint "https://<REGION>.cloud.appwrite.io/v1" --email "user@example.com"
+```
+
+The CLI matches `--email` case-insensitively and normalizes equivalent Appwrite Cloud regional endpoints. A selector must match exactly one saved account. If it matches multiple accounts, the CLI tells you to add the missing `--email` or `--endpoint` selector; if it matches none, the CLI lists the available saved accounts. In a non-interactive terminal, `--switch` requires at least one selector and fails instead of opening a prompt.
+
+The `--password`, `--mfa`, and `--code` options cannot be combined with `--switch`. They are credentials for a new self-hosted login, not selectors for a saved account.
+
 {% info title="Seeing an email and password prompt instead?" %}
 Older CLI versions, and CLI sessions pointed at a self-hosted Appwrite instance, do not support the OAuth device authorization flow and fall back to asking for your email and password. Run `appwrite update` to get the latest version, or pass the Appwrite Cloud endpoint explicitly:
 

--- a/src/routes/docs/tooling/command-line/non-interactive/+page.markdoc
+++ b/src/routes/docs/tooling/command-line/non-interactive/+page.markdoc
@@ -16,6 +16,41 @@ When you set the global configuration parameters using the `appwrite client` com
 
 In this mode, the CLI can only interact with one project at a time.
 
+# Switch saved accounts {% #switch-saved-accounts %}
+
+Scripts can make a saved account current without opening the interactive account picker. Use `appwrite login --switch` with `--endpoint`, `--email`, or both:
+
+```sh
+appwrite login --switch \
+    --endpoint "https://<REGION>.cloud.appwrite.io/v1" \
+    --email "user@example.com"
+```
+
+The selectors must identify exactly one account that is already signed in. Use both when the same email is saved for multiple endpoints or multiple emails are saved for one endpoint. Without a selector, `appwrite login --switch` opens the account picker in a terminal and fails in a headless environment.
+
+This switches between stored user sessions. For CI jobs that access a project, continue to use an API key as described below.
+
+# Install agent skills {% #install-agent-skills %}
+
+Select skills explicitly to run installation without prompts:
+
+```sh
+appwrite init skill --all
+```
+
+Use `--skill <directory-name>` instead of `--all` to select individual skills. Repeat `--skill` to install more than one. The two selection modes cannot be combined.
+
+```sh
+appwrite init skill \
+    --skill <SKILL_DIRECTORY> \
+    --skill <ANOTHER_SKILL_DIRECTORY> \
+    --agent .agents \
+    --agent .claude \
+    --method copy
+```
+
+`--agent` is repeatable and accepts `.agents` or `.claude`. `--method` accepts `symlink` or `copy`. When `--all` or at least one `--skill` makes the installation non-interactive, the CLI defaults to `--agent .agents` and `--method symlink` if those options are omitted.
+
 # API Keys {% #api-keys %}
 In non-interactive mode, the CLI uses an API key to authenticate. Your API key must have sufficient permissions to execute the commands you plan to use. [Learn more about API Keys](/docs/partners/project/api-keys).
 


### PR DESCRIPTION
## Summary

- document deterministic saved-account switching with `login --switch` selectors
- document interactive and headless agent skill installation options and defaults
- document raw GraphQL documents, JSON request envelopes, and batched requests for `graphql query` and `graphql mutation`

## Validation

- `git diff --check`
- `bun run check` *(blocked by 37 missing required Appwrite environment-variable exports in the local environment; no errors point to the changed Markdoc pages)*

References appwrite/sdk-generator#1757, appwrite/sdk-generator#1758, and appwrite/sdk-generator#1766.