### PR TITLE
docs: document remote MCP OAuth on hosts without a local browser

### DIFF
--- a/src/routes/docs/tooling/ai/agents/claude-code/+page.markdoc
+++ b/src/routes/docs/tooling/ai/agents/claude-code/+page.markdoc
@@ -33,6 +33,14 @@ claude mcp add --transport http appwrite https://mcp.appwrite.io/
 
 The server uses OAuth for authentication. Run `/mcp` in Claude Code, select **appwrite**, and choose **Authenticate**. Your browser opens so you can sign in to your Appwrite account and authorize access.
 
+If you run Claude Code on a remote host, log in from the shell with `--no-browser`:
+
+```bash
+claude mcp login appwrite --no-browser
+```
+
+Open the printed authorization URL in a browser on your local machine, sign in, and authorize access. After you approve, copy the full `http://localhost:.../callback` URL from the address bar and paste it into the Claude Code prompt. Use an interactive SSH session (`ssh -t`) so the prompt can accept the paste. This is the same localhost-callback pattern described in [Authenticate from a remote machine](/docs/tooling/ai/mcp-servers/api#remote).
+
 {% /section %}
 
 {% section #step-3 step=3 title="Verify MCP tools" %}

--- a/src/routes/docs/tooling/ai/mcp-servers/api/+page.markdoc
+++ b/src/routes/docs/tooling/ai/mcp-servers/api/+page.markdoc
@@ -25,6 +25,8 @@ https://mcp.appwrite.io/
 
 The server uses OAuth for authentication. When you add the server to an AI tool and connect for the first time, your browser opens so you can sign in to your Appwrite account and authorize access. You don't need to create or manage API keys.
 
+MCP clients complete that OAuth flow with a localhost callback URL. If you run your AI tool on a remote host, follow [Authenticate from a remote machine](#remote).
+
 # Pre-requisites {% #pre-requisites %}
 
 Before connecting to the MCP server, you must [set up an Appwrite project](https://cloud.appwrite.io) on Appwrite Cloud. No additional software needs to be installed on your system.
@@ -43,6 +45,18 @@ The MCP server starts in a compact workflow where only a small set of MCP tools 
 - `appwrite_search_docs` - Semantically searches the Appwrite documentation
 
 The full Appwrite tool catalog stays internal and is searched at runtime, using less of the model's context.
+
+# Authenticate from a remote machine {% #remote %}
+
+MCP clients listen on a localhost callback URL for the OAuth redirect. When the client runs over SSH, on a droplet, or on any host without a local browser, that callback stays on the remote machine's loopback.
+
+Log in from the [Claude Code](/docs/tooling/ai/agents/claude-code) shell with `--no-browser`:
+
+```bash
+claude mcp login appwrite --no-browser
+```
+
+The command prints an authorization URL. Open it in a browser on your local machine, sign in to Appwrite, and authorize access. After you approve, the browser navigates to a `http://localhost:.../callback` URL. Copy the full URL from the address bar and paste it into the Claude Code prompt.
 
 # Self-hosted Appwrite {% #self-hosted %}
 


### PR DESCRIPTION
## Summary
- Document that hosted MCP OAuth uses a localhost callback, which stays on the remote loopback when the client runs over SSH, on a droplet, or on any host without a local browser.
- Walk through Claude Code's `--no-browser` login as the worked example: open the printed auth URL locally, then paste the `http://localhost:.../callback` URL back into the remote prompt.
- Mirror the same Claude Code steps on the Claude Code install page, with a link to the remote MCP section.

## Test plan
- [ ] Open `/docs/tooling/ai/mcp-servers/api#remote` and confirm the first paragraph is client-agnostic, then the Claude Code command and callback steps.
- [ ] Open `/docs/tooling/ai/agents/claude-code` and confirm `--no-browser` login plus the link to the remote section.
- [ ] Confirm the `#remote` anchor from the connection-details paragraph lands on the new section.


Made with [Cursor](https://cursor.com)