### PR TITLE
fix: support standard OpenAPI example fields in refs

### DIFF
--- a/src/routes/docs/references/[version]/[platform]/[service]/specs.ts
+++ b/src/routes/docs/references/[version]/[platform]/[service]/specs.ts
@@ -128,6 +128,7 @@ type AppwriteAdditionalMethod = {
 
 export type AppwriteSchemaObject = OpenAPIV3.SchemaObject & {
     'x-example': string;
+    example?: OpenAPIV3.SchemaObject['example'];
 };
 
 export interface Property {
@@ -368,7 +369,7 @@ function getParameters(operation: AppwriteOperationObject): SDKMethod['parameter
                 description: property.description ?? '',
                 required: schemaJson?.required?.includes(key) ?? false,
                 type: property.type ?? '',
-                example: property['x-example'] ?? ''
+                example: property.example ?? property['x-example'] ?? ''
             });
         }
     }
@@ -380,7 +381,7 @@ function getParameters(operation: AppwriteOperationObject): SDKMethod['parameter
                 description: property.description ?? '',
                 required: schemaMultipart?.required?.includes(key) ?? false,
                 type: property.type ?? '',
-                example: property['x-example'] ?? ''
+                example: property.example ?? property['x-example'] ?? ''
             });
         }
     }


### PR DESCRIPTION
## Summary
- update the reference spec loader to read standard OpenAPI `example` fields for JSON and multipart request-body properties
- keep `x-example` as a fallback so older specs still render examples
- align website reference rendering with the sdk-generator change in PR #1812

## Verification
- verified the website code path in `src/routes/docs/references/[version]/[platform]/[service]/specs.ts`
- verified sdk-generator PR #1812 switched to standard OpenAPI example fields
- `bun run check` was not run in this clean clone because the repo dependencies are not installed here
