### PR TITLE
chore(blog): unfeature the Appwrite CLI Go rewrite post

### DIFF
--- a/src/routes/blog/post/rewriting-the-appwrite-cli-in-go/+page.markdoc
+++ b/src/routes/blog/post/rewriting-the-appwrite-cli-in-go/+page.markdoc
@@ -7,7 +7,7 @@ cover: /images/blog/rewriting-the-appwrite-cli-in-go/cover.avif
 timeToRead: 9
 author: chirag-aggarwal
 category: announcement
-featured: true
+featured: false
 callToAction: true
 draft: false
 faqs:


### PR DESCRIPTION
Sets `featured: false` on the Appwrite CLI Go rewrite blog post.

The post was published with `featured: true` in #3155, which puts it in the featured hero on /blog. This removes it from that rotation. No other content changes.