### PR TITLE
fix(bento): dispose homepage animation listeners and timers on unmount

### DIFF
--- a/src/routes/(marketing)/(components)/bento/(animations)/auth.svelte
+++ b/src/routes/(marketing)/(components)/bento/(animations)/auth.svelte
@@ -16,7 +16,15 @@
     let currentAnimation: WriteAnimation | null = null;
 
     $effect(() => {
-        inView(
+        // The write animation can settle after the component has been destroyed
+        // (e.g. the user clicks the card mid-animation), by which point
+        // `bind:this` has already reset `button` to null.
+        const pulseButton = () => {
+            if (!button) return;
+            animate(button, { scale: [1, 0.95, 1] }, { duration: 0.25 });
+        };
+
+        const stopInView = inView(
             container,
             () => {
                 if (!isMobile()) return;
@@ -28,9 +36,7 @@
                     1000,
                     password.length
                 );
-                currentAnimation.then(() => {
-                    animate(button, { scale: [1, 0.95, 1] }, { duration: 0.25 });
-                });
+                currentAnimation.then(pulseButton);
                 return () => {
                     currentAnimation?.cancel();
                     currentAnimation = unwrite(
@@ -43,14 +49,12 @@
             { amount: 'all' }
         );
 
-        hover(container, () => {
+        const stopHover = hover(container, () => {
             if (isMobile()) return;
 
             currentAnimation?.cancel();
             currentAnimation = write('•••••••••••••', (v) => (password = v), 1000, password.length);
-            currentAnimation.then(() => {
-                animate(button, { scale: [1, 0.95, 1] }, { duration: 0.25 });
-            });
+            currentAnimation.then(pulseButton);
             return () => {
                 currentAnimation?.cancel();
                 currentAnimation = unwrite(
@@ -60,6 +64,13 @@
                 );
             };
         });
+
+        return () => {
+            stopInView();
+            stopHover();
+            currentAnimation?.cancel();
+            currentAnimation = null;
+        };
     });
 </script>
 

--- a/src/routes/(marketing)/(components)/bento/(animations)/databases.svelte
+++ b/src/routes/(marketing)/(components)/bento/(animations)/databases.svelte
@@ -65,7 +65,7 @@
     let shouldAnimate = $state<boolean>(false);
 
     $effect(() => {
-        hover(container, () => {
+        const stopHover = hover(container, () => {
             if (isMobile()) return;
             animate(
                 table,
@@ -99,7 +99,7 @@
             };
         });
 
-        inView(
+        const stopInView = inView(
             container,
             () => {
                 if (!isMobile()) return;
@@ -137,6 +137,11 @@
             },
             { amount: 'all' }
         );
+
+        return () => {
+            stopHover();
+            stopInView();
+        };
     });
 </script>
 

--- a/src/routes/(marketing)/(components)/bento/(animations)/functions.svelte
+++ b/src/routes/(marketing)/(components)/bento/(animations)/functions.svelte
@@ -25,7 +25,7 @@
     $effect(() => {
         baseWidth = activeCommand.offsetWidth;
 
-        hover(container, () => {
+        const stopHover = hover(container, () => {
             if (isMobile()) return;
 
             widthAnim?.stop();
@@ -46,7 +46,7 @@
             };
         });
 
-        inView(
+        const stopInView = inView(
             container,
             () => {
                 if (!isMobile()) return;
@@ -70,6 +70,13 @@
             },
             { amount: 'all' }
         );
+
+        return () => {
+            stopHover();
+            stopInView();
+            widthAnim?.stop();
+            widthAnim = null;
+        };
     });
 </script>
 

--- a/src/routes/(marketing)/(components)/bento/(animations)/messaging.svelte
+++ b/src/routes/(marketing)/(components)/bento/(animations)/messaging.svelte
@@ -26,7 +26,7 @@
             [notification, { opacity: 1, y: 0, filter: 'blur(0px)' }, { duration: 0.2, at: 0.15 }]
         ];
 
-        inView(
+        const stopInView = inView(
             container,
             () => {
                 if (!isMobile()) return;
@@ -39,7 +39,7 @@
             { amount: 'all' }
         );
 
-        hover(container, () => {
+        const stopHover = hover(container, () => {
             if (isMobile()) return;
             animate(to);
 
@@ -47,6 +47,11 @@
                 animate(from);
             };
         });
+
+        return () => {
+            stopInView();
+            stopHover();
+        };
     });
 </script>
 

--- a/src/routes/(marketing)/(components)/bento/(animations)/realtime.svelte
+++ b/src/routes/(marketing)/(components)/bento/(animations)/realtime.svelte
@@ -34,7 +34,7 @@
             [topRightCursor, { scale: 1 }, { duration: 0.25, at: 0.35 }]
         ];
 
-        inView(
+        const stopInView = inView(
             container,
             () => {
                 if (!isMobile()) return;
@@ -47,7 +47,7 @@
             { amount: 'all' }
         );
 
-        hover(container, () => {
+        const stopHover = hover(container, () => {
             if (isMobile()) return;
             animate(to);
 
@@ -55,6 +55,11 @@
                 animate(from);
             };
         });
+
+        return () => {
+            stopInView();
+            stopHover();
+        };
     });
 </script>
 

--- a/src/routes/(marketing)/(components)/bento/(animations)/sites.svelte
+++ b/src/routes/(marketing)/(components)/bento/(animations)/sites.svelte
@@ -46,9 +46,10 @@
     ];
 
     let shouldAnimate = $state<boolean>(false);
+    let secondsAnimation: ReturnType<typeof animate> | null = null;
 
     $effect(() => {
-        hover(container, () => {
+        const stopHover = hover(container, () => {
             if (isMobile()) return;
 
             shouldAnimate = true;
@@ -57,6 +58,7 @@
                 onUpdate: (latest) => (seconds = +latest.toFixed()),
                 duration: 44
             });
+            secondsAnimation = animation;
 
             currentAnimation?.cancel();
             currentAnimation = write(
@@ -82,7 +84,7 @@
             };
         });
 
-        inView(
+        const stopInView = inView(
             container,
             () => {
                 if (!isMobile()) return;
@@ -92,6 +94,7 @@
                     onUpdate: (latest) => (seconds = +latest.toFixed()),
                     duration: 44
                 });
+                secondsAnimation = animation;
 
                 currentAnimation?.cancel();
                 currentAnimation = write(
@@ -118,6 +121,15 @@
             },
             { amount: 'all' }
         );
+
+        return () => {
+            stopHover();
+            stopInView();
+            secondsAnimation?.stop();
+            secondsAnimation = null;
+            currentAnimation?.cancel();
+            currentAnimation = null;
+        };
     });
 </script>
 

--- a/src/routes/(marketing)/(components)/bento/(animations)/storage.svelte
+++ b/src/routes/(marketing)/(components)/bento/(animations)/storage.svelte
@@ -10,7 +10,7 @@
     let image: HTMLElement;
 
     $effect(() => {
-        hover(container, () => {
+        const stopHover = hover(container, () => {
             if (isMobile()) return;
 
             animate(image, { borderRadius: '24px', filter: 'grayscale(25%)' }, { duration: 0.2 });
@@ -27,7 +27,7 @@
             };
         });
 
-        inView(
+        const stopInView = inView(
             container,
             () => {
                 if (!isMobile()) return;
@@ -53,6 +53,11 @@
                 amount: 'all'
             }
         );
+
+        return () => {
+            stopHover();
+            stopInView();
+        };
     });
 </script>
 


### PR DESCRIPTION
## What does this PR do?

The bento animation components on the homepage register motion's `hover()` and `inView()` handlers inside `$effect` / `onMount`, but discard the disposer function each one returns and never cancel the in-flight animation. Nothing is torn down when the component is destroyed by a client-side navigation.

This has two visible consequences:

**1. Every bento card leaks its `IntersectionObserver`.** Navigating away from the homepage left 10 of 12 observers alive, each still holding a reference to the now-detached subtree.

**2. `auth.svelte` throws an uncaught error.** Hovering the Auth card starts a 1000ms `write()` interval. Because the card is a link, clicking it mid-animation is a completely ordinary interaction — the page navigates, the component is destroyed, but the interval keeps running and its `.then()` still calls `animate(button, ...)` after `bind:this` has reset `button` to `null`:

```
Error: You're trying to perform an animation on null. Ensure that selectors are
correctly finding elements and refs are correctly hydrated.
    at animateSubject (motion.js)
    at bento/(animations)/auth.svelte
```

This reproduces on production today — on `appwrite.io` the minified build surfaces it as `Invalid value used as weak map key` from the same call.

`sites.svelte` has the same shape and additionally leaves a 44-second `animate()` running after unmount.

### The fix

Capture the disposers that `hover()` / `inView()` already return, return a teardown from the effect, and stop any in-flight animation. `auth.svelte` also guards the deferred button pulse, since a `write()` that settles at the exact moment of unmount resolves *after* teardown has run and so cannot be cancelled.

No behaviour changes while the component is mounted — this only adds cleanup.

## Test Plan

Repro (before this PR): load the homepage, hover the Auth bento card, and click it within ~1s. The error above appears in the console on `/products/auth`.

Measured with an instrumented Playwright run that hovers the Auth card, clicks through to `/products/auth`, then counts animation ticks that still fire and observers that are still connected:

|                                    | before | after |
| ---------------------------------- | -----: | ----: |
| animation ticks after unmount      |     11 |     0 |
| `IntersectionObserver`s still live |     10 |     3 |
| uncaught error on navigation       |    yes |    no |

The 7 newly-disposed observers correspond exactly to the 7 bento cards; the remaining 3 belong to other components on the page and are out of scope here.

Also verified there is **no regression** to the hover animation itself — rapid hover in/out over 12 cycles still shows 1 concurrent animation, 0 multi-character jumps, and clean write/unwrite alternation, identical to `main`.

Checks: `svelte-check` reports 0 errors and 0 warnings, and `prettier --check` passes on all touched files.

## Related PRs and Issues

None. Found while investigating #2758 (which is already fixed by d1b92c90 — I've left a note on that issue).

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.
